### PR TITLE
thumbnail: relax size assertions for JPEG tests

### DIFF
--- a/pkg/media/thumbnail_test.go
+++ b/pkg/media/thumbnail_test.go
@@ -49,6 +49,10 @@ func TestThumbnail(t *testing.T) {
 				if thumbnail.Len() == 0 {
 					return fmt.Errorf("thumbnail buffer is empty")
 				}
+				// jpeg thumbnails aren't deterministic, so let's give a range instead
+				// testing gave 140969 bytes, but it can vary a bit
+				require.Greater(t, thumbnail.Len(), 140000)
+				require.Less(t, thumbnail.Len(), 150000)
 				require.Equal(t, 140969, thumbnail.Len())
 				return nil
 			})
@@ -89,7 +93,8 @@ func TestThumbnailStall(t *testing.T) {
 		err = Thumbnail(context.Background(), bytes.NewReader(bs), &thumbnail, "jpeg")
 		require.NoError(t, err)
 		// This is inconsistent. Which is concerning.
-		require.Greater(t, thumbnail.Len(), 22000)
+		// Testing gave ~22000 bytes
+		require.Greater(t, thumbnail.Len(), 20000)
 		require.Less(t, thumbnail.Len(), 25000)
 	})
 }


### PR DESCRIPTION
Close #401 