### PR TITLE
chat: scroll up to dismiss keyboard

### DIFF
--- a/js/app/components/mobile/chat.tsx
+++ b/js/app/components/mobile/chat.tsx
@@ -10,7 +10,7 @@ import {
 } from "@streamplace/components";
 import { useKeyboard } from "hooks/useKeyboard";
 import { useEffect } from "react";
-import { Keyboard, Pressable, TouchableWithoutFeedback } from "react-native";
+import { Pressable } from "react-native";
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
@@ -111,11 +111,9 @@ function ChatPanel() {
         { width: "100%", maxWidth: "100%" },
       ]}
     >
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-        <View style={[flex.values[1]]}>
-          <Chat canModerate={canModerate} />
-        </View>
-      </TouchableWithoutFeedback>
+      <View style={[flex.values[1]]}>
+        <Chat canModerate={canModerate} />
+      </View>
       <View style={[layout.flex.column, gap.all[2], px[4]]}>
         {handle ? (
           <ChatBox

--- a/js/components/src/components/chat/chat.tsx
+++ b/js/components/src/components/chat/chat.tsx
@@ -1,6 +1,6 @@
 import { Ellipsis, Reply } from "lucide-react-native";
 import { ComponentProps, memo, useEffect, useRef, useState } from "react";
-import { Platform, Pressable } from "react-native";
+import { Keyboard, Platform, Pressable } from "react-native";
 import { FlatList } from "react-native-gesture-handler";
 import Swipeable, {
   SwipeableMethods,
@@ -258,6 +258,22 @@ export function Chat({
   canModerate?: boolean;
 }) {
   const chat = useChat();
+  const [isScrolledUp, setIsScrolledUp] = useState(false);
+
+  const handleScroll = (event: any) => {
+    const { contentOffset } = event.nativeEvent;
+
+    const scrolledUp = contentOffset.y > 20; // threshold
+
+    if (scrolledUp !== isScrolledUp) {
+      setIsScrolledUp(scrolledUp);
+
+      // Dismiss keyboard when scrolled up
+      if (scrolledUp && Platform.OS !== "web") {
+        Keyboard.dismiss();
+      }
+    }
+  };
 
   if (!chat)
     return (
@@ -288,6 +304,8 @@ export function Chat({
         maxToRenderPerBatch={10}
         initialNumToRender={10}
         updateCellsBatchingPeriod={50}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
       />
       <ModView />
     </View>


### PR DESCRIPTION
tapping chat to dismiss the keyboard is kind of clunky, this is closer to how other apps (discord) do it. scrolling up (swiping down) will close the keyboard.