### PR TITLE
app: fixes for ota update capabilities

### DIFF
--- a/cmd/libstreamplace/build-flags.go
+++ b/cmd/libstreamplace/build-flags.go
@@ -1,5 +1,13 @@
 package main
 
-var Version = "unknown"
-var BuildTime = "0"
-var UUID = "unknown"
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var Version = os.Getenv("STREAMPLACE_DEV_VERSION")
+var BuildTime = fmt.Sprint(time.Now().Unix())
+var UUID = uuid.New().String()

--- a/js/app/components/settings/updates.native.tsx
+++ b/js/app/components/settings/updates.native.tsx
@@ -7,16 +7,12 @@ import pkg from "../../package.json";
 
 export function Updates() {
   const version = pkg.version;
-  const { currentlyRunning, isUpdateAvailable, isUpdatePending } =
-    ExpoUpdates.useUpdates();
+  const updateInfo = ExpoUpdates.useUpdates();
+  const { currentlyRunning, isUpdateAvailable, isUpdatePending } = updateInfo;
+
+  console.log(`updateInfo: ${JSON.stringify(updateInfo)}`);
 
   const [checked, setChecked] = useState(false);
-
-  useEffect(() => {
-    if (isUpdatePending) {
-      ExpoUpdates.reloadAsync();
-    }
-  }, [isUpdatePending]);
 
   useEffect(() => {
     if (isUpdateAvailable && checked) {
@@ -74,6 +70,16 @@ export function Updates() {
         >
           <Text>{buttonText}</Text>
         </Button>
+        {isUpdatePending && (
+          <Button
+            mt="$2"
+            onPress={() => {
+              ExpoUpdates.reloadAsync();
+            }}
+          >
+            <Text>Reload app for new version</Text>
+          </Button>
+        )}
       </View>
     </View>
   );

--- a/pkg/api/app-updates.go
+++ b/pkg/api/app-updates.go
@@ -238,6 +238,21 @@ func PrepareUpdater(cli *config.CLI) (*Updater, error) {
 		return nil, fmt.Errorf("package.json has runtimeVersion that's not a string")
 	}
 
+	expoConfig, err := fs.Open("expoConfig.json")
+	if err != nil {
+		return nil, fmt.Errorf("couldn't open expoConfig.json: %w", err)
+	}
+	expoConfigBytes, err := io.ReadAll(expoConfig)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read expoConfig.json: %w", err)
+	}
+	expoConfigJSON := map[string]any{}
+	err = json.Unmarshal(expoConfigBytes, &expoConfigJSON)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't parse expoConfig.json: %w", err)
+	}
+	extra["expoClient"] = expoConfigJSON
+
 	var privateKey *rsa.PrivateKey
 	if cli.SigningKeyPath != "" {
 		privateKey, err = cli.ParseSigningKey()
@@ -257,10 +272,14 @@ func PrepareUpdater(cli *config.CLI) (*Updater, error) {
 
 func (a *StreamplaceAPI) HandleAppUpdates(ctx context.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		prefix := fmt.Sprintf("http://%s", req.Host)
+		proto := "http"
 		if req.TLS != nil {
-			prefix = fmt.Sprintf("https://%s", req.Host)
+			proto = "https"
 		}
+		if xfproto := req.Header.Get("x-forwarded-proto"); xfproto == "https" {
+			proto = "https"
+		}
+		prefix := fmt.Sprintf("%s://%s", proto, req.Host)
 		log.Log(ctx, "got app-updates request", "method", req.Method, "headers", req.Header)
 		plat := req.Header.Get("expo-platform")
 		if plat == "" {

--- a/util/streamplace-dev.sh
+++ b/util/streamplace-dev.sh
@@ -6,7 +6,8 @@
 set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+STREAMPLACE_DEV_VERSION=$(go run ./pkg/config/git/git.go -v) \
 LD_LIBRARY_PATH="$SCRIPT_DIR/lib/usr/local/lib/x86_64-linux-gnu" \
-  DYLD_LIBRARY_PATH="$SCRIPT_DIR/lib/usr/local/lib" \
-  SP_DEV_FRONTEND_PROXY="http://127.0.0.1:38081" \
+DYLD_LIBRARY_PATH="$SCRIPT_DIR/lib/usr/local/lib" \
+SP_DEV_FRONTEND_PROXY="http://127.0.0.1:38081" \
   exec "$SCRIPT_DIR/libstreamplace" "$@"


### PR DESCRIPTION
So there were TWO root causes of https://github.com/streamplace/streamplace/issues/380, at least on iOS:

1. For some reason expo-linking needs `extra.expoClient` to be populated by the `app.config.ts` output; this wasn't true before 0.7.0. This commit fixes that.
2. For 0.7.0 we ported the codemod changes from Objective-C to Swift. The Swift version crashes when OTA updates run. But importantly, it only happens during the soft reload of a new app bundle, which is to say it only happens when you apply the new update from the "updates" screen. 99% of people will get the new update when they open the app and they won't encounter this problem. So this kind of stinks but it doesn't actually block updates so whatever.

Leaving #380 open for the second issue, but this change fixes the first one.

Also includes a couple changes to the dev-only `build-flags.go` file to make debugging this stuff easier in development. (It's still a huge pain.)