### PR TITLE
player: add manual rotation

### DIFF
--- a/js/app/app.config.ts
+++ b/js/app/app.config.ts
@@ -197,6 +197,7 @@ export default function () {
         withAndroidProfileable,
         "expo-video",
         "expo-web-browser",
+        "expo-screen-orientation",
         streamplaceReactNativeWebRTC,
         [
           "expo-video",

--- a/js/app/components/mobile/player.tsx
+++ b/js/app/components/mobile/player.tsx
@@ -7,6 +7,7 @@ import {
   PlayerProps,
   PlayerProvider,
   PlayerUI,
+  RotationProvider,
   Text,
   usePlayerDimensions,
   usePlayerStore,
@@ -19,7 +20,7 @@ import { useLiveUser } from "hooks/useLiveUser";
 import { useSidebarControl } from "hooks/useSidebarControl";
 import { ArrowLeft, ArrowRight } from "lucide-react-native";
 import { ComponentRef, useEffect, useRef, useState } from "react";
-import { Animated, ScrollView, StatusBar } from "react-native";
+import { Animated, Platform, ScrollView, StatusBar } from "react-native";
 import { useAppSelector } from "store/hooks";
 import { BottomMetadata } from "./bottom-metadata";
 import { DesktopChatPanel } from "./chat";
@@ -121,36 +122,38 @@ export function Player(
   }
 
   return (
-    <LivestreamProvider src={props.src ?? ""}>
-      <StatusBar hidden={true} />
-      <PlayerProvider defaultId={props.playerId || undefined}>
-        <View
-          style={{
-            flexDirection: chatVisible ? "row" : "column",
-            flex: 1,
-            width: "100%",
-            height: "100%",
-            paddingLeft: safeAreaInsets.left,
-            paddingRight: safeAreaInsets.right,
-          }}
-        >
-          <PlayerInner
-            {...props}
-            showChat={showChat}
-            setShowChat={setShowChat}
-          />
-          {shouldShowChatSidePanel ? (
-            <DesktopChatPanel
-              chatVisible={chatVisible}
-              chatPanelWidth={chatPanelWidth}
-              safeAreaInsets={safeAreaInsets}
+    <RotationProvider enabled={Platform.OS !== "web"}>
+      <LivestreamProvider src={props.src ?? ""}>
+        <StatusBar hidden={true} />
+        <PlayerProvider defaultId={props.playerId || undefined}>
+          <View
+            style={{
+              flexDirection: chatVisible ? "row" : "column",
+              flex: 1,
+              width: "100%",
+              height: "100%",
+              paddingLeft: safeAreaInsets.left,
+              paddingRight: safeAreaInsets.right,
+            }}
+          >
+            <PlayerInner
+              {...props}
+              showChat={showChat}
+              setShowChat={setShowChat}
             />
-          ) : (
-            <MobileUi />
-          )}
-        </View>
-      </PlayerProvider>
-    </LivestreamProvider>
+            {shouldShowChatSidePanel ? (
+              <DesktopChatPanel
+                chatVisible={chatVisible}
+                chatPanelWidth={chatPanelWidth}
+                safeAreaInsets={safeAreaInsets}
+              />
+            ) : (
+              <MobileUi />
+            )}
+          </View>
+        </PlayerProvider>
+      </LivestreamProvider>
+    </RotationProvider>
   );
 }
 

--- a/js/app/components/mobile/player.tsx
+++ b/js/app/components/mobile/player.tsx
@@ -29,6 +29,12 @@ import { OfflineCounter } from "./offline-counter";
 import { MobileUi } from "./ui";
 import { useResponsiveLayout } from "./useResponsiveLayout";
 
+import {
+  setSidebarHidden,
+  setSidebarUnhidden,
+} from "features/base/sidebarSlice";
+import { useDispatch } from "react-redux";
+
 export function Player(
   props: Partial<PlayerProps> & {
     setFullscreen?: (fullscreen: boolean) => void;
@@ -179,6 +185,9 @@ export function PlayerInner(
     showChatSidePanelOnLandscape: props.showChat,
   });
 
+  // for hiding sidebar
+  const dispatch = useDispatch();
+
   // content info
   const { width, height } = usePlayerDimensions();
 
@@ -186,6 +195,19 @@ export function PlayerInner(
 
   // Calculate aspect ratio and determine if we're in desktop mode
   const aspectRatio = width > 0 && height > 0 ? width / height : 16 / 9;
+
+  // on mobile we want to hide the sidebar when going fullscreen
+  useEffect(() => {
+    if (Platform.OS !== "web" && width > height) {
+      console.log("hiding sb");
+      dispatch(setSidebarHidden());
+    } else {
+      dispatch(setSidebarUnhidden());
+    }
+    return () => {
+      dispatch(setSidebarUnhidden());
+    };
+  }, [width, height]);
   // should cover full width on mobile?
   const isDesktopMode = shouldShowChatSidePanel || screenWidth > 1200;
 

--- a/js/app/components/mobile/ui.tsx
+++ b/js/app/components/mobile/ui.tsx
@@ -10,6 +10,7 @@ import {
   useMuted,
   usePlayerDimensions,
   usePlayerStore,
+  useRotation,
   useSegmentDimensions,
   useSetMuted,
   useSetVolume,
@@ -23,6 +24,7 @@ import {
   ChevronRight,
   Fullscreen,
   Minimize,
+  RotateCw,
   SwitchCamera,
   Volume2,
   VolumeX,
@@ -375,6 +377,9 @@ function RightControlsPanel({
   const setMuted = useSetMuted();
   const fullscreen = usePlayerStore((x) => x.fullscreen);
   const setFullscreen = usePlayerStore((x) => x.setFullscreen);
+  const { toggleRotation, canRotate, currentOrientation } = useRotation();
+
+  console.log("rotation", canRotate, currentOrientation);
 
   const [showVolumeSlider, setShowVolumeSlider] = useState(false);
 
@@ -422,23 +427,24 @@ function RightControlsPanel({
         {ingest === null ? (
           Platform.OS === "web" && <PlayerUI.ContextMenu />
         ) : (
-          <Pressable onPress={doSetIngestCamera}>
-            <SwitchCamera color={theme.colors.foreground} size={20} />
-          </Pressable>
+          <>
+            <Pressable onPress={doSetIngestCamera}>
+              <SwitchCamera color={theme.colors.foreground} size={20} />
+            </Pressable>
+          </>
         )}
         {Platform.OS === "web" ? (
           <>
             <Pressable
               onPress={() => {
-                console.log("UI.tsx Button pressed at:", Date.now());
                 setFullscreen(!fullscreen);
               }}
               style={[zero.p[2], r[1]]}
             >
               {fullscreen ? (
-                <Minimize color={theme.colors.text} />
+                <Minimize color={theme.colors.text} size={20} />
               ) : (
-                <Fullscreen color={theme.colors.text} />
+                <Fullscreen color={theme.colors.text} size={20} />
               )}
             </Pressable>
             <Pressable onPress={handleVolumePress}>
@@ -450,7 +456,18 @@ function RightControlsPanel({
             </Pressable>
           </>
         ) : (
-          <PlayerUI.ContextMenu />
+          <>
+            {canRotate && (
+              <Pressable
+                onPress={() => {
+                  toggleRotation();
+                }}
+              >
+                <RotateCw color={theme.colors.foreground} size={20} />
+              </Pressable>
+            )}
+            <PlayerUI.ContextMenu />
+          </>
         )}
         {shouldShowChatSidePanel && setShowChat && (
           <Pressable

--- a/js/app/components/mobile/ui.tsx
+++ b/js/app/components/mobile/ui.tsx
@@ -379,7 +379,6 @@ function RightControlsPanel({
   const setFullscreen = usePlayerStore((x) => x.setFullscreen);
   const { toggleRotation, canRotate, currentOrientation } = useRotation();
 
-  console.log("rotation", canRotate, currentOrientation);
 
   const [showVolumeSlider, setShowVolumeSlider] = useState(false);
 

--- a/js/app/components/mobile/ui.tsx
+++ b/js/app/components/mobile/ui.tsx
@@ -23,8 +23,8 @@ import {
   ChevronLeft,
   ChevronRight,
   Fullscreen,
+  Maximize,
   Minimize,
-  RotateCw,
   SwitchCamera,
   Volume2,
   VolumeX,
@@ -419,7 +419,7 @@ function RightControlsPanel({
             : zero.layout.flex.row,
           zero.layout.flex.center,
           zero.gap.all[4],
-          zero.py[2],
+          zero.py[3],
           showChat === undefined ? zero.px[2] : zero.px[3],
           zero.layout.position.relative,
         ]}
@@ -456,18 +456,30 @@ function RightControlsPanel({
             </Pressable>
           </>
         ) : (
-          <>
+          <View
+            style={[
+              showChat === undefined
+                ? { flexDirection: "column-reverse" }
+                : { flexDirection: "row" },
+              zero.layout.flex.center,
+              zero.gap.all[4],
+            ]}
+          >
             {canRotate && (
               <Pressable
                 onPress={() => {
                   toggleRotation();
                 }}
               >
-                <RotateCw color={theme.colors.foreground} size={20} />
+                {currentOrientation === 1 ? (
+                  <Maximize color={theme.colors.foreground} size={20} />
+                ) : (
+                  <Minimize color={theme.colors.foreground} size={20} />
+                )}
               </Pressable>
             )}
             <PlayerUI.ContextMenu />
-          </>
+          </View>
         )}
         {shouldShowChatSidePanel && setShowChat && (
           <Pressable

--- a/js/app/components/mobile/ui.tsx
+++ b/js/app/components/mobile/ui.tsx
@@ -379,7 +379,6 @@ function RightControlsPanel({
   const setFullscreen = usePlayerStore((x) => x.setFullscreen);
   const { toggleRotation, canRotate, currentOrientation } = useRotation();
 
-
   const [showVolumeSlider, setShowVolumeSlider] = useState(false);
 
   const handleVolumePress = () => {

--- a/js/app/components/mobile/useResponsiveLayout.ts
+++ b/js/app/components/mobile/useResponsiveLayout.ts
@@ -37,7 +37,13 @@ export function useResponsiveLayout({
       return sidebarWidth.value;
     }
     return sidebarWidth;
-  }, [sidebarWidth]);
+  }, [
+    sidebarWidth,
+    // weirddd
+    (sidebarWidth as any)?.value,
+    sidebarHidden,
+    showChatSidePanelOnLandscape,
+  ]);
 
   const isLandscape = screenWidth > screenHeight;
   const shouldShowChatSidePanel =

--- a/js/components/package.json
+++ b/js/components/package.json
@@ -30,6 +30,8 @@
     "@rn-primitives/slider": "^1.2.0",
     "class-variance-authority": "^0.6.1",
     "expo-keep-awake": "^14.0.0",
+    "expo-screen-orientation": "^9.0.7",
+    "expo-sensors": "^15.0.7",
     "expo-sqlite": "~15.2.12",
     "expo-video": "^2.0.0",
     "hls.js": "^1.5.17",

--- a/js/components/src/components/mobile-player/rotation-async.native.tsx
+++ b/js/components/src/components/mobile-player/rotation-async.native.tsx
@@ -1,0 +1,15 @@
+let ScreenOrientation: typeof import("expo-screen-orientation") | null = null;
+
+try {
+  ScreenOrientation = require("expo-screen-orientation");
+} catch {
+  // expo-screen-orientation not available
+  if (__DEV__) {
+    console.warn(
+      "expo-screen-orientation not installed, rotation features disabled",
+    );
+  }
+}
+
+export const isRotationAvailable = ScreenOrientation != null;
+export { ScreenOrientation };

--- a/js/components/src/components/mobile-player/rotation-lock.tsx
+++ b/js/components/src/components/mobile-player/rotation-lock.tsx
@@ -1,5 +1,4 @@
-import * as ScreenOrientation from "expo-screen-orientation";
-import { Orientation, OrientationLock } from "expo-screen-orientation";
+import type { Orientation } from "expo-screen-orientation";
 import React, {
   createContext,
   useContext,
@@ -8,6 +7,10 @@ import React, {
   useRef,
   useState,
 } from "react";
+import {
+  isRotationAvailable,
+  ScreenOrientation,
+} from "./rotation-async.native";
 
 export interface RotationContextValue {
   currentOrientation: Orientation;
@@ -31,20 +34,44 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
   enabled = true,
 }) => {
   const [isLocked, setIsLocked] = useState(false);
-  const [canRotate, setCanRotate] = useState(true);
-  const currentOrientation = useRef<Orientation>(Orientation.PORTRAIT_UP);
+  const [canRotate, setCanRotate] = useState(isRotationAvailable);
+  const currentOrientation = useRef<Orientation>(
+    ScreenOrientation?.Orientation.PORTRAIT_UP ?? 1,
+  );
+
+  // If module not available, provide disabled context
+  if (!isRotationAvailable || !ScreenOrientation) {
+    const disabledContextValue: RotationContextValue = {
+      currentOrientation: 1, // Orientation.PORTRAIT_UP
+      isLocked: false,
+      isActive: false,
+      rotateToLandscape: async () => {},
+      rotateToPortrait: async () => {},
+      toggleRotation: async () => {},
+      canRotate: false,
+    };
+
+    return (
+      <RotationContext.Provider value={disabledContextValue}>
+        {children}
+      </RotationContext.Provider>
+    );
+  }
 
   // Manual rotation functions
   const rotateToLandscape = async () => {
-    if (!enabled || !canRotate) return;
+    if (!enabled || !canRotate || !ScreenOrientation) return;
 
     try {
       await ScreenOrientation.unlockAsync();
-      await ScreenOrientation.lockAsync(OrientationLock.LANDSCAPE_RIGHT);
+      await ScreenOrientation.lockAsync(
+        ScreenOrientation.OrientationLock.LANDSCAPE_RIGHT,
+      );
       setIsLocked(true);
 
       // set current orientation to landscape left for consistency
-      currentOrientation.current = Orientation.LANDSCAPE_RIGHT;
+      currentOrientation.current =
+        ScreenOrientation.Orientation.LANDSCAPE_RIGHT;
 
       if (__DEV__) {
         console.log("📲 Manual landscape");
@@ -55,13 +82,15 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
   };
 
   const rotateToPortrait = async () => {
-    if (!enabled || !canRotate) return;
+    if (!enabled || !canRotate || !ScreenOrientation) return;
 
     try {
-      await ScreenOrientation.lockAsync(OrientationLock.PORTRAIT_UP);
+      await ScreenOrientation.lockAsync(
+        ScreenOrientation.OrientationLock.PORTRAIT_UP,
+      );
       setIsLocked(true);
 
-      currentOrientation.current = Orientation.PORTRAIT_UP;
+      currentOrientation.current = ScreenOrientation.Orientation.PORTRAIT_UP;
 
       if (__DEV__) {
         console.log("📲 Manual portrait");
@@ -72,9 +101,13 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
   };
 
   const toggleRotation = async () => {
+    if (!ScreenOrientation) return;
+
     const isLandscape =
-      currentOrientation.current === Orientation.LANDSCAPE_LEFT ||
-      currentOrientation.current === Orientation.LANDSCAPE_RIGHT;
+      currentOrientation.current ===
+        ScreenOrientation.Orientation.LANDSCAPE_LEFT ||
+      currentOrientation.current ===
+        ScreenOrientation.Orientation.LANDSCAPE_RIGHT;
 
     if (__DEV__) {
       console.log(
@@ -94,6 +127,7 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
     if (!enabled) return;
 
     const getCurrentOrientation = async () => {
+      if (!ScreenOrientation) return;
       try {
         const orient = await ScreenOrientation.getOrientationAsync();
         currentOrientation.current = orient;
@@ -107,6 +141,8 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
     };
 
     getCurrentOrientation();
+
+    if (!ScreenOrientation) return;
 
     const subscription = ScreenOrientation.addOrientationChangeListener(
       (event) => {
@@ -128,10 +164,12 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
 
     return () => {
       subscription?.remove();
-      ScreenOrientation.removeOrientationChangeListeners();
-      ScreenOrientation.unlockAsync().catch(() => {});
+      if (ScreenOrientation) {
+        ScreenOrientation.removeOrientationChangeListeners();
+        ScreenOrientation.unlockAsync().catch(() => {});
+      }
     };
-  }, [enabled]);
+  }, [enabled, isLocked]);
 
   const contextValue = useMemo(
     () => ({

--- a/js/components/src/components/mobile-player/rotation-lock.tsx
+++ b/js/components/src/components/mobile-player/rotation-lock.tsx
@@ -4,7 +4,6 @@ import React, {
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import {
@@ -35,7 +34,7 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
 }) => {
   const [isLocked, setIsLocked] = useState(false);
   const [canRotate, setCanRotate] = useState(isRotationAvailable);
-  const currentOrientation = useRef<Orientation>(
+  const [currentOrientation, setCurrentOrientation] = useState<Orientation>(
     ScreenOrientation?.Orientation.PORTRAIT_UP ?? 1,
   );
 
@@ -69,9 +68,8 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
       );
       setIsLocked(true);
 
-      // set current orientation to landscape left for consistency
-      currentOrientation.current =
-        ScreenOrientation.Orientation.LANDSCAPE_RIGHT;
+      // set current orientation to landscape right
+      setCurrentOrientation(ScreenOrientation.Orientation.LANDSCAPE_RIGHT);
 
       if (__DEV__) {
         console.log("📲 Manual landscape");
@@ -85,12 +83,13 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
     if (!enabled || !canRotate || !ScreenOrientation) return;
 
     try {
+      await ScreenOrientation.unlockAsync();
       await ScreenOrientation.lockAsync(
         ScreenOrientation.OrientationLock.PORTRAIT_UP,
       );
       setIsLocked(true);
 
-      currentOrientation.current = ScreenOrientation.Orientation.PORTRAIT_UP;
+      setCurrentOrientation(ScreenOrientation.Orientation.PORTRAIT_UP);
 
       if (__DEV__) {
         console.log("📲 Manual portrait");
@@ -104,14 +103,12 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
     if (!ScreenOrientation) return;
 
     const isLandscape =
-      currentOrientation.current ===
-        ScreenOrientation.Orientation.LANDSCAPE_LEFT ||
-      currentOrientation.current ===
-        ScreenOrientation.Orientation.LANDSCAPE_RIGHT;
+      currentOrientation === ScreenOrientation.Orientation.LANDSCAPE_LEFT ||
+      currentOrientation === ScreenOrientation.Orientation.LANDSCAPE_RIGHT;
 
     if (__DEV__) {
       console.log(
-        `🔄 Toggle: current=${currentOrientation.current}, isLandscape=${isLandscape}`,
+        `🔄 Toggle: current=${currentOrientation}, isLandscape=${isLandscape}`,
       );
     }
 
@@ -130,7 +127,7 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
       if (!ScreenOrientation) return;
       try {
         const orient = await ScreenOrientation.getOrientationAsync();
-        currentOrientation.current = orient;
+        setCurrentOrientation(orient);
 
         if (__DEV__) {
           console.log(`📲 Orientation on load: ${orient}`);
@@ -147,17 +144,12 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
     const subscription = ScreenOrientation.addOrientationChangeListener(
       (event) => {
         const newOrientation = event.orientationInfo.orientation;
-        currentOrientation.current = newOrientation;
+        setCurrentOrientation(newOrientation);
 
         if (__DEV__) {
           console.log(
             `🔄 Orientation: ${newOrientation} (locked: ${isLocked})`,
           );
-        }
-
-        // Only allow natural rotation when unlocked
-        if (!isLocked) {
-          // Natural rotation is happening, let it continue
         }
       },
     );
@@ -169,11 +161,11 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
         ScreenOrientation.unlockAsync().catch(() => {});
       }
     };
-  }, [enabled, isLocked]);
+  }, [enabled]);
 
   const contextValue = useMemo(
     () => ({
-      currentOrientation: currentOrientation.current,
+      currentOrientation,
       isLocked,
       isActive: enabled,
       rotateToLandscape,
@@ -181,7 +173,15 @@ export const RotationProvider: React.FC<RotationProviderProps> = ({
       toggleRotation,
       canRotate,
     }),
-    [isLocked, enabled, canRotate],
+    [
+      currentOrientation,
+      isLocked,
+      enabled,
+      canRotate,
+      rotateToLandscape,
+      rotateToPortrait,
+      toggleRotation,
+    ],
   );
 
   return (

--- a/js/components/src/components/mobile-player/rotation-lock.tsx
+++ b/js/components/src/components/mobile-player/rotation-lock.tsx
@@ -1,0 +1,162 @@
+import * as ScreenOrientation from "expo-screen-orientation";
+import { Orientation, OrientationLock } from "expo-screen-orientation";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export interface RotationContextValue {
+  currentOrientation: Orientation;
+  isLocked: boolean;
+  isActive: boolean;
+  rotateToLandscape: () => Promise<void>;
+  rotateToPortrait: () => Promise<void>;
+  toggleRotation: () => Promise<void>;
+  canRotate: boolean;
+}
+
+export interface RotationProviderProps {
+  children: React.ReactNode;
+  enabled?: boolean;
+}
+
+const RotationContext = createContext<RotationContextValue | null>(null);
+
+export const RotationProvider: React.FC<RotationProviderProps> = ({
+  children,
+  enabled = true,
+}) => {
+  const [isLocked, setIsLocked] = useState(false);
+  const [canRotate, setCanRotate] = useState(true);
+  const currentOrientation = useRef<Orientation>(Orientation.PORTRAIT_UP);
+
+  // Manual rotation functions
+  const rotateToLandscape = async () => {
+    if (!enabled || !canRotate) return;
+
+    try {
+      await ScreenOrientation.unlockAsync();
+      await ScreenOrientation.lockAsync(OrientationLock.LANDSCAPE_RIGHT);
+      setIsLocked(true);
+
+      // set current orientation to landscape left for consistency
+      currentOrientation.current = Orientation.LANDSCAPE_RIGHT;
+
+      if (__DEV__) {
+        console.log("📲 Manual landscape");
+      }
+    } catch (error) {
+      console.warn("Failed to rotate to landscape:", error);
+    }
+  };
+
+  const rotateToPortrait = async () => {
+    if (!enabled || !canRotate) return;
+
+    try {
+      await ScreenOrientation.lockAsync(OrientationLock.PORTRAIT_UP);
+      setIsLocked(true);
+
+      currentOrientation.current = Orientation.PORTRAIT_UP;
+
+      if (__DEV__) {
+        console.log("📲 Manual portrait");
+      }
+    } catch (error) {
+      console.warn("Failed to rotate to portrait:", error);
+    }
+  };
+
+  const toggleRotation = async () => {
+    const isLandscape =
+      currentOrientation.current === Orientation.LANDSCAPE_LEFT ||
+      currentOrientation.current === Orientation.LANDSCAPE_RIGHT;
+
+    if (__DEV__) {
+      console.log(
+        `🔄 Toggle: current=${currentOrientation.current}, isLandscape=${isLandscape}`,
+      );
+    }
+
+    if (isLandscape) {
+      await rotateToPortrait();
+    } else {
+      await rotateToLandscape();
+    }
+  };
+
+  // Track orientation changes
+  useEffect(() => {
+    if (!enabled) return;
+
+    const getCurrentOrientation = async () => {
+      try {
+        const orient = await ScreenOrientation.getOrientationAsync();
+        currentOrientation.current = orient;
+
+        if (__DEV__) {
+          console.log(`📲 Orientation on load: ${orient}`);
+        }
+      } catch (error) {
+        console.warn("Failed to get orientation:", error);
+      }
+    };
+
+    getCurrentOrientation();
+
+    const subscription = ScreenOrientation.addOrientationChangeListener(
+      (event) => {
+        const newOrientation = event.orientationInfo.orientation;
+        currentOrientation.current = newOrientation;
+
+        if (__DEV__) {
+          console.log(
+            `🔄 Orientation: ${newOrientation} (locked: ${isLocked})`,
+          );
+        }
+
+        // Only allow natural rotation when unlocked
+        if (!isLocked) {
+          // Natural rotation is happening, let it continue
+        }
+      },
+    );
+
+    return () => {
+      subscription?.remove();
+      ScreenOrientation.removeOrientationChangeListeners();
+      ScreenOrientation.unlockAsync().catch(() => {});
+    };
+  }, [enabled]);
+
+  const contextValue = useMemo(
+    () => ({
+      currentOrientation: currentOrientation.current,
+      isLocked,
+      isActive: enabled,
+      rotateToLandscape,
+      rotateToPortrait,
+      toggleRotation,
+      canRotate,
+    }),
+    [isLocked, enabled, canRotate],
+  );
+
+  return (
+    <RotationContext.Provider value={contextValue}>
+      {children}
+    </RotationContext.Provider>
+  );
+};
+
+export const useRotation = (): RotationContextValue => {
+  const context = useContext(RotationContext);
+  if (!context) {
+    throw new Error("useRotation must be used within a RotationProvider");
+  }
+  return context;
+};

--- a/js/components/src/index.tsx
+++ b/js/components/src/index.tsx
@@ -33,6 +33,16 @@ export * from "./components/chat/system-message";
 export { default as VideoRetry } from "./components/mobile-player/video-retry";
 export * from "./lib/system-messages";
 
+// Rotation lock system exports
+export {
+  RotationProvider,
+  useRotation,
+} from "./components/mobile-player/rotation-lock";
+export type {
+  RotationContextValue,
+  RotationProviderProps,
+} from "./components/mobile-player/rotation-lock";
+
 export * from "./components/share/sharesheet";
 
 export * from "./components/keep-awake";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,12 @@ importers:
       expo-keep-awake:
         specifier: ^14.0.0
         version: 14.1.4(expo@53.0.11(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-native-webview@13.15.0(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
+      expo-screen-orientation:
+        specifier: ^9.0.7
+        version: 9.0.7(expo@53.0.11(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-native-webview@13.15.0(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))
+      expo-sensors:
+        specifier: ^15.0.7
+        version: 15.0.7(expo@53.0.11(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-native-webview@13.15.0(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))
       expo-sqlite:
         specifier: ~15.2.12
         version: 15.2.12(expo@53.0.11(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-native-webview@13.15.0(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)
@@ -6845,6 +6851,12 @@ packages:
 
   expo-screen-orientation@9.0.7:
     resolution: {integrity: sha512-UH/XlB9eMw+I2cyHSkXhAHRAPk83WyA3k5bst7GLu14wRuWiTch9fb6I7qEJK5CN6+XelcWxlBJymys6Fr/FKA==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
+  expo-sensors@15.0.7:
+    resolution: {integrity: sha512-TGUxRx/Ss7KGgfWo453YF64ENucw6oYryPiu/8I3ZZuf114xQPRxAbsZohPLaVUUGuaUyWbDsb0eRsmuKUzBnQ==}
     peerDependencies:
       expo: '*'
       react-native: '*'
@@ -21229,6 +21241,17 @@ snapshots:
     dependencies:
       expo: 53.0.11(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.26.0)(@types/react@18.3.12)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-native-webview@13.15.0(react-native@0.79.3(@babel/core@7.26.0)(@types/react@18.3.12)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.26.0)(@types/react@18.3.12)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10)
       react-native: 0.79.3(@babel/core@7.26.0)(@types/react@18.3.12)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)
+
+  expo-screen-orientation@9.0.7(expo@53.0.11(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-native-webview@13.15.0(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      expo: 53.0.11(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-native-webview@13.15.0(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10)
+      react-native: 0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)
+
+  expo-sensors@15.0.7(expo@53.0.11(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-native-webview@13.15.0(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      expo: 53.0.11(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-native-webview@13.15.0(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10)
+      invariant: 2.2.4
+      react-native: 0.79.3(@babel/core@7.26.0)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)
 
   expo-splash-screen@0.30.9(expo@53.0.11(@babel/core@7.26.0)(@expo/metro-runtime@5.0.4(react-native@0.79.3(@babel/core@7.26.0)(@types/react@18.3.12)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-native-webview@13.15.0(react-native@0.79.3(@babel/core@7.26.0)(@types/react@18.3.12)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0))(react-native@0.79.3(@babel/core@7.26.0)(@types/react@18.3.12)(bufferutil@4.0.8)(react@19.0.0)(utf-8-validate@5.0.10))(react@19.0.0)(utf-8-validate@5.0.10)):
     dependencies:


### PR DESCRIPTION
Implements rotation for the native video player via a rotation provider and accompanying hook.

Will need a native release, as we add `expo-screen-orientation`.