### PR TITLE
media: fix a memory leak when livepeer transcoding fails

### DIFF
--- a/pkg/media/leak_test.go
+++ b/pkg/media/leak_test.go
@@ -37,6 +37,7 @@ func init() {
 var LeakTestMutex sync.Mutex
 
 const IgnoreLeaks = "STREAMPLACE_IGNORE_LEAKS"
+const ShowTrace = "STREAMPLACE_SHOW_TRACE"
 const GSTDebugNeeded = "leaks:9,GST_TRACER:9"
 const LeakLine = "GST_TRACER :0:: object-alive"
 
@@ -52,6 +53,7 @@ func TestMain(m *testing.M) {
 		os.Exit(m.Run())
 		return
 	}
+	showTrace := os.Getenv(ShowTrace) != ""
 	gstDebug := os.Getenv("GST_DEBUG")
 	if gstDebug == "" {
 		gstDebug = GSTDebugNeeded
@@ -85,7 +87,7 @@ func TestMain(m *testing.M) {
 		for scanner.Scan() {
 			lineAnsi := scanner.Text()
 			line := stripansi.Strip(lineAnsi)
-			if !strings.Contains(line, " TRACE ") {
+			if !strings.Contains(line, " TRACE ") || showTrace {
 				fmt.Println(lineAnsi)
 			}
 			if strings.Contains(line, LeakLine) {

--- a/pkg/media/segment_conv.go
+++ b/pkg/media/segment_conv.go
@@ -528,7 +528,6 @@ func MPEGTSVideoMP4AudioToMP4(ctx context.Context, videoInput io.Reader, audioIn
 	onPadAdded := func(element *gst.Element, pad *gst.Pad) {
 		if pad.GetDirection() == gst.PadDirectionSource {
 			ok := pad.Link(videoParseSinkPad)
-			defer func() { videoParseSinkPad = nil }()
 			if ok != gst.PadLinkOK {
 				log.Error(ctx, "failed to link video parse sink pad to video demux pad", "error", ok)
 				cancel()
@@ -539,13 +538,12 @@ func MPEGTSVideoMP4AudioToMP4(ctx context.Context, videoInput io.Reader, audioIn
 		return fmt.Errorf("failed connect pad-added handler: %w", err)
 	}
 
-	// Handle bus messages in a separate goroutine
-	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
+	errCh := make(chan error)
+	go func() {
 		err = HandleBusMessages(ctx, pipeline)
 		cancel()
-		return err
-	})
+		errCh <- err
+	}()
 
 	// Start the pipeline
 	err = pipeline.SetState(gst.StatePlaying)
@@ -553,14 +551,13 @@ func MPEGTSVideoMP4AudioToMP4(ctx context.Context, videoInput io.Reader, audioIn
 		return fmt.Errorf("failed to set pipeline state to playing: %w", err)
 	}
 
-	// Wait for the pipeline to finish or context to be canceled
-	<-ctx.Done()
+	defer func() {
+		err = pipeline.SetState(gst.StateNull)
+		if err != nil {
+			log.Error(ctx, "failed to set pipeline state to null", "error", err)
+		}
+		videoParseSinkPad = nil
+	}()
 
-	// Clean up
-	err = pipeline.SetState(gst.StateNull)
-	if err != nil {
-		return fmt.Errorf("failed to set pipeline state to null: %w", err)
-	}
-
-	return g.Wait()
+	return <-errCh
 }

--- a/pkg/media/segment_conv_test.go
+++ b/pkg/media/segment_conv_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -154,5 +155,33 @@ func TestMP4ToMPEGTSVideoMP4Audio(t *testing.T) {
 		require.Greater(t, buf.Len(), 0, "Output buffer should not be empty")
 		elapsed = time.Since(start)
 		require.Less(t, elapsed, 4*time.Second, "MPEG-TS/MP4 to MP4 conversion should take less than 4 seconds")
+	})
+}
+
+func TestMPEGTSVideoMP4AudioToMP4Invalid(t *testing.T) {
+	withNoGSTLeaks(t, func() {
+
+		// Join video and audio back together
+		videoBuf := bytes.Buffer{}
+		audioBuf := bytes.Buffer{}
+		// Fill buffers with 1MB of random data
+
+		rng := rand.New(rand.NewSource(42))
+		randomData := make([]byte, 1024*1024) // 1MB
+		_, err := rng.Read(randomData)
+		require.NoError(t, err)
+		_, err = videoBuf.Write(randomData)
+		require.NoError(t, err)
+
+		randomData = make([]byte, 1024*1024) // 1MB
+		_, err = rng.Read(randomData)
+		require.NoError(t, err)
+		_, err = audioBuf.Write(randomData)
+		require.NoError(t, err)
+
+		buf := bytes.Buffer{}
+
+		err = MPEGTSVideoMP4AudioToMP4(context.Background(), &videoBuf, &audioBuf, &buf)
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
The sink pad of `h264parse` wasn't getting properly cleaned up in the case where we failed to convert the results. This fixes that.