### PR TITLE
make internal API url configurable for live subcommand

### DIFF
--- a/pkg/cmd/live.go
+++ b/pkg/cmd/live.go
@@ -7,9 +7,9 @@ import (
 	"os"
 )
 
-func Live(streamKey string) error {
+func Live(streamKey string, httpInternalAddr string) error {
 	// Create the URL for the live stream endpoint
-	url := fmt.Sprintf("http://127.0.0.1:39090/live/%s", streamKey)
+	url := fmt.Sprintf("http://%s/live/%s", httpInternalAddr, streamKey)
 
 	// Create a new HTTP request with POST method
 	req, err := http.NewRequest("POST", url, os.Stdin)

--- a/pkg/cmd/streamplace.go
+++ b/pkg/cmd/streamplace.go
@@ -87,11 +87,21 @@ func start(build *config.BuildFlags, platformJobs []jobFunc) error {
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "live" {
-		if len(os.Args) != 3 {
-			fmt.Println("usage: streamplace live [stream-key]")
+		cli := config.CLI{Build: build}
+		fs := cli.NewFlagSet("streamplace live")
+
+		err := cli.Parse(fs, os.Args[2:])
+		if err != nil {
+			return err
+		}
+
+		args := fs.Args()
+		if len(args) != 1 {
+			fmt.Println("usage: streamplace live [flags] [stream-key]")
 			os.Exit(1)
 		}
-		return Live(os.Args[2])
+
+		return Live(args[0], cli.HTTPInternalAddr)
 	}
 
 	if len(os.Args) > 1 && os.Args[1] == "sign" {


### PR DESCRIPTION
Important for dockerized deployments of Mistserver, without directly using host networking mode

e.g. if one is setting up mistserver elsewhere, one can set the internal API url to the specific host IP (assuming they have the firewall set up correctly), or to something like host.docker.internal.