### PR TITLE
fix: unscope functions in dropdown

### DIFF
--- a/js/components/src/components/chat/mod-view.tsx
+++ b/js/components/src/components/chat/mod-view.tsx
@@ -45,6 +45,9 @@ export const ModView = forwardRef<ModViewRef, ModViewProps>(() => {
   let { createBlock, isLoading: isBlockLoading } = useCreateBlockRecord();
   let { createHideChat, isLoading: isHideLoading } = useCreateHideChatRecord();
 
+  const setReportModalOpen = usePlayerStore((x) => x.setReportModalOpen);
+  const setReportSubject = usePlayerStore((x) => x.setReportSubject);
+
   // get the channel did
   const channelId = usePlayerStore((state) => state.src);
   // get the logged in user's identity
@@ -161,7 +164,11 @@ export const ModView = forwardRef<ModViewRef, ModViewProps>(() => {
               >
                 <Text color="primary">View user on {BSKY_FRONTEND_DOMAIN}</Text>
               </DropdownMenuItem>
-              <ReportButton message={message} />
+              <ReportButton
+                message={message}
+                setReportModalOpen={setReportModalOpen}
+                setReportSubject={setReportSubject}
+              />
             </DropdownMenuGroup>
           </>
         )}
@@ -172,11 +179,13 @@ export const ModView = forwardRef<ModViewRef, ModViewProps>(() => {
 
 export function ReportButton({
   message,
+  setReportModalOpen,
+  setReportSubject,
 }: {
   message: ChatMessageViewHydrated;
+  setReportModalOpen: (open: boolean) => void;
+  setReportSubject: (subject: any) => void;
 }) {
-  const setReportModalOpen = usePlayerStore((x) => x.setReportModalOpen);
-  const setReportSubject = usePlayerStore((x) => x.setReportSubject);
   const { onOpenChange } = useRootContext();
   return (
     <DropdownMenuItem

--- a/js/components/src/components/mobile-player/ui/viewer-context-menu.tsx
+++ b/js/components/src/components/mobile-player/ui/viewer-context-menu.tsx
@@ -27,6 +27,10 @@ export function ContextMenu() {
   const debugInfo = usePlayerStore((x) => x.showDebugInfo);
   const setShowDebugInfo = usePlayerStore((x) => x.setShowDebugInfo);
 
+  const livestream = useLivestreamStore((x) => x.livestream);
+  const setReportModalOpen = usePlayerStore((x) => x.setReportModalOpen);
+  const setReportSubject = usePlayerStore((x) => x.setReportSubject);
+
   const lowLatency = protocol === "webrtc";
   const setLowLatency = (value: boolean) => {
     setProtocol(value ? PlayerProtocol.WEBRTC : PlayerProtocol.HLS);
@@ -68,17 +72,22 @@ export function ContextMenu() {
           </DropdownMenuCheckboxItem>
         </DropdownMenuGroup>
         <DropdownMenuGroup title="Report">
-          <ReportButton />
+          <ReportButton
+            livestream={livestream}
+            setReportModalOpen={setReportModalOpen}
+            setReportSubject={setReportSubject}
+          />
         </DropdownMenuGroup>
       </ResponsiveDropdownMenuContent>
     </DropdownMenu>
   );
 }
 
-export function ReportButton() {
-  const livestream = useLivestreamStore((x) => x.livestream);
-  const setReportModalOpen = usePlayerStore((x) => x.setReportModalOpen);
-  const setReportSubject = usePlayerStore((x) => x.setReportSubject);
+export function ReportButton({
+  livestream,
+  setReportModalOpen,
+  setReportSubject,
+}) {
   const { onOpenChange } = useRootContext();
   return (
     <DropdownMenuItem

--- a/js/components/src/components/ui/dropdown.tsx
+++ b/js/components/src/components/ui/dropdown.tsx
@@ -200,6 +200,8 @@ export const DropdownMenuContent = forwardRef<
   );
 });
 
+/// Responsive Dropdown Menu Content. On mobile this will render a *bottom sheet* that is **portaled to the root of the app**.
+/// Prefer passing scoped content in as **otherwise it may crash the app**.
 export const ResponsiveDropdownMenuContent = forwardRef<any, any>(
   ({ children, ...props }, ref) => {
     const { width } = useWindowDimensions();


### PR DESCRIPTION
The dropdown is portaled to the top of the app on mobile (it's actually a sheet on mobile), so scoped data like react contexts won't work properly.