### PR TITLE
feat: add canonical url in livestream record

### DIFF
--- a/js/app/components/live-dashboard/livestream-panel.tsx
+++ b/js/app/components/live-dashboard/livestream-panel.tsx
@@ -202,11 +202,11 @@ function LivestreamPanel() {
       }
 
       if (mode === "create") {
-        await createStreamRecord(
-          title.trim(),
-          thumbnailToUse as Blob | undefined,
-          true,
-        );
+        await createStreamRecord({
+          title: title.trim(),
+          customThumbnail: thumbnailToUse as Blob | undefined,
+          submitPost: true,
+        });
       } else {
         await updateStreamRecord(
           title.trim(),

--- a/js/components/src/hooks/useLivestreamInfo.ts
+++ b/js/components/src/hooks/useLivestreamInfo.ts
@@ -21,7 +21,10 @@ export function useLivestreamInfo(url?: string) {
       if (title !== "") {
         setRecordSubmitted(true);
         // Create the livestream record with title and custom url if available
-        await createStreamRecord(title, undefined, undefined, url);
+        await createStreamRecord({
+          title,
+          customUrl: url || null,
+        });
       }
     } catch (error) {
       console.error("Error creating livestream:", error);

--- a/js/components/src/hooks/useLivestreamInfo.ts
+++ b/js/components/src/hooks/useLivestreamInfo.ts
@@ -3,7 +3,7 @@ import { useLivestreamStore } from "../livestream-store";
 import { usePlayerStore } from "../player-store";
 import { useCreateStreamRecord } from "../streamplace-store";
 
-export function useLivestreamInfo() {
+export function useLivestreamInfo(url?: string) {
   const ingest = usePlayerStore((x) => x.ingestConnectionState);
   const profile = useLivestreamStore((x) => x.profile);
   const ingestStarting = usePlayerStore((x) => x.ingestStarting);
@@ -20,7 +20,8 @@ export function useLivestreamInfo() {
     try {
       if (title !== "") {
         setRecordSubmitted(true);
-        await createStreamRecord(title);
+        // Create the livestream record with title and custom url if available
+        await createStreamRecord(title, undefined, undefined, url);
       }
     } catch (error) {
       console.error("Error creating livestream:", error);

--- a/js/components/src/lib/browser.ts
+++ b/js/components/src/lib/browser.ts
@@ -1,0 +1,27 @@
+export function getBrowserName(userAgent: string) {
+  // The order matters here, and this may report false positives for unlisted browsers.
+
+  if (userAgent.includes("Firefox")) {
+    // "Mozilla/5.0 (X11; Linux i686; rv:104.0) Gecko/20100101 Firefox/104.0"
+    return "Mozilla Firefox";
+  } else if (userAgent.includes("SamsungBrowser")) {
+    // "Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G955F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36"
+    return "Samsung Internet";
+  } else if (userAgent.includes("Opera") || userAgent.includes("OPR")) {
+    // "Mozilla/5.0 (Macintosh; Intel Mac OS X 12_5_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36 OPR/90.0.4480.54"
+    return "Opera";
+  } else if (userAgent.includes("Edge")) {
+    // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299"
+    return "Microsoft Edge (Legacy)";
+  } else if (userAgent.includes("Edg")) {
+    // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36 Edg/104.0.1293.70"
+    return "Microsoft Edge (Chromium)";
+  } else if (userAgent.includes("Chrome")) {
+    // "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"
+    return "Google Chrome or Chromium";
+  } else if (userAgent.includes("Safari")) {
+    // "Mozilla/5.0 (iPhone; CPU iPhone OS 15_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6 Mobile/15E148 Safari/604.1"
+    return "Apple Safari";
+  }
+  return "unknown";
+}

--- a/js/components/src/livestream-store/stream-key.tsx
+++ b/js/components/src/livestream-store/stream-key.tsx
@@ -3,36 +3,9 @@ import { useEffect, useState } from "react";
 import { Platform } from "react-native";
 import { PlaceStreamKey } from "streamplace";
 import { privateKeyToAccount } from "viem/accounts";
+import { getBrowserName } from "../lib/browser";
 import { usePDSAgent } from "../streamplace-store/xrpc";
 import { useLivestreamStore } from "./livestream-store";
-
-function getBrowserName(userAgent: string) {
-  // The order matters here, and this may report false positives for unlisted browsers.
-
-  if (userAgent.includes("Firefox")) {
-    // "Mozilla/5.0 (X11; Linux i686; rv:104.0) Gecko/20100101 Firefox/104.0"
-    return "Mozilla Firefox";
-  } else if (userAgent.includes("SamsungBrowser")) {
-    // "Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G955F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36"
-    return "Samsung Internet";
-  } else if (userAgent.includes("Opera") || userAgent.includes("OPR")) {
-    // "Mozilla/5.0 (Macintosh; Intel Mac OS X 12_5_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36 OPR/90.0.4480.54"
-    return "Opera";
-  } else if (userAgent.includes("Edge")) {
-    // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299"
-    return "Microsoft Edge (Legacy)";
-  } else if (userAgent.includes("Edg")) {
-    // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36 Edg/104.0.1293.70"
-    return "Microsoft Edge (Chromium)";
-  } else if (userAgent.includes("Chrome")) {
-    // "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"
-    return "Google Chrome or Chromium";
-  } else if (userAgent.includes("Safari")) {
-    // "Mozilla/5.0 (iPhone; CPU iPhone OS 15_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6 Mobile/15E148 Safari/604.1"
-    return "Apple Safari";
-  }
-  return "unknown";
-}
 
 export const useStreamKey = (): {
   streamKey: {

--- a/js/components/src/streamplace-store/stream.tsx
+++ b/js/components/src/streamplace-store/stream.tsx
@@ -6,7 +6,11 @@ import { LivestreamViewHydrated } from "streamplace/src/useful-types";
 import { useUrl } from "./streamplace-store";
 import { usePDSAgent } from "./xrpc";
 
+import PackageJson from "../../package.json";
+
 import { useEffect, useRef } from "react";
+import { Platform } from "react-native";
+import { getBrowserName } from "../lib/browser";
 
 const useUploadThumbnail = () => {
   const abortRef = useRef<AbortController | null>(null);
@@ -216,10 +220,27 @@ export function useCreateStreamRecord() {
       }
     }
 
+    // get version? only works on andoid/ios
+    //
+    let platform: string = Platform.OS;
+    let platVersion: string = Platform.Version.toString();
+    if (
+      platform === "web" &&
+      typeof window !== "undefined" &&
+      window.navigator
+    ) {
+      platVersion = getBrowserName(window.navigator.userAgent);
+    }
+
     const record: PlaceStreamLivestream.Record = {
       title: title,
       url: url,
       createdAt: new Date().toISOString(),
+      // would match up with e.g. https://stream.place/<iame.li's did>
+      canonicalUrl: `${url}/${agent.did}`,
+      // user agent style string
+      // e.g. `@streamplace/components/0.1.0 (ios, 32.0)`
+      agent: `@streamplace/components/${PackageJson.version} (${Platform.OS}, ${Platform.Version})`,
       post: newPost,
       thumb: thumbnail,
     };

--- a/js/components/src/streamplace-store/stream.tsx
+++ b/js/components/src/streamplace-store/stream.tsx
@@ -127,12 +127,23 @@ export function useCreateStreamRecord() {
   let url = useUrl();
   const uploadThumbnail = useUploadThumbnail();
 
-  return async (
-    title: string,
-    customThumbnail?: Blob,
-    submitPost: boolean = true,
-    customUrl: string | null = null,
-  ) => {
+  return async ({
+    title,
+    customThumbnail,
+    submitPost,
+    customUrl,
+  }: {
+    title: string;
+    customThumbnail?: Blob;
+    submitPost?: boolean;
+    customUrl?: string | null;
+  }) => {
+    if (!submitPost) {
+      submitPost = true;
+    }
+    if (!customUrl) {
+      customUrl = null;
+    }
     if (!agent) {
       throw new Error("No PDS agent found");
     }

--- a/js/components/src/streamplace-store/stream.tsx
+++ b/js/components/src/streamplace-store/stream.tsx
@@ -189,10 +189,10 @@ export function useCreateStreamRecord() {
 
     let newPost: undefined | { uri: string; cid: string } = undefined;
 
-    if (submitPost) {
-      const did = agent.did;
-      const profile = await agent.getProfile({ actor: did });
+    const did = agent.did;
+    const profile = await agent.getProfile({ actor: did });
 
+    if (submitPost) {
       if (!profile) {
         throw new Error("No profile found for the user DID");
       }
@@ -236,11 +236,11 @@ export function useCreateStreamRecord() {
       title: title,
       url: url,
       createdAt: new Date().toISOString(),
-      // would match up with e.g. https://stream.place/<iame.li's did>
-      canonicalUrl: `${url}/${agent.did}`,
+      // would match up with e.g. https://stream.place/iame.li
+      canonicalUrl: `${url}/${profile.data.handle}`,
       // user agent style string
       // e.g. `@streamplace/components/0.1.0 (ios, 32.0)`
-      agent: `@streamplace/components/${PackageJson.version} (${Platform.OS}, ${Platform.Version})`,
+      agent: `@streamplace/components/${PackageJson.version} (${platform}, ${platVersion})`,
       post: newPost,
       thumb: thumbnail,
     };

--- a/js/components/src/streamplace-store/stream.tsx
+++ b/js/components/src/streamplace-store/stream.tsx
@@ -131,6 +131,7 @@ export function useCreateStreamRecord() {
     title: string,
     customThumbnail?: Blob,
     submitPost: boolean = true,
+    customUrl: string | null = null,
   ) => {
     if (!agent) {
       throw new Error("No PDS agent found");
@@ -140,9 +141,11 @@ export function useCreateStreamRecord() {
       throw new Error("No user DID found, assuming not logged in");
     }
 
-    let thumbnail: BlobRef | undefined = undefined;
+    // Use customUrl if provided, otherwise fall back to the store URL
+    const finalUrl = customUrl || url;
+    const u = new URL(finalUrl);
 
-    const u = new URL(url);
+    let thumbnail: BlobRef | undefined = undefined;
 
     if (customThumbnail) {
       try {
@@ -234,10 +237,10 @@ export function useCreateStreamRecord() {
 
     const record: PlaceStreamLivestream.Record = {
       title: title,
-      url: url,
+      url: finalUrl,
       createdAt: new Date().toISOString(),
       // would match up with e.g. https://stream.place/iame.li
-      canonicalUrl: `${url}/${profile.data.handle}`,
+      canonicalUrl: `${finalUrl}/${profile.data.handle}`,
       // user agent style string
       // e.g. `@streamplace/components/0.1.0 (ios, 32.0)`
       agent: `@streamplace/components/${PackageJson.version} (${platform}, ${platVersion})`,
@@ -254,7 +257,7 @@ export function useCreateStreamRecord() {
   };
 }
 
-export function useUpdateStreamRecord() {
+export function useUpdateStreamRecord(customUrl: string | null = null) {
   let agent = usePDSAgent();
   let url = useUrl();
   const uploadThumbnail = useUploadThumbnail();
@@ -276,6 +279,9 @@ export function useUpdateStreamRecord() {
       throw new Error("No latest record");
     }
 
+    // Use customUrl if provided, otherwise fall back to the store URL
+    const finalUrl = customUrl || url;
+
     let rkey = livestream.uri.split("/").pop();
     let oldRecordValue: PlaceStreamLivestream.Record = livestream.record;
 
@@ -296,7 +302,7 @@ export function useUpdateStreamRecord() {
 
     const record: PlaceStreamLivestream.Record = {
       title: title,
-      url: url,
+      url: finalUrl,
       createdAt: new Date().toISOString(),
       post: oldRecordValue.post,
       thumb: thumbnail,

--- a/js/docs/src/content/docs/lex-reference/place-stream-livestream.md
+++ b/js/docs/src/content/docs/lex-reference/place-stream-livestream.md
@@ -19,13 +19,15 @@ Record announcing a livestream is happening
 
 **Record Properties:**
 
-| Name        | Type                                                                                                                                   | Req'd | Description                                                                                                                      | Constraints                                   |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `title`     | `string`                                                                                                                               | ✅    | The title of the livestream, as it will be announced to followers.                                                               | Max Length: 1400<br/>Max Graphemes: 140       |
-| `url`       | `string`                                                                                                                               | ❌    | The URL where this stream can be found. This is primarily a hint for other Streamplace nodes to locate and replicate the stream. | Format: `uri`                                 |
-| `createdAt` | `string`                                                                                                                               | ✅    | Client-declared timestamp when this livestream started.                                                                          | Format: `datetime`                            |
-| `post`      | [`com.atproto.repo.strongRef`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/repo/strongref.json#undefined) | ❌    | The post that announced this livestream.                                                                                         |                                               |
-| `thumb`     | `blob`                                                                                                                                 | ❌    |                                                                                                                                  | Accept: `image/*`<br/>Max Size: 1000000 bytes |
+| Name           | Type                                                                                                                                   | Req'd | Description                                                                                                                              | Constraints                                   |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `title`        | `string`                                                                                                                               | ✅    | The title of the livestream, as it will be announced to followers.                                                                       | Max Length: 1400<br/>Max Graphemes: 140       |
+| `url`          | `string`                                                                                                                               | ❌    | The URL where this stream can be found. This is primarily a hint for other Streamplace nodes to locate and replicate the stream.         | Format: `uri`                                 |
+| `createdAt`    | `string`                                                                                                                               | ✅    | Client-declared timestamp when this livestream started.                                                                                  | Format: `datetime`                            |
+| `post`         | [`com.atproto.repo.strongRef`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/repo/strongref.json#undefined) | ❌    | The post that announced this livestream.                                                                                                 |                                               |
+| `agent`        | `string`                                                                                                                               | ❌    | The source of the livestream, if available, in a User Agent format: `<product> / <product-version> <comment>` e.g. Streamplace/0.7.5 iOS |                                               |
+| `canonicalUrl` | `string`                                                                                                                               | ❌    | The primary URL where this livestream can be viewed, if available.                                                                       | Format: `uri`                                 |
+| `thumb`        | `blob`                                                                                                                                 | ❌    |                                                                                                                                          | Accept: `image/*`<br/>Max Size: 1000000 bytes |
 
 ---
 
@@ -111,6 +113,15 @@ Record announcing a livestream is happening
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
             "description": "The post that announced this livestream."
+          },
+          "agent": {
+            "type": "string",
+            "description": "The source of the livestream, if available, in a User Agent format: `<product> / <product-version> <comment>` e.g. Streamplace/0.7.5 iOS"
+          },
+          "canonicalUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "The primary URL where this livestream can be viewed, if available."
           },
           "thumb": {
             "type": "blob",

--- a/lexicons/place/stream/livestream.json
+++ b/lexicons/place/stream/livestream.json
@@ -31,6 +31,15 @@
             "ref": "com.atproto.repo.strongRef",
             "description": "The post that announced this livestream."
           },
+          "agent": {
+            "type": "string",
+            "description": "The source of the livestream, if available, in a User Agent format: `<product> / <product-version> <comment>` e.g. Streamplace/0.7.5 iOS"
+          },
+          "canonicalUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "The primary URL where this livestream can be viewed, if available."
+          },
           "thumb": {
             "type": "blob",
             "accept": ["image/*"],

--- a/pkg/director/stream_session.go
+++ b/pkg/director/stream_session.go
@@ -300,11 +300,17 @@ func (ss *StreamSession) UpdateStatus(ctx context.Context, repoDID string) error
 		return fmt.Errorf("livestream is not a streamplace livestream")
 	}
 
+	canonicalUrl := fmt.Sprintf("https://%s/%s", ss.cli.PublicHost, repo.Handle)
+
+	if lsr.CanonicalUrl != nil {
+		canonicalUrl = *lsr.CanonicalUrl
+	}
+
 	actorStatusEmbed := bsky.ActorStatus_Embed{
 		EmbedExternal: &bsky.EmbedExternal{
 			External: &bsky.EmbedExternal_External{
 				Title:       lsr.Title,
-				Uri:         *lsr.CanonicalUrl,
+				Uri:         canonicalUrl,
 				Description: fmt.Sprintf("@%s is 🔴LIVE on %s", repo.Handle, ss.cli.PublicHost),
 				Thumb:       thumb,
 			},

--- a/pkg/director/stream_session.go
+++ b/pkg/director/stream_session.go
@@ -304,7 +304,7 @@ func (ss *StreamSession) UpdateStatus(ctx context.Context, repoDID string) error
 		EmbedExternal: &bsky.EmbedExternal{
 			External: &bsky.EmbedExternal_External{
 				Title:       lsr.Title,
-				Uri:         fmt.Sprintf("https://%s/%s", ss.cli.PublicHost, repo.Handle),
+				Uri:         *lsr.CanonicalUrl,
 				Description: fmt.Sprintf("@%s is 🔴LIVE on %s", repo.Handle, ss.cli.PublicHost),
 				Thumb:       thumb,
 			},

--- a/pkg/streamplace/cbor_gen.go
+++ b/pkg/streamplace/cbor_gen.go
@@ -250,7 +250,15 @@ func (t *Livestream) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
-	fieldCount := 6
+	fieldCount := 8
+
+	if t.Agent == nil {
+		fieldCount--
+	}
+
+	if t.CanonicalUrl == nil {
+		fieldCount--
+	}
 
 	if t.Post == nil {
 		fieldCount--
@@ -338,6 +346,38 @@ func (t *Livestream) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.Agent (string) (string)
+	if t.Agent != nil {
+
+		if len("agent") > 1000000 {
+			return xerrors.Errorf("Value in field \"agent\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("agent"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("agent")); err != nil {
+			return err
+		}
+
+		if t.Agent == nil {
+			if _, err := cw.Write(cbg.CborNull); err != nil {
+				return err
+			}
+		} else {
+			if len(*t.Agent) > 1000000 {
+				return xerrors.Errorf("Value in field t.Agent was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.Agent))); err != nil {
+				return err
+			}
+			if _, err := cw.WriteString(string(*t.Agent)); err != nil {
+				return err
+			}
+		}
+	}
+
 	// t.Thumb (util.LexBlob) (struct)
 	if t.Thumb != nil {
 
@@ -402,6 +442,38 @@ func (t *Livestream) MarshalCBOR(w io.Writer) error {
 	if _, err := cw.WriteString(string(t.CreatedAt)); err != nil {
 		return err
 	}
+
+	// t.CanonicalUrl (string) (string)
+	if t.CanonicalUrl != nil {
+
+		if len("canonicalUrl") > 1000000 {
+			return xerrors.Errorf("Value in field \"canonicalUrl\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("canonicalUrl"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("canonicalUrl")); err != nil {
+			return err
+		}
+
+		if t.CanonicalUrl == nil {
+			if _, err := cw.Write(cbg.CborNull); err != nil {
+				return err
+			}
+		} else {
+			if len(*t.CanonicalUrl) > 1000000 {
+				return xerrors.Errorf("Value in field t.CanonicalUrl was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.CanonicalUrl))); err != nil {
+				return err
+			}
+			if _, err := cw.WriteString(string(*t.CanonicalUrl)); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -430,7 +502,7 @@ func (t *Livestream) UnmarshalCBOR(r io.Reader) (err error) {
 
 	n := extra
 
-	nameBuf := make([]byte, 9)
+	nameBuf := make([]byte, 12)
 	for i := uint64(0); i < n; i++ {
 		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 1000000)
 		if err != nil {
@@ -498,6 +570,27 @@ func (t *Livestream) UnmarshalCBOR(r io.Reader) (err error) {
 
 				t.LexiconTypeID = string(sval)
 			}
+			// t.Agent (string) (string)
+		case "agent":
+
+			{
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+
+					sval, err := cbg.ReadStringWithMax(cr, 1000000)
+					if err != nil {
+						return err
+					}
+
+					t.Agent = (*string)(&sval)
+				}
+			}
 			// t.Thumb (util.LexBlob) (struct)
 		case "thumb":
 
@@ -539,6 +632,27 @@ func (t *Livestream) UnmarshalCBOR(r io.Reader) (err error) {
 				}
 
 				t.CreatedAt = string(sval)
+			}
+			// t.CanonicalUrl (string) (string)
+		case "canonicalUrl":
+
+			{
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+
+					sval, err := cbg.ReadStringWithMax(cr, 1000000)
+					if err != nil {
+						return err
+					}
+
+					t.CanonicalUrl = (*string)(&sval)
+				}
 			}
 
 		default:

--- a/pkg/streamplace/streamlivestream.go
+++ b/pkg/streamplace/streamlivestream.go
@@ -19,6 +19,10 @@ func init() {
 // RECORDTYPE: Livestream
 type Livestream struct {
 	LexiconTypeID string `json:"$type,const=place.stream.livestream" cborgen:"$type,const=place.stream.livestream"`
+	// agent: The source of the livestream, if available, in a User Agent format: `<product> / <product-version> <comment>` e.g. Streamplace/0.7.5 iOS
+	Agent *string `json:"agent,omitempty" cborgen:"agent,omitempty"`
+	// canonicalUrl: The primary URL where this livestream can be viewed, if available.
+	CanonicalUrl *string `json:"canonicalUrl,omitempty" cborgen:"canonicalUrl,omitempty"`
 	// createdAt: Client-declared timestamp when this livestream started.
 	CreatedAt string `json:"createdAt" cborgen:"createdAt"`
 	// post: The post that announced this livestream.


### PR DESCRIPTION
This would help certain individuals if one wanted to access one's livestream via e.g. bluesky statuses