### PR TITLE
login: force lower case, url keyboard

### DIFF
--- a/js/app/components/login/login.tsx
+++ b/js/app/components/login/login.tsx
@@ -142,9 +142,12 @@ export default function Login() {
               <Input
                 id="pdsUrl"
                 value={handle}
-                onChangeText={setHandle}
+                onChangeText={(text) => setHandle(text.toLowerCase())}
                 backgroundColor="$color2"
                 onSubmitEditing={onEnterPress}
+                autoCapitalize="none"
+                autoCorrect={false}
+                keyboardType="url"
               />
             </YStack>
             <XStack justifyContent="space-between">


### PR DESCRIPTION
"Scumb.ag" actually causes an error per https://github.com/bluesky-social/atproto/issues/3646 so may as well force all input to lower case