### PR TITLE
add gofmt check to see if files could be formatted

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,9 @@
 ./node_modules/.bin/lint-staged
 cd js/app && yarn run check
+
+unformatted=$(gofmt -l $(find . -name "*.go"))
+if [ -n "$unformatted" ]; then
+  printf "The following files are not formatted.\n"
+  printf "%s\n" "$unformatted"
+  exit 1
+fi


### PR DESCRIPTION
should close issue #14 could also automatticaly just apply formatting and run a `go fmt ./...` but i'm not a huge fan of changes being made automatically without seeing what they are.