### PR TITLE
fix native fullscreen for webRTC

### DIFF
--- a/js/app/components/player/controls.tsx
+++ b/js/app/components/player/controls.tsx
@@ -133,7 +133,7 @@ export default function Controls(props: PlayerProps) {
           justifyContent: "space-between",
         }}
       > */}
-      <Bar opacity={props.showControls ? 1 : 0}>
+      <Bar opacity={props.showControls ? (props.fullscreen ? 0 : 1) : 0}>
         <Part>
           <View justifyContent="center" paddingLeft="$5">
             <Text>{props.name}</Text>

--- a/js/app/components/player/fullscreen.native.tsx
+++ b/js/app/components/player/fullscreen.native.tsx
@@ -6,7 +6,7 @@ import { useNavigation } from "@react-navigation/native";
 import { View } from "tamagui";
 import Controls from "./controls";
 import PlayerLoading from "./player-loading";
-import { PlayerProps } from "./props";
+import { PlayerProps, PROTOCOL_WEBRTC } from "./props";
 import Video from "./video.native";
 import VideoRetry from "./video-retry";
 
@@ -77,11 +77,23 @@ export default function Fullscreen(props: PlayerProps) {
   }, [props.fullscreen, navigation]);
 
   const setFullscreen = (on) => {
-    // Instead of using native fullscreen, just update our fullscreen state
-    props.setFullscreen(on);
+    // For WebRTC, use custom fullscreen implementation
+    if (props.protocol === PROTOCOL_WEBRTC) {
+      props.setFullscreen(on);
+      return;
+    }
+
+    // For HLS and other protocols, use native fullscreen
+    if (ref.current) {
+      if (on) {
+        ref.current.enterFullscreen();
+      } else {
+        ref.current.exitFullscreen();
+      }
+    }
   };
 
-  if (props.fullscreen) {
+  if (props.fullscreen && props.protocol === PROTOCOL_WEBRTC) {
     // Determine if we're in landscape mode
     const isLandscape = dimensions.width > dimensions.height;
 
@@ -89,22 +101,26 @@ export default function Fullscreen(props: PlayerProps) {
     let videoWidth, videoHeight;
 
     if (isLandscape) {
-      // In landscape, the video takes the full height, width is calculated from aspect ratio
-      videoHeight = dimensions.height + 0;
+      // In landscape, account for safe areas and use available height
+      const availableHeight = dimensions.height - (insets.top + insets.bottom);
+      const availableWidth = dimensions.width - (insets.left + insets.right);
+
+      videoHeight = availableHeight;
       videoWidth = videoHeight * VIDEO_ASPECT_RATIO;
 
-      // If calculated width is greater than screen width, constrain to screen width
-      if (videoWidth > dimensions.width) {
-        videoWidth = dimensions.width;
+      // If calculated width exceeds available width, constrain and maintain aspect ratio
+      if (videoWidth > availableWidth) {
+        videoWidth = availableWidth;
         videoHeight = videoWidth / VIDEO_ASPECT_RATIO;
       }
     } else {
-      // In portrait, the video takes the full width, height is calculated from aspect ratio
-      videoWidth = dimensions.width;
+      // In portrait, account for safe areas
+      const availableWidth = dimensions.width - (insets.left + insets.right);
+      videoWidth = availableWidth;
       videoHeight = videoWidth / VIDEO_ASPECT_RATIO;
     }
 
-    // Calculate position to center the video
+    // Calculate position to center the video, accounting for safe areas
     const leftPosition = (dimensions.width - videoWidth) / 2;
     const topPosition = (dimensions.height - videoHeight) / 2;
 

--- a/js/app/components/player/fullscreen.native.tsx
+++ b/js/app/components/player/fullscreen.native.tsx
@@ -1,23 +1,146 @@
 import { VideoView } from "expo-video";
-import { useRef } from "react";
+import React, { useRef, useEffect, useState } from "react";
+import { StatusBar, Dimensions, StyleSheet, BackHandler } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useNavigation } from "@react-navigation/native";
+import { View } from "tamagui";
 import Controls from "./controls";
 import PlayerLoading from "./player-loading";
 import { PlayerProps } from "./props";
 import Video from "./video.native";
 import VideoRetry from "./video-retry";
 
+// Standard 16:9 video aspect ratio
+const VIDEO_ASPECT_RATIO = 16 / 9;
+
 export default function Fullscreen(props: PlayerProps) {
   const ref = useRef<VideoView>(null);
-  const setFullscreen = (on) => {
-    if (!ref.current) {
-      return;
-    }
-    if (on) {
-      ref.current.enterFullscreen();
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation();
+  const [dimensions, setDimensions] = useState(Dimensions.get("window"));
+
+  // Re-calculate dimensions on orientation change
+  useEffect(() => {
+    const updateDimensions = () => {
+      setDimensions(Dimensions.get("window"));
+    };
+
+    const subscription = Dimensions.addEventListener(
+      "change",
+      updateDimensions,
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+
+  // Hide status bar when in fullscreen mode
+  useEffect(() => {
+    if (props.fullscreen) {
+      StatusBar.setHidden(true);
+
+      // Hide the navigation header
+      navigation.setOptions({
+        headerShown: false,
+      });
+
+      // Handle hardware back button
+      const backHandler = BackHandler.addEventListener(
+        "hardwareBackPress",
+        () => {
+          props.setFullscreen(false);
+          return true;
+        },
+      );
+
+      return () => {
+        backHandler.remove();
+      };
     } else {
-      ref.current.exitFullscreen();
+      StatusBar.setHidden(false);
+
+      // Restore the navigation header
+      navigation.setOptions({
+        headerShown: true,
+      });
     }
+
+    return () => {
+      StatusBar.setHidden(false);
+
+      // Ensure header is restored if component unmounts
+      navigation.setOptions({
+        headerShown: true,
+      });
+    };
+  }, [props.fullscreen, navigation]);
+
+  const setFullscreen = (on) => {
+    // Instead of using native fullscreen, just update our fullscreen state
+    props.setFullscreen(on);
   };
+
+  if (props.fullscreen) {
+    // Determine if we're in landscape mode
+    const isLandscape = dimensions.width > dimensions.height;
+
+    // Calculate video container dimensions based on screen size and orientation
+    let videoWidth, videoHeight;
+
+    if (isLandscape) {
+      // In landscape, the video takes the full height, width is calculated from aspect ratio
+      videoHeight = dimensions.height + 0;
+      videoWidth = videoHeight * VIDEO_ASPECT_RATIO;
+
+      // If calculated width is greater than screen width, constrain to screen width
+      if (videoWidth > dimensions.width) {
+        videoWidth = dimensions.width;
+        videoHeight = videoWidth / VIDEO_ASPECT_RATIO;
+      }
+    } else {
+      // In portrait, the video takes the full width, height is calculated from aspect ratio
+      videoWidth = dimensions.width;
+      videoHeight = videoWidth / VIDEO_ASPECT_RATIO;
+    }
+
+    // Calculate position to center the video
+    const leftPosition = (dimensions.width - videoWidth) / 2;
+    const topPosition = (dimensions.height - videoHeight) / 2;
+
+    // When in custom fullscreen mode
+    return (
+      <View
+        style={[
+          styles.fullscreenContainer,
+          {
+            width: isLandscape ? dimensions.width + 40 : dimensions.width,
+            height: dimensions.height,
+          },
+        ]}
+      >
+        <View
+          style={[
+            styles.videoContainer,
+            {
+              width: isLandscape ? videoWidth + 40 : videoWidth,
+              height: videoHeight,
+              left: leftPosition,
+              top: topPosition,
+            },
+          ]}
+        >
+          <VideoRetry {...props}>
+            <Video {...props} videoRef={ref} />
+          </VideoRetry>
+          <PlayerLoading {...props} />
+          <Controls {...props} setFullscreen={setFullscreen} />
+        </View>
+      </View>
+    );
+  }
+
+  // Normal non-fullscreen mode
   return (
     <>
       <PlayerLoading {...props}></PlayerLoading>
@@ -28,3 +151,25 @@ export default function Fullscreen(props: PlayerProps) {
     </>
   );
 }
+
+const styles = StyleSheet.create({
+  fullscreenContainer: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: "#000",
+    zIndex: 9999,
+    elevation: 9999,
+    margin: 0,
+    padding: 0,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  videoContainer: {
+    position: "absolute",
+    backgroundColor: "#111",
+    overflow: "hidden",
+  },
+});

--- a/js/app/components/player/video.native.tsx
+++ b/js/app/components/player/video.native.tsx
@@ -72,15 +72,9 @@ export default function NativeVideo(
       style={{ flex: 1, backgroundColor: "#111" }}
       ref={props.videoRef}
       player={player}
-      allowsFullscreen
+      allowsFullscreen={false}
       allowsPictureInPicture
-      nativeControls={props.fullscreen}
-      onFullscreenEnter={() => {
-        props.setFullscreen(true);
-      }}
-      onFullscreenExit={() => {
-        props.setFullscreen(false);
-      }}
+      nativeControls={false}
     />
   );
 }

--- a/js/app/components/player/video.native.tsx
+++ b/js/app/components/player/video.native.tsx
@@ -72,9 +72,15 @@ export default function NativeVideo(
       style={{ flex: 1, backgroundColor: "#111" }}
       ref={props.videoRef}
       player={player}
-      allowsFullscreen={false}
+      allowsFullscreen
+      nativeControls={props.fullscreen}
+      onFullscreenEnter={() => {
+        props.setFullscreen(true);
+      }}
+      onFullscreenExit={() => {
+        props.setFullscreen(false);
+      }}
       allowsPictureInPicture
-      nativeControls={false}
     />
   );
 }

--- a/js/app/components/settings/settings.tsx
+++ b/js/app/components/settings/settings.tsx
@@ -2,22 +2,43 @@ import {
   selectTelemetry,
   setURL,
   telemetryOpt,
+  selectStreamplace,
 } from "features/streamplace/streamplaceSlice";
 import useStreamplaceNode from "hooks/useStreamplaceNode";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useAppDispatch, useAppSelector } from "store/hooks";
-import { Button, Form, H3, Input, View, XStack, Label } from "tamagui";
+import { Button, Form, H3, Input, View, XStack, Label, Text } from "tamagui";
 import { Updates } from "./updates";
 import { Switch } from "react-native";
+
+const DEFAULT_PROD_URL = "https://stream.place";
+const DEFAULT_DEV_URL = "http://10.0.1.5:38080";
 
 export function Settings() {
   const dispatch = useAppDispatch();
   const { url } = useStreamplaceNode();
   const [newUrl, setNewUrl] = useState("");
+  const [overrideEnabled, setOverrideEnabled] = useState(false);
+
+  // Initialize the override state based on current URL
+  useEffect(() => {
+    setOverrideEnabled(url !== DEFAULT_PROD_URL);
+  }, [url]);
+
   const onSubmit = () => {
     dispatch(setURL(newUrl));
     setNewUrl("");
   };
+
+  const handleToggleOverride = (enabled: boolean) => {
+    setOverrideEnabled(enabled);
+    if (enabled) {
+      dispatch(setURL(DEFAULT_DEV_URL));
+    } else {
+      dispatch(setURL(DEFAULT_PROD_URL));
+    }
+  };
+
   const telemetry = useAppSelector(selectTelemetry);
   return (
     <View f={1} alignItems="stretch" justifyContent="center" fg={1}>
@@ -30,23 +51,44 @@ export function Settings() {
         padding="$4"
         onSubmit={onSubmit}
       >
-        <H3 margin="$2">Change Streamplace Node URL</H3>
-        <XStack alignItems="center" space="$2">
-          <Input
-            value={newUrl}
-            flex={1}
-            size="$3"
-            placeholder={url}
-            onChangeText={(t) => setNewUrl(t)}
-            onSubmitEditing={onSubmit}
-            textContentType="URL"
-            autoCapitalize="none"
-            autoCorrect={false}
+        <Text fontSize="$4" color="$gray10" marginBottom="$3">
+          Current node: {url}
+        </Text>
+
+        <XStack
+          alignItems="center"
+          justifyContent="space-around"
+          width="100%"
+          margin="$2"
+        >
+          <H3>Use custom node?</H3>
+          <Switch
+            style={{
+              transform: [{ scaleX: 1.2 }, { scaleY: 1.2 }],
+            }}
+            value={overrideEnabled}
+            onValueChange={handleToggleOverride}
           />
-          <Form.Trigger asChild>
-            <Button size="$3">Go</Button>
-          </Form.Trigger>
         </XStack>
+
+        {overrideEnabled && (
+          <XStack alignItems="center" gap="$2" marginTop="$2" width="100%">
+            <Input
+              value={newUrl}
+              flex={1}
+              size="$3"
+              placeholder={url}
+              onChangeText={(t) => setNewUrl(t)}
+              onSubmitEditing={onSubmit}
+              textContentType="URL"
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+            <Form.Trigger asChild>
+              <Button size="$3">Go</Button>
+            </Form.Trigger>
+          </XStack>
+        )}
       </Form>
       <View
         alignItems="center"


### PR DESCRIPTION
on native it hides the buttons on fullscreen so this mimics the fullscreen behavior and adds the controls overlay for webRTC only. HLS uses native fullscreen method

closes #2