### PR TITLE
fix: throw if model repo is nil in discord integration

### DIFF
--- a/pkg/atproto/sync.go
+++ b/pkg/atproto/sync.go
@@ -137,7 +137,7 @@ func (atsync *ATProtoSynchronizer) handleCreateUpdate(ctx context.Context, userD
 			for _, webhook := range atsync.CLI.DiscordWebhooks {
 				if webhook.DID == rec.Streamer && webhook.Type == "chat" {
 					go func() {
-						err := discord.SendChat(ctx, webhook, r, scm)
+						err := discord.SendChat(ctx, webhook, repo, scm)
 						if err != nil {
 							log.Error(ctx, "failed to send livestream to discord", "err", err)
 						} else {

--- a/pkg/integrations/discord/avatars.go
+++ b/pkg/integrations/discord/avatars.go
@@ -2,6 +2,7 @@ package discord
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/bluesky-social/indigo/api/bsky"
@@ -19,6 +20,10 @@ var avatarCacheMutex = sync.Mutex{}
 func getAvatarURL(ctx context.Context, r *model.Repo) (string, error) {
 	avatarCacheMutex.Lock()
 	defer avatarCacheMutex.Unlock()
+
+	if r == nil || r.DID == "" {
+		return "", fmt.Errorf("repo or DID is nil or empty")
+	}
 
 	if avatar, ok := avatarCache[r.DID]; ok {
 		return avatar, nil


### PR DESCRIPTION
I feel like the 'actual' 'issue' is that we don't fetch repos if we don't have them locally (unsure if this is intended or not), but this should do in the time being