### PR TITLE
home: dump redux, fix long first load time

### DIFF
--- a/js/app/features/streamplace/streamplaceSlice.tsx
+++ b/js/app/features/streamplace/streamplaceSlice.tsx
@@ -202,61 +202,6 @@ export const streamplaceSlice = createAppSlice({
       },
     ),
 
-    pollSegments: create.asyncThunk(
-      async (_, { getState, dispatch }) => {
-        const { streamplace } = getState() as {
-          streamplace: StreamplaceState;
-        };
-        const { bluesky } = getState() as {
-          bluesky: BlueskyState;
-        };
-
-        let agent = bluesky.anonPDSAgent;
-
-        if (!agent) {
-          throw new Error("no anonPDSAgent");
-        }
-
-        let users = await agent.place.stream.live.getLiveUsers();
-
-        return users.data.streams;
-      },
-      {
-        pending: (state) => {
-          return {
-            ...state,
-            recentSegments: {
-              ...state.recentSegments,
-              loading: true,
-            },
-          };
-        },
-        fulfilled: (state, action) => {
-          return {
-            ...state,
-            recentSegments: {
-              ...state.recentSegments,
-              segments: action.payload || [],
-              loading: false,
-              error: null,
-              firstRequest: false,
-            },
-          };
-        },
-        rejected: (state, err) => {
-          // console.error("pollSegments rejected", err);
-          return {
-            ...state,
-            recentSegments: {
-              ...state.recentSegments,
-              error: err.error.message ?? null,
-              loading: false,
-            },
-          };
-        },
-      },
-    ),
-
     pollMySegments: create.asyncThunk(
       async (_, { getState, dispatch }) => {
         const { streamplace } = getState() as {
@@ -314,7 +259,6 @@ export const {
   getIdentity,
   setURL,
   initialize,
-  pollSegments,
   pollMySegments,
   telemetryOpt,
   userMute,
@@ -322,7 +266,6 @@ export const {
 } = streamplaceSlice.actions;
 export const {
   selectStreamplace,
-  selectRecentSegments,
   selectMySegments,
   selectTelemetry,
   selectUserMuted,

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -45,10 +45,7 @@ import {
   selectNotificationDestination,
   selectNotificationToken,
 } from "features/platform/platformSlice.native";
-import {
-  pollMySegments,
-  pollSegments,
-} from "features/streamplace/streamplaceSlice";
+import { pollMySegments } from "features/streamplace/streamplaceSlice";
 import { useLiveUser } from "hooks/useLiveUser";
 import usePlatform from "hooks/usePlatform";
 import { useSidebarControl } from "hooks/useSidebarControl";
@@ -322,16 +319,11 @@ export function StreamplaceDrawer() {
   // Top-level stuff to handle polling for live streamers
   useEffect(() => {
     let handle: NodeJS.Timeout;
-    const doSegments = () => {
-      handle = setTimeout(doMySegments, 2500);
-      dispatch(pollSegments());
-    };
-    const doMySegments = () => {
-      handle = setTimeout(doSegments, 2500);
+    handle = setInterval(() => {
       dispatch(pollMySegments());
-    };
-    doSegments();
-    return () => clearTimeout(handle);
+    }, 2500);
+    dispatch(pollMySegments());
+    return () => clearInterval(handle);
   }, []);
 
   const userIsLive = useLiveUser();

--- a/js/app/src/screens/home.tsx
+++ b/js/app/src/screens/home.tsx
@@ -1,3 +1,4 @@
+import { useStreamplaceStore } from "@streamplace/components";
 import { AlertCircle } from "@tamagui/lucide-icons";
 import { UseMediaState } from "@tamagui/web";
 import AQLink from "components/aqlink";
@@ -7,15 +8,9 @@ import StreamCardHorizontal, { StreamCardSize } from "components/home/cards";
 import LiveDot from "components/home/live-dot";
 import Loading from "components/loading/loading";
 import Title from "components/title";
-import {
-  pollSegments,
-  selectRecentSegments,
-} from "features/streamplace/streamplaceSlice";
 import useAvatars from "hooks/useAvatars";
-import useStreamplaceNode from "hooks/useStreamplaceNode";
 import { useEffect, useState } from "react";
 import { RefreshControl } from "react-native";
-import { useAppDispatch, useAppSelector } from "store/hooks";
 import { PlaceStreamLivestream } from "streamplace";
 import {
   H3,
@@ -183,50 +178,39 @@ export default function HomeScreen({
     string
   >;
 }) {
-  const { url } = useStreamplaceNode();
-  const {
-    segments: realSegments,
-    error,
-    loading,
-    firstRequest,
-  } = useAppSelector(selectRecentSegments);
-  const dispatch = useAppDispatch();
+  const liveUsers = useStreamplaceStore((state) => state.liveUsers);
+  const setLiveUsers = useStreamplaceStore((state) => state.setLiveUsers);
+  const refreshLiveUsers = () => setLiveUsers({ liveUsersRefresh: Date.now() });
+  const liveUsersLoading = useStreamplaceStore(
+    (state) => state.liveUsersLoading,
+  );
+  const liveUsersError = useStreamplaceStore((state) => state.liveUsersError);
   const [manualRefresh, setManualRefresh] = useState(false);
 
   // Use mock data for development/testing if needed
   //const segments = generateMockSegments(1).streams; // Uncomment this line to use mock data
-  const segments = realSegments; // Comment this line out if using mock data
+  const segments = useStreamplaceStore((state) => state.liveUsers);
+  // const segments = realSegments; // Comment this line out if using mock data
   const media = useMedia();
 
-  const avis = useAvatars(segments.map((s) => s.author.did));
+  const avis = useAvatars((segments || []).map((s) => s.author.did));
 
   useEffect(() => {
-    dispatch(pollSegments());
-    // get array of
-  }, [dispatch]);
-
-  useEffect(() => {
-    if (!loading) {
+    if (!liveUsersLoading) {
       setManualRefresh(false);
     }
-  }, [loading]);
+  }, [liveUsersLoading]);
 
-  if (error) {
-    if (loading) {
+  if (liveUsersError) {
+    if (liveUsersLoading) {
       return <Loading />;
     }
     if (!segments) {
-      return (
-        <ErrorBox
-          onRetry={() => {
-            dispatch(pollSegments());
-          }}
-        />
-      );
+      return <ErrorBox onRetry={refreshLiveUsers} />;
     }
   }
 
-  if (firstRequest && !segments.length) {
+  if (segments === null) {
     // Only show loading if not using mock data and no segments yet
     return <Loading />;
   }
@@ -262,7 +246,7 @@ export default function HomeScreen({
 
   return (
     <>
-      {error && (
+      {liveUsersError && (
         <View>
           <Container
             backgroundColor="#774316"
@@ -280,7 +264,7 @@ export default function HomeScreen({
             <AlertCircle size={24} minWidth={24} color="$white" />
             <Text>
               There was an error fetching the latest streams. You might be
-              offline? code: {error || "nocode"}
+              offline? code: {liveUsersError || "nocode"}
             </Text>
           </Container>
         </View>
@@ -295,7 +279,7 @@ export default function HomeScreen({
           <RefreshControl
             refreshing={manualRefresh}
             onRefresh={() => {
-              dispatch(pollSegments());
+              refreshLiveUsers();
               setManualRefresh(true);
             }}
           />
@@ -318,7 +302,7 @@ export default function HomeScreen({
             </View>
           )}
 
-          {segments.length === 0 && !loading && (
+          {segments.length === 0 && (
             <View
               f={1}
               justifyContent="center"

--- a/js/components/src/streamplace-provider/poller.tsx
+++ b/js/components/src/streamplace-provider/poller.tsx
@@ -15,6 +15,9 @@ export default function Poller({ children }: { children: React.ReactNode }) {
   const pdsAgent = usePDSAgent();
   const getChatProfile = useGetChatProfile();
   const getBskyProfile = useGetBskyProfile();
+  const liveUserRefresh = useStreamplaceStore(
+    (state) => state.liveUsersRefresh,
+  );
 
   useEffect(() => {
     if (pdsAgent && did) {
@@ -26,13 +29,27 @@ export default function Poller({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const agent = new StreamplaceAgent(url);
     const go = async () => {
-      const res = await agent.place.stream.live.getLiveUsers();
-      setLiveUsers(res.data.streams || []);
+      setLiveUsers({
+        liveUsersLoading: true,
+      });
+      try {
+        const res = await agent.place.stream.live.getLiveUsers();
+        setLiveUsers({
+          liveUsers: res.data.streams || [],
+          liveUsersLoading: false,
+          liveUsersError: null,
+        });
+      } catch (e) {
+        setLiveUsers({
+          liveUsersLoading: false,
+          liveUsersError: e.message,
+        });
+      }
     };
     go();
     const handle = setInterval(go, 3000);
     return () => clearInterval(handle);
-  }, [url]);
+  }, [url, liveUserRefresh]);
 
   return <>{children}</>;
 }

--- a/js/components/src/streamplace-store/streamplace-store.tsx
+++ b/js/components/src/streamplace-store/streamplace-store.tsx
@@ -18,8 +18,16 @@ import { StreamplaceContext } from "../streamplace-provider/context";
 
 export interface StreamplaceState {
   url: string;
-  liveUsers: PlaceStreamLivestream.LivestreamView[];
-  setLiveUsers: (users: PlaceStreamLivestream.LivestreamView[]) => void;
+  liveUsers: PlaceStreamLivestream.LivestreamView[] | null;
+  setLiveUsers: (opts: {
+    liveUsers?: PlaceStreamLivestream.LivestreamView[];
+    liveUsersLoading?: boolean;
+    liveUsersError?: string | null;
+    liveUsersRefresh?: number;
+  }) => void;
+  liveUsersRefresh: number;
+  liveUsersLoading: boolean;
+  liveUsersError: string | null;
   oauthSession: SessionManager | null;
   handle: string | null;
   chatProfile: PlaceStreamChatProfile.Record | null;
@@ -34,10 +42,20 @@ export const makeStreamplaceStore = ({
 }): StoreApi<StreamplaceState> => {
   return createStore<StreamplaceState>()((set) => ({
     url,
-    liveUsers: [],
-    setLiveUsers: (users: PlaceStreamLivestream.LivestreamView[]) => {
-      set({ liveUsers: users });
+    liveUsers: null,
+    setLiveUsers: (opts: {
+      liveUsers?: PlaceStreamLivestream.LivestreamView[];
+      liveUsersLoading?: boolean;
+      liveUsersError?: string | null;
+      liveUsersRefresh?: number;
+    }) => {
+      set({
+        ...opts,
+      });
     },
+    liveUsersRefresh: 0,
+    liveUsersLoading: true,
+    liveUsersError: null,
     oauthSession: null,
     handle: null,
     chatProfile: null,


### PR DESCRIPTION
@espeon Our first experiment into `{data, loading, error, refresh}` in Zustand — did this to speed up the first load which I think wasn't happening for a couple seconds. Not certain whether this is clever or not or if we're going to need something else entirely. (Is this... what Tanstack Query is for?)

```typescript
    setLiveUsers: (opts: {
      liveUsers?: PlaceStreamLivestream.LivestreamView[];
      liveUsersLoading?: boolean;
      liveUsersError?: string | null;
      liveUsersRefresh?: number;
    }) => {
      set({
        ...opts,
      });
    },
```