### PR TITLE
ci: move to aws docker registry

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 include: ".ci/dockerfile-hash.yaml"
 
 variables:
-  DOCKER_REPO: "us-central1-docker.pkg.dev/aquareum-tv/streamplace/build"
+  DOCKER_REPO: "975050346355.dkr.ecr.us-east-2.amazonaws.com/streamplace"
 
 build-bunny:
   stage: build


### PR DESCRIPTION
currently we're doing builds on AWS and our images on GCP which costs us a lot in GCP data egress, this should fix that