### PR TITLE
chat: on mobile, use a larger touch area instead of hitslop

### DIFF
--- a/js/components/src/components/ui/resizeable.tsx
+++ b/js/components/src/components/ui/resizeable.tsx
@@ -15,7 +15,7 @@ import Animated, {
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useKeyboardSlide } from "../../hooks";
-import { bottom, layout, p, w, zIndex } from "../../lib/theme/atoms";
+import { bottom, h, layout, p, w, zIndex } from "../../lib/theme/atoms";
 import { View } from "./view";
 
 const AnimatedView = Animated.createAnimatedComponent(View);
@@ -154,24 +154,35 @@ export function Resizable({
           style,
         ]}
       >
-        <View style={[layout.flex.row, layout.flex.justifyCenter]}>
+        <View style={[layout.flex.row, layout.flex.justifyCenter, h[2]]}>
           <GestureDetector gesture={panGesture}>
             <View
-              hitSlop={{ top: 20, bottom: 20, left: 20, right: 20 }}
-              style={[
-                w[32],
-                {
-                  height: 6,
-                  transform: [{ translateY: -10 }],
-                  backgroundColor: "#eeeeee66",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  borderRadius: 999,
-                },
-              ]}
-            />
+              // Make the touch area much larger, but keep the visible handle small
+              style={{
+                height: 30, // Large touch area
+                width: 120, // Wide enough for thumbs
+                alignItems: "center",
+                justifyContent: "center",
+                backgroundColor: "rgba(0,255,255,0.1)",
+                transform: [{ translateY: -30 }],
+              }}
+            >
+              <View
+                style={[
+                  w[32],
+                  {
+                    height: 6,
+                    backgroundColor: "#eeeeee66",
+                    borderRadius: 999,
+
+                    transform: [{ translateY: 5 }],
+                  },
+                ]}
+              />
+            </View>
           </GestureDetector>
         </View>
+
         {children}
       </AnimatedView>
     </>

--- a/js/components/src/components/ui/resizeable.tsx
+++ b/js/components/src/components/ui/resizeable.tsx
@@ -163,7 +163,7 @@ export function Resizable({
                 width: 120, // Wide enough for thumbs
                 alignItems: "center",
                 justifyContent: "center",
-                backgroundColor: "rgba(0,255,255,0.1)",
+                //backgroundColor: "rgba(0,255,255,0.1)",
                 transform: [{ translateY: -30 }],
               }}
             >


### PR DESCRIPTION
Looks like something's overriding the hitslop on web/android and not on iOS, so switching to simply having a bigger touch area. Shown in the image below
![image](https://github.com/user-attachments/assets/1d1c5dff-334f-4df3-8484-5e11dbb31b7e)

fixes https://github.com/streamplace/streamplace/issues/361