### PR TITLE
fix: show dropdowns in fullscreen on web

### DIFF
--- a/js/app/components/mobile/desktop-ui.tsx
+++ b/js/app/components/mobile/desktop-ui.tsx
@@ -35,7 +35,11 @@ function isRefObject(
   return ref && typeof ref === "object" && "current" in ref;
 }
 
-export function DesktopUi() {
+export function DesktopUi({
+  dropdownPortalContainer,
+}: {
+  dropdownPortalContainer?: any;
+}) {
   const {
     ingest,
     title,
@@ -251,6 +255,7 @@ export function DesktopUi() {
               pipSupported={pipSupported}
               pipActive={pipActive}
               onHandlePip={handlePip}
+              dropdownPortalContainer={dropdownPortalContainer}
             />
           </Animated.View>
 

--- a/js/app/components/mobile/desktop-ui/bottom-controls.tsx
+++ b/js/app/components/mobile/desktop-ui/bottom-controls.tsx
@@ -10,6 +10,7 @@ interface BottomControlBarProps {
   pipSupported: boolean;
   pipActive: boolean;
   onHandlePip: () => void;
+  dropdownPortalContainer?: any;
 }
 
 export function BottomControlBar({
@@ -17,6 +18,7 @@ export function BottomControlBar({
   pipSupported,
   pipActive,
   onHandlePip,
+  dropdownPortalContainer,
 }: BottomControlBarProps) {
   const fullscreen = usePlayerStore((state) => state.fullscreen);
   const setFullscreen = usePlayerStore((state) => state.setFullscreen);
@@ -51,7 +53,11 @@ export function BottomControlBar({
             {fullscreen ? <Minimize /> : <Fullscreen />}
           </Pressable>
         )}
-        {ingest === null && <PlayerUI.ContextMenu />}
+        {ingest === null && (
+          <PlayerUI.ContextMenu
+            dropdownPortalContainer={dropdownPortalContainer}
+          />
+        )}
       </View>
     </View>
   );

--- a/js/app/components/mobile/player.tsx
+++ b/js/app/components/mobile/player.tsx
@@ -17,7 +17,7 @@ import { ArrowLeft, ArrowRight } from "@tamagui/lucide-icons";
 import { selectUserProfile } from "features/bluesky/blueskySlice";
 import { useLiveUser } from "hooks/useLiveUser";
 import { useSidebarControl } from "hooks/useSidebarControl";
-import { useEffect, useState } from "react";
+import { ComponentRef, useEffect, useRef, useState } from "react";
 import { Animated, ScrollView } from "react-native";
 import { useAppSelector } from "store/hooks";
 import { BottomMetadata } from "./bottom-metadata";
@@ -154,6 +154,7 @@ export function PlayerInner(
 ) {
   let sb = useSidebarControl();
   let fullscreen = usePlayerStore((x) => x.fullscreen);
+  const dropdownPortalRef = useRef<ComponentRef<typeof View> | null>(null);
   const {
     shouldShowChatSidePanel,
     chatPanelWidth,
@@ -187,11 +188,6 @@ export function PlayerInner(
 
   const showBottomMetaPanel = aspectRatio > 1 && screenWidth > 980;
 
-  // Direct responsive styling without animations
-  const playerStyle = {
-    width: calculatedWidth,
-    height: calculatedHeight,
-  };
   // i don't really like this, but it's the only way to ensure the
   // player is sized correctly on both desktop and mobile views
   const ContainerElement = showBottomMetaPanel ? ScrollView : View;
@@ -227,9 +223,22 @@ export function PlayerInner(
         ]}
       >
         <PlayerInnerInner {...props}>
-          {(showBottomMetaPanel || fullscreen) && <DesktopUi />}
+          {(showBottomMetaPanel || fullscreen) && (
+            <DesktopUi dropdownPortalContainer={dropdownPortalRef.current} />
+          )}
           <PlayerUI.ViewerLoadingOverlay />
           <OfflineCounter isMobile={true} />
+          <View
+            ref={dropdownPortalRef}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              pointerEvents: "none",
+            }}
+          />
         </PlayerInnerInner>
       </Animated.View>
       {showBottomMetaPanel && (

--- a/js/components/src/components/mobile-player/ui/viewer-context-menu.tsx
+++ b/js/components/src/components/mobile-player/ui/viewer-context-menu.tsx
@@ -1,14 +1,17 @@
 import { useRootContext } from "@rn-primitives/dropdown-menu";
 import { Settings } from "lucide-react-native";
+import { Platform, View } from "react-native";
 import { colors } from "../../../lib/theme";
 import { useLivestreamStore } from "../../../livestream-store";
 import { PlayerProtocol, usePlayerStore } from "../../../player-store/";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
+  DropdownMenuContentWithoutPortal,
   DropdownMenuGroup,
   DropdownMenuInfo,
   DropdownMenuItem,
+  DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
@@ -16,7 +19,11 @@ import {
   Text,
 } from "../../ui";
 
-export function ContextMenu() {
+export function ContextMenu({
+  dropdownPortalContainer,
+}: {
+  dropdownPortalContainer?: any;
+}) {
   const quality = usePlayerStore((x) => x.selectedRendition);
   const setQuality = usePlayerStore((x) => x.setSelectedRendition);
   const qualities = useLivestreamStore((x) => x.renditions);
@@ -36,49 +43,62 @@ export function ContextMenu() {
     setProtocol(value ? PlayerProtocol.WEBRTC : PlayerProtocol.HLS);
   };
 
+  // are we on mobile? then do dropdowns
+  const isMobile = Platform.OS === "ios" || Platform.OS === "android";
+
+  // dummy portal for mobile
+  const Portal = isMobile ? View : DropdownMenuPortal;
+
+  // render the responsive version on mobile as we can't fullscreen there
+  const DropdownMenuContent = isMobile
+    ? ResponsiveDropdownMenuContent
+    : DropdownMenuContentWithoutPortal;
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger>
         <Settings color={colors.gray[200]} />
       </DropdownMenuTrigger>
-      <ResponsiveDropdownMenuContent side="top" align="end">
-        <DropdownMenuGroup title="Resolution">
-          <DropdownMenuRadioGroup value={quality} onValueChange={setQuality}>
-            <DropdownMenuRadioItem value="source">
-              <Text>Source (Original Quality)</Text>
-            </DropdownMenuRadioItem>
-            {qualities.map((r) => (
-              <DropdownMenuRadioItem value={r.name}>
-                <Text>{r.name}</Text>
+      <Portal container={dropdownPortalContainer}>
+        <DropdownMenuContent side="top" align="end">
+          <DropdownMenuGroup title="Resolution">
+            <DropdownMenuRadioGroup value={quality} onValueChange={setQuality}>
+              <DropdownMenuRadioItem value="source">
+                <Text>Source (Original Quality)</Text>
               </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-        </DropdownMenuGroup>
-        <DropdownMenuGroup title="Advanced">
-          <DropdownMenuCheckboxItem
-            checked={lowLatency}
-            onCheckedChange={() => setLowLatency(!lowLatency)}
-          >
-            <Text>Low Latency</Text>
-          </DropdownMenuCheckboxItem>
-        </DropdownMenuGroup>
-        <DropdownMenuInfo description="Reduces the delay between video and chat for a more real-time experience." />
-        <DropdownMenuGroup>
-          <DropdownMenuCheckboxItem
-            checked={debugInfo}
-            onCheckedChange={() => setShowDebugInfo(!debugInfo)}
-          >
-            <Text>Show Debug Info</Text>
-          </DropdownMenuCheckboxItem>
-        </DropdownMenuGroup>
-        <DropdownMenuGroup title="Report">
-          <ReportButton
-            livestream={livestream}
-            setReportModalOpen={setReportModalOpen}
-            setReportSubject={setReportSubject}
-          />
-        </DropdownMenuGroup>
-      </ResponsiveDropdownMenuContent>
+              {qualities.map((r) => (
+                <DropdownMenuRadioItem value={r.name}>
+                  <Text>{r.name}</Text>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuGroup>
+          <DropdownMenuGroup title="Advanced">
+            <DropdownMenuCheckboxItem
+              checked={lowLatency}
+              onCheckedChange={() => setLowLatency(!lowLatency)}
+            >
+              <Text>Low Latency</Text>
+            </DropdownMenuCheckboxItem>
+          </DropdownMenuGroup>
+          <DropdownMenuInfo description="Reduces the delay between video and chat for a more real-time experience." />
+          <DropdownMenuGroup>
+            <DropdownMenuCheckboxItem
+              checked={debugInfo}
+              onCheckedChange={() => setShowDebugInfo(!debugInfo)}
+            >
+              <Text>Show Debug Info</Text>
+            </DropdownMenuCheckboxItem>
+          </DropdownMenuGroup>
+          <DropdownMenuGroup title="Report">
+            <ReportButton
+              livestream={livestream}
+              setReportModalOpen={setReportModalOpen}
+              setReportSubject={setReportSubject}
+            />
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </Portal>
     </DropdownMenu>
   );
 }

--- a/js/components/src/components/ui/dropdown.tsx
+++ b/js/components/src/components/ui/dropdown.tsx
@@ -8,7 +8,7 @@ import {
   ChevronUp,
   Circle,
 } from "lucide-react-native";
-import { forwardRef, ReactNode, useMemo, useRef } from "react";
+import React, { forwardRef, ReactNode, useMemo, useRef } from "react";
 import {
   Platform,
   Pressable,
@@ -200,6 +200,41 @@ export const DropdownMenuContent = forwardRef<
   );
 });
 
+export const DropdownMenuContentWithoutPortal = forwardRef<
+  any,
+  DropdownMenuPrimitive.ContentProps & {
+    overlayStyle?: any;
+  }
+>(({ overlayStyle, ...props }, ref) => {
+  return (
+    <DropdownMenuPrimitive.Overlay
+      style={[
+        Platform.OS !== "web" ? StyleSheet.absoluteFill : undefined,
+        overlayStyle,
+      ]}
+    >
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        style={
+          [
+            { zIndex: 999999 },
+            a.sizes.minWidth[32],
+            a.sizes.maxWidth[64],
+            a.overflow.hidden,
+            a.radius.all.md,
+            a.borders.width.thin,
+            a.borders.color.gray[800],
+            bg.gray[950],
+            p[2],
+            a.shadows.md,
+          ] as any
+        }
+        {...props}
+      />
+    </DropdownMenuPrimitive.Overlay>
+  );
+});
+
 /// Responsive Dropdown Menu Content. On mobile this will render a *bottom sheet* that is **portaled to the root of the app**.
 /// Prefer passing scoped content in as **otherwise it may crash the app**.
 export const ResponsiveDropdownMenuContent = forwardRef<any, any>(
@@ -223,8 +258,6 @@ export const ResponsiveDropdownMenuContent = forwardRef<any, any>(
     );
   },
 );
-
-import React from "react";
 
 export const DropdownMenuItem = forwardRef<
   any,


### PR DESCRIPTION
Dropdowns are usually rendered in a portal, but that portal ends up being behind the player in fullscreen mode. Here we manually make a portal-like div inside the fullscreen context and tell the dropdown to render in that div.