### PR TITLE
fIx: remove key on navigator

### DIFF
--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -336,8 +336,6 @@ export function StreamplaceDrawer() {
     <>
       <StatusBar backgroundColor={theme.background.val} />
       <Drawer.Navigator
-        // if this isn't here there are issues around drawer width
-        key={sidebar.isActive ? "1" : "0"}
         initialRouteName="Home"
         screenOptions={{
           // for the custom sidebar


### PR DESCRIPTION
- The navigator acts appropriately either way apparently (it didn't on my snack i initially tried it out on)
- Changing the key reset the current view to the main view when changed (caused by breakpoint between regular/custom sidebar is reached)