### PR TITLE
fix: sidebar slice app error on sim

### DIFF
--- a/js/app/features/base/sidebarSlice.tsx
+++ b/js/app/features/base/sidebarSlice.tsx
@@ -54,9 +54,12 @@ export const sidebarSlice = createAppSlice({
         rejected: (state, action) => {
           state.isLoaded = true;
           console.error(
-            "Failed to load sidebar state from storage:",
+            "Failed to load sidebar state from storage, using defaults:",
             action.error,
           );
+          // use defaults
+          state.isCollapsed = false;
+          state.targetWidth = 250;
         },
       },
     ),

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -336,8 +336,6 @@ export function StreamplaceDrawer() {
     <>
       <StatusBar backgroundColor={theme.background.val} />
       <Drawer.Navigator
-        // if this isn't here there are issues around drawer width
-        key={sidebar.isActive ? "1" : "0"}
         initialRouteName="Home"
         screenOptions={{
           // for the custom sidebar


### PR DESCRIPTION
on first launch, the app errors out due to some sidebar-related items not being available. haven't encountered this on a real device just yet but it's possible it may occur? after the first launch, it works fine.