### PR TITLE
hotfix: remove `cursor: pointer` + invalid dimension on iOS

### DIFF
--- a/js/app/components/chat/chat.tsx
+++ b/js/app/components/chat/chat.tsx
@@ -385,7 +385,6 @@ function ChatMessageRow({
                   paddingVertical="$1"
                   paddingHorizontal="$2"
                   borderRadius="$2"
-                  marginLeft="-$1"
                 >
                   <Text fontSize={12} color={replyToColor} fontWeight="bold">
                     {replyToHandle ? `@${replyToHandle}` : ""}

--- a/js/app/components/livestream/livestream.tsx
+++ b/js/app/components/livestream/livestream.tsx
@@ -267,7 +267,8 @@ export function LivestreamInner(props: Partial<PlayerProps>) {
                                 color: "$blue11",
                               }}
                               aria-label={`View @${streamerHandle} on Bluesky`}
-                              style={{ cursor: "pointer" }}
+                              // TODO: re-add on New Architecture
+                              //style={{ cursor: "pointer" }}
                               ellipse={true}
                             >
                               {`@${streamerHandle}`}

--- a/js/app/components/livestream/livestream.tsx
+++ b/js/app/components/livestream/livestream.tsx
@@ -268,7 +268,7 @@ export function LivestreamInner(props: Partial<PlayerProps>) {
                               }}
                               aria-label={`View @${streamerHandle} on Bluesky`}
                               // TODO: re-add on New Architecture
-                              //style={{ cursor: "pointer" }}
+                              style={isWeb ? { cursor: "pointer" } : {}}
                               ellipse={true}
                             >
                               {`@${streamerHandle}`}

--- a/js/app/components/livestream/livestream.tsx
+++ b/js/app/components/livestream/livestream.tsx
@@ -157,8 +157,7 @@ export function LivestreamInner(props: Partial<PlayerProps>) {
     }
   };
 
-  const MainView =
-    (width < height && width < 980) || fullscreen ? View : ScrollView;
+  const MainView = width < height && width < 980 ? View : ScrollView;
 
   const dir = width < height && width < 980 ? "column" : "row";
 

--- a/js/app/components/livestream/livestream.tsx
+++ b/js/app/components/livestream/livestream.tsx
@@ -157,7 +157,6 @@ export function LivestreamInner(props: Partial<PlayerProps>) {
     }
   };
 
-  // if width <600px or if in horizontal mode, use View, otherwise use ScrollView
   const MainView =
     (width < height && width < 980) || fullscreen ? View : ScrollView;
 
@@ -190,7 +189,6 @@ export function LivestreamInner(props: Partial<PlayerProps>) {
           >
             <MainView
               width={videoWidth}
-              height="100%"
               maxHeight={videoHeight}
               maxWidth={videoWidth}
               fs={0}
@@ -347,6 +345,7 @@ export function LivestreamInner(props: Partial<PlayerProps>) {
                 backgroundColor="$background2"
                 animation={"quick"}
                 pt="$11"
+                $gtXs={{ pt: 0 }}
                 transform={
                   isIOS
                     ? [
@@ -361,6 +360,7 @@ export function LivestreamInner(props: Partial<PlayerProps>) {
                     ? {
                         paddingTop: 0,
                         width: isChatVisible ? 380 : 0,
+                        minWidth: isChatVisible ? 380 : 0,
                         flexBasis: isChatVisible ? 380 : 0,
                         flexShrink: 1,
                         borderLeftColor: "#666",


### PR DESCRIPTION
Two fixes:

- Warning on "-$1" not being a valid dimension on iOS

- Fix occasional infinite loading on iOS. So far as I can tell, we can add this back in on the switch to New Architecture eventually.