### PR TITLE
build: hardcode /usr/local to fight off homebrew

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ project(
     'auto_features': 'disabled',
     'force_fallback_for': 'gio-2.0,gstreamer-controller-1.0,gstreamer-app-1.0,gstreamer-pbutils-1.0,glib-2.0,gobject-2.0,gio-2.0,gio-unix-2.0,fdk-aac,zlib,libffi,pcre2,intl,x264,freetype2,libpng,libjpeg,fontconfig,pango,opus,fribidi,harfbuzz,nettle,cairo,pixman,expat',
     'buildtype': 'debugoptimized',
+    'prefix': '/usr/local', # otherwise mac meson will try and do /opt/homebrew sometimes
   },
 )
 


### PR DESCRIPTION
Fixes this issue on mac builds:
```
 Reason: tried: '/Users/iameli/code/streamplace/build-darwin-arm64/lib/usr/local/lib/libavfilter.10.dylib' (no such file), '/Users/iameli/code/streamplace/build-darwin-arm64/lib/libavfilter.10.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/iameli/code/streamplace/build-darwin-arm64/lib/libavfilter.10.dylib' (no such file), '/Users/iameli/code/streamplace/build-darwin-arm64/lib/libavfilter.10.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/iameli/code/streamplace/build-darwin-arm64/lib/libavfilter.10.dylib' (no such file)
```