### PR TITLE
add atproto proxy header to app.bsky.actor.getProfile

### DIFF
--- a/pkg/spxrpc/app_bsky_actor.go
+++ b/pkg/spxrpc/app_bsky_actor.go
@@ -16,6 +16,11 @@ func (s *Server) handleAppBskyActorGetProfile(ctx context.Context, actor string)
 		return nil, echo.NewHTTPError(http.StatusUnauthorized, "oauth session not found")
 	}
 
+	// in case the end user doesn't have a default fallback client in the pds
+	client.SetHeaders(map[string]string{
+		"atproto-proxy": "did:web:api.bsky.app#bsky_appview",
+	})
+
 	// brief check to make sure we can actually do stuff
 	var out appbskytypes.ActorDefs_ProfileViewDetailed
 	err := client.Do(ctx, xrpc.Query, "application/json", "app.bsky.actor.getProfile", map[string]any{"actor": actor}, nil, &out)

--- a/pkg/spxrpc/app_bsky_actor.go
+++ b/pkg/spxrpc/app_bsky_actor.go
@@ -18,7 +18,7 @@ func (s *Server) handleAppBskyActorGetProfile(ctx context.Context, actor string)
 
 	// in case the end user doesn't have a default fallback client in the pds
 	client.SetHeaders(map[string]string{
-		"atproto-proxy": "did:web:api.bsky.app#bsky_appview",
+		"Atproto-Proxy": "did:web:api.bsky.app#bsky_appview",
 	})
 
 	// brief check to make sure we can actually do stuff


### PR DESCRIPTION
Without the atproto-proxy header, some pdses may not be able to auto-proxy bluesky appview requests, which means users get a 403 and can't log in. The app.bsky.actor.getProfile routes to the bsky appview and currently lacks this header, so we add it to enable proper proxying.