### PR TITLE
feat: add rtmp to dash, redo rtmp in settings

### DIFF
--- a/js/app/components/live-dashboard/livestream-panel.tsx
+++ b/js/app/components/live-dashboard/livestream-panel.tsx
@@ -1,4 +1,7 @@
 import {
+  Button,
+  Text,
+  Textarea,
   useCreateStreamRecord,
   useLivestream,
   useToast,
@@ -11,16 +14,14 @@ import {
   Image,
   Platform,
   ScrollView,
-  Text,
   TouchableOpacity,
   View,
 } from "react-native";
-import { Button } from "../../../components/src/components/ui/button";
-import { Textarea } from "../../../components/src/components/ui/textarea";
 import { selectUserProfile } from "../../features/bluesky/blueskySlice";
 import { useCaptureVideoFrame } from "../../hooks/useCaptureVideoFrame";
 import { useLiveUser } from "../../hooks/useLiveUser";
 import { useAppSelector } from "../../store/hooks";
+import MultistreamStatus from "./multistream-status";
 
 const { flex, p, px, py, gap, layout, bg, borders, text, r, w, typography } =
   zero;
@@ -50,17 +51,13 @@ const ButtonSelector = ({
         onPress={() => setSelectedValue(value)}
         style={[
           r.md,
+          py[0],
           {
             opacity: disabledValues.includes(value) ? 0.5 : 1,
           },
         ]}
       >
-        <Text
-          style={[
-            selectedValue === value ? text.white : text.gray[300],
-            { fontSize: 14, fontWeight: "600" },
-          ]}
-        >
+        <Text style={[selectedValue === value ? text.white : text.gray[300]]}>
           {label}
         </Text>
       </Button>
@@ -320,9 +317,7 @@ function LivestreamPanel() {
               borders.bottom.color.neutral[700],
             ]}
           >
-            <Text style={[text.white, { fontSize: 18, fontWeight: "600" }]}>
-              Stream Settings
-            </Text>
+            <Text size="xl">Stream Settings</Text>
             <ButtonSelector
               values={[
                 { label: "Create", value: "create" },
@@ -336,9 +331,7 @@ function LivestreamPanel() {
           </View>
 
           {mode === "edit" && (
-            <Text
-              style={[p[4], text.white, typography.universal?.xl || text.white]}
-            >
+            <Text style={[p[4], typography.universal?.xl || text.white]}>
               Change your Current Livestream Title
             </Text>
           )}
@@ -488,6 +481,12 @@ function LivestreamPanel() {
               </Button>
             </View>
           )}
+          {/* Multistream Status Section */}
+          <View
+            style={[borders.top.width.thin, borders.top.color.neutral[700]]}
+          >
+            <MultistreamStatus />
+          </View>
         </View>
       </ScrollView>
     </>

--- a/js/app/components/live-dashboard/multistream-status.tsx
+++ b/js/app/components/live-dashboard/multistream-status.tsx
@@ -1,0 +1,209 @@
+import { Loader, Text, View, zero } from "@streamplace/components";
+import { usePDSAgent } from "@streamplace/components/src/streamplace-store/xrpc";
+import { useCallback, useEffect, useState } from "react";
+import { Switch } from "react-native";
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
+import { PlaceStreamMultistreamDefs } from "streamplace";
+
+const { flex, p, gap, layout, bg, borders, text, r } = zero;
+
+interface MultistreamTargetViewHydrated
+  extends PlaceStreamMultistreamDefs.TargetView {
+  record: any;
+}
+
+export default function MultistreamStatus() {
+  const agent = usePDSAgent();
+  const [targets, setTargets] = useState<MultistreamTargetViewHydrated[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [togglingTargets, setTogglingTargets] = useState<Set<string>>(
+    new Set(),
+  );
+
+  // Reanimated animation for connecting states
+  const opacity = useSharedValue(1);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+  }));
+
+  useEffect(() => {
+    const hasConnectingTargets = targets.some(
+      (t) => t.record.active && t.latestEvent?.status === "pending",
+    );
+
+    if (hasConnectingTargets) {
+      opacity.value = withRepeat(withTiming(0.3, { duration: 1000 }), -1, true);
+    } else {
+      cancelAnimation(opacity);
+      opacity.value = withTiming(1, { duration: 200 });
+    }
+  }, [targets, opacity]);
+
+  const loadTargets = useCallback(async () => {
+    if (!agent) return;
+
+    try {
+      setLoading(true);
+      const targetViews = await agent.place.stream.multistream.listTargets({
+        limit: 50,
+      });
+      setTargets(targetViews.data.targets as MultistreamTargetViewHydrated[]);
+    } catch (error) {
+      console.error("Failed to load multistream targets:", error);
+      setTargets([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [agent]);
+
+  const toggleTarget = useCallback(
+    async (target: MultistreamTargetViewHydrated, newActiveState: boolean) => {
+      if (!agent) return;
+      try {
+        setTogglingTargets((prev) => new Set(prev).add(target.uri));
+        await agent.place.stream.multistream.putTarget({
+          multistreamTarget: {
+            ...target.record,
+            active: newActiveState,
+          },
+          rkey: target.uri.split("/").pop() || "",
+        });
+        await loadTargets();
+      } catch (error) {
+        console.error("Failed to toggle multistream target:", error);
+      } finally {
+        setTogglingTargets((prev) => {
+          const newSet = new Set(prev);
+          newSet.delete(target.uri);
+          return newSet;
+        });
+      }
+    },
+    [agent, loadTargets],
+  );
+
+  useEffect(() => {
+    loadTargets();
+  }, [loadTargets]);
+
+  const activeTargets = targets.filter((t) => t.record.active);
+  const inactiveTargets = targets.filter((t) => !t.record.active);
+
+  const getTargetName = (target: MultistreamTargetViewHydrated) => {
+    if (target.record.name) return target.record.name;
+    if (target.record.url) {
+      try {
+        const u = new URL(target.record.url);
+        return u.host;
+      } catch {
+        return "Untitled Target";
+      }
+    }
+    return "Untitled Target";
+  };
+
+  const getTargetHostname = (target: MultistreamTargetViewHydrated) => {
+    if (!target.record.url) return null;
+    try {
+      const u = new URL(target.record.url);
+      return u.host.split(":")[0];
+    } catch {
+      return null;
+    }
+  };
+
+  const getStatusColor = (target: MultistreamTargetViewHydrated) => {
+    if (!target.record.active) return text.gray[500];
+
+    switch (target.latestEvent?.status) {
+      case "active":
+        return text.green[400];
+      case "error":
+        return text.red[400];
+      case "pending":
+        return text.yellow[400];
+      default:
+        return text.gray[600];
+    }
+  };
+
+  if (loading && targets.length === 0) {
+    return (
+      <View style={[p[3]]}>
+        <Text style={[text.gray[400], { fontSize: 14 }]}>
+          Loading multistream...
+        </Text>
+      </View>
+    );
+  }
+
+  if (targets.length === 0) {
+    return (
+      <View style={[p[3]]}>
+        <Text style={[text.gray[400], { fontSize: 14 }]}>
+          No multistream targets configured
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[p[3], gap.all[2]]}>
+      <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
+        <Text size="xl" style={[text.white]}>
+          Multistream {loading && <Loader size="small" />}
+        </Text>
+      </View>
+
+      {targets.map((target) => (
+        <View
+          key={target.uri}
+          style={[
+            layout.flex.row,
+            layout.flex.alignCenter,
+            layout.flex.spaceBetween,
+            p[2],
+            bg.neutral[800],
+            r.md,
+            borders.width.thin,
+            borders.color.neutral[700],
+          ]}
+        >
+          <View style={[flex.values[1]]}>
+            <View
+              style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}
+            >
+              <Text>{getTargetName(target)}</Text>
+              {target.record.name && getTargetHostname(target) && (
+                <Text color="muted">{getTargetHostname(target)}</Text>
+              )}
+            </View>
+            {target.latestEvent && (
+              <Animated.Text
+                style={[
+                  getStatusColor(target),
+                  { fontSize: 11 },
+                  target.latestEvent.status === "pending" && animatedStyle,
+                ]}
+              >
+                {target.latestEvent.status}
+              </Animated.Text>
+            )}
+          </View>
+          <Switch
+            value={target.record.active}
+            onValueChange={(active) => toggleTarget(target, active)}
+            disabled={togglingTargets.has(target.uri)}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/js/app/components/settings/multistream-manager.tsx
+++ b/js/app/components/settings/multistream-manager.tsx
@@ -8,30 +8,25 @@ import {
 import { ThemeProvider } from "@streamplace/components/src/lib/theme/theme";
 import { usePDSAgent } from "@streamplace/components/src/streamplace-store/xrpc";
 import {
-  bg,
-  borders,
   flex,
   gap,
-  h,
   layout,
   mb,
   mt,
   mx,
-  p,
-  pt,
-  r,
   text,
   w,
 } from "@streamplace/components/src/ui";
 import Loading from "components/loading/loading";
-import { Edit3, Plus, RefreshCw, Trash2 } from "lucide-react-native";
+import { Plus, RefreshCw } from "lucide-react-native";
 import { useEffect, useState } from "react";
-import { Alert, Pressable, ScrollView, Switch, View } from "react-native";
+import { Alert, ScrollView, Switch, View } from "react-native";
 import {
   PlaceStreamMultistreamDefs,
   PlaceStreamMultistreamTarget,
 } from "streamplace";
 import { timeAgo } from "utils/timeAgo";
+import { SettingsListItem } from "./settings-list-item";
 
 interface MultistreamTargetViewHydrated
   extends PlaceStreamMultistreamDefs.TargetView {
@@ -73,6 +68,9 @@ export default function MultistreamManager() {
     isLoading: boolean;
   }>({ isVisible: false, target: null, isLoading: false });
   const [deletingTargets, setDeletingTargets] = useState<Set<string>>(
+    new Set(),
+  );
+  const [togglingTargets, setTogglingTargets] = useState<Set<string>>(
     new Set(),
   );
   const [formError, setFormError] = useState<string>("");
@@ -140,6 +138,36 @@ export default function MultistreamManager() {
       setFormError(error.message);
     } finally {
       setFormLoading(false);
+    }
+  };
+
+  const toggleMultistreamTarget = async (
+    target: MultistreamTargetViewHydrated,
+    newActiveState: boolean,
+  ) => {
+    if (!agent) return;
+    try {
+      setTogglingTargets((prev) => new Set(prev).add(target.uri));
+      await agent.place.stream.multistream.putTarget({
+        multistreamTarget: {
+          ...target.record,
+          active: newActiveState,
+        },
+        rkey: target.uri.split("/").pop() || "",
+      });
+      await loadMultistreamTargets();
+    } catch (error) {
+      console.error("Failed to toggle multistream target:", error);
+      Alert.alert(
+        "Error",
+        "Failed to toggle multistream target. Please try again.",
+      );
+    } finally {
+      setTogglingTargets((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(target.uri);
+        return newSet;
+      });
     }
   };
 
@@ -245,9 +273,9 @@ export default function MultistreamManager() {
                       isLoading: false,
                     })
                   }
-                  isDeleting={false}
-                  // onEdit={handleEdit}
-                  // isDeleting={deletingWebhooks.has(webhook.id)}
+                  onToggle={toggleMultistreamTarget}
+                  isDeleting={deletingTargets.has(target.uri)}
+                  isToggling={togglingTargets.has(target.uri)}
                 />
               ))}
             </>
@@ -296,111 +324,49 @@ export function MultistreamRow({
   target,
   onEdit,
   onDelete,
+  onToggle,
   isDeleting,
+  isToggling,
 }: {
   target: MultistreamTargetViewHydrated;
   onEdit: (target: MultistreamTargetViewHydrated) => void;
   onDelete: (uri: string) => void;
+  onToggle: (target: MultistreamTargetViewHydrated, active: boolean) => void;
   isDeleting: boolean;
+  isToggling: boolean;
 }) {
-  return (
-    <View
-      style={[
-        flex.shrink[1],
-        borders.width.thin,
-        borders.color.gray[200],
-        bg.neutral[800],
-        r.xl,
-        p[4],
-        mb[3],
-        layout.flex.column,
-        gap.all[3],
-        { opacity: isDeleting ? 0.5 : target.record.active ? 1 : 0.7 },
-      ]}
-    >
-      {/* Header */}
-      <View
-        style={[
-          layout.flex.row,
-          layout.flex.spaceBetween,
-          layout.flex.alignCenter,
-        ]}
-      >
-        <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
-          <View
-            style={[
-              w[3],
-              h[3],
-              r.full,
-              { backgroundColor: target.record.active ? "#22c55e" : "#6b7280" },
-            ]}
-          />
-          <Text style={[{ fontSize: 16, fontWeight: "600" }]}>
-            {mulistreamTitle(target)}
+  // Determine latest event status for footer
+  const getStatusInfo = () => {
+    if (target.latestEvent) {
+      return (
+        <View style={[layout.flex.row, gap.all[4]]}>
+          <Text style={[text.gray[400], { fontSize: 11 }]}>
+            Status: {target.latestEvent.status}
+          </Text>
+          <Text style={[text.gray[400], { fontSize: 11 }]}>
+            {timeAgo(new Date(target.latestEvent.createdAt))}
           </Text>
         </View>
+      );
+    }
+    return null;
+  };
 
-        <View style={[layout.flex.row, gap.all[2]]}>
-          <Pressable
-            style={[
-              bg.gray[100],
-              p[2],
-              r.md,
-              layout.flex.center,
-              { minWidth: 32, minHeight: 32 },
-            ]}
-            onPress={() => onEdit(target)}
-            disabled={isDeleting}
-          >
-            <Edit3 size={16} color="#374151" />
-          </Pressable>
-
-          <Pressable
-            style={[
-              bg.red[800],
-              p[2],
-              r.md,
-              layout.flex.center,
-              { minWidth: 32, minHeight: 32 },
-            ]}
-            onPress={() => onDelete(target.uri)}
-            disabled={isDeleting}
-          >
-            <Trash2 size={16} />
-          </Pressable>
-        </View>
-      </View>
-
-      {/* URL */}
-      <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
-        <Text style={[text.gray[300], { fontSize: 12 }]}>URL:</Text>
-        <Text
-          style={[text.gray[400], { fontSize: 12, fontFamily: "monospace" }]}
-          numberOfLines={1}
-        >
-          {target.record.url.length > 50
-            ? target.record.url.slice(0, 45) +
-              "..." +
-              target.record.url.slice(target.record.url.length - 5)
-            : target.record.url}
-        </Text>
-      </View>
-
-      {/* Status info */}
-      <View
-        style={[
-          layout.flex.row,
-          layout.flex.spaceBetween,
-          pt[2],
-          borders.top.width.thin,
-          borders.top.color.gray[100],
-        ]}
-      >
-        <Text style={[text.gray[400], { fontSize: 11 }]}>
-          Created {timeAgo(new Date(target.record.createdAt))}
-        </Text>
-      </View>
-    </View>
+  return (
+    <SettingsListItem
+      title={mulistreamTitle(target)}
+      url={target.record.url}
+      active={target.record.active}
+      isDeleting={isDeleting}
+      isToggling={isToggling}
+      footer={{
+        left: `Created ${timeAgo(new Date(target.record.createdAt))}`,
+        right: getStatusInfo(),
+      }}
+      onEdit={() => onEdit(target)}
+      onDelete={() => onDelete(target.uri)}
+      onToggle={(active) => onToggle(target, active)}
+    />
   );
 }
 

--- a/js/app/components/settings/settings-list-item.tsx
+++ b/js/app/components/settings/settings-list-item.tsx
@@ -1,0 +1,191 @@
+import { Text, zero } from "@streamplace/components";
+import { Edit3, Trash2 } from "lucide-react-native";
+import { ReactNode } from "react";
+import { Pressable, Switch, View } from "react-native";
+
+const { bg, text, p, mb, w, h, r, layout, borders, flex, gap, pt } = zero;
+
+interface SettingsListItemProps {
+  title: string;
+  subtitle?: string;
+  url?: string;
+  active: boolean;
+  isDeleting?: boolean;
+  badges?: Array<{ text: string; color: string; bgColor: string }>;
+  metadata?: Array<{ label: string; value: string | string[] }>;
+  footer?: {
+    left?: string;
+    right?: ReactNode;
+  };
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggle?: (active: boolean) => void;
+  isToggling?: boolean;
+}
+
+export function SettingsListItem({
+  title,
+  subtitle,
+  url,
+  active,
+  isDeleting = false,
+  badges = [],
+  metadata = [],
+  footer,
+  onEdit,
+  onDelete,
+  onToggle,
+  isToggling = false,
+}: SettingsListItemProps) {
+  const { theme } = zero.useTheme();
+
+  return (
+    <View
+      style={[
+        flex.shrink[1],
+        borders.width.thin,
+        borders.color.gray[200],
+        bg.neutral[800],
+        r.xl,
+        p[4],
+        mb[3],
+        layout.flex.column,
+        gap.all[3],
+        { opacity: isDeleting ? 0.5 : active ? 1 : 0.7 },
+      ]}
+    >
+      {/* Header */}
+      <View
+        style={[
+          layout.flex.row,
+          layout.flex.spaceBetween,
+          layout.flex.alignCenter,
+        ]}
+      >
+        <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
+          <View
+            style={[
+              w[3],
+              h[3],
+              r.full,
+              { backgroundColor: active ? "#22c55e" : "#6b7280" },
+            ]}
+          />
+          <Text style={[{ fontSize: 16, fontWeight: "600" }]}>{title}</Text>
+          {badges.map((badge, index) => (
+            <View
+              key={index}
+              style={[{ backgroundColor: badge.bgColor }, p[1], r.full]}
+            >
+              <Text style={[{ color: badge.color, fontSize: 12 }]}>
+                {badge.text}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        <View style={[layout.flex.row, gap.all[2]]}>
+          {onToggle && (
+            <Switch
+              value={active}
+              onValueChange={onToggle}
+              disabled={isDeleting || isToggling}
+            />
+          )}
+          <Pressable
+            style={[
+              bg.gray[100],
+              p[2],
+              r.md,
+              layout.flex.center,
+              { minWidth: 32, minHeight: 32 },
+            ]}
+            onPress={onEdit}
+            disabled={isDeleting}
+          >
+            <Edit3 size={16} color="#374151" />
+          </Pressable>
+
+          <Pressable
+            style={[
+              bg.red[800],
+              p[2],
+              r.md,
+              layout.flex.center,
+              { minWidth: 32, minHeight: 32 },
+            ]}
+            onPress={onDelete}
+            disabled={isDeleting}
+          >
+            <Trash2 size={16} />
+          </Pressable>
+        </View>
+      </View>
+
+      {/* Subtitle/Description */}
+      {subtitle && (
+        <Text style={[text.gray[300], { fontSize: 14 }]}>{subtitle}</Text>
+      )}
+
+      {/* URL */}
+      {url && (
+        <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
+          <Text style={[text.gray[300], { fontSize: 12 }]}>URL:</Text>
+          <Text
+            style={[text.gray[400], { fontSize: 12, fontFamily: "monospace" }]}
+            numberOfLines={1}
+          >
+            {url.length > 50
+              ? url.slice(0, 45) + "..." + url.slice(url.length - 5)
+              : url}
+          </Text>
+        </View>
+      )}
+
+      {/* Metadata */}
+      {metadata.map((meta, index) => (
+        <View
+          key={index}
+          style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}
+        >
+          <Text style={[text.gray[300], { fontSize: 12 }]}>{meta.label}:</Text>
+          <View style={[layout.flex.row, gap.all[1], { flexWrap: "wrap" }]}>
+            {Array.isArray(meta.value) ? (
+              meta.value.map((item: any, idx: number) => (
+                <View key={idx} style={[bg.blue[700], p[1], r.full]}>
+                  <Text style={[text.blue[300], { fontSize: 11 }]}>{item}</Text>
+                </View>
+              ))
+            ) : (
+              <Text style={[text.gray[400], { fontSize: 12 }]}>
+                {meta.value}
+              </Text>
+            )}
+          </View>
+        </View>
+      ))}
+
+      {/* Footer */}
+      {footer && (
+        <View
+          style={[
+            layout.flex.row,
+            layout.flex.spaceBetween,
+            pt[2],
+            borders.top.width.thin,
+            borders.top.color.gray[100],
+          ]}
+        >
+          {footer.left && (
+            <Text style={[text.gray[400], { fontSize: 11 }]}>
+              {footer.left}
+            </Text>
+          )}
+          {footer.right && (
+            <View style={[layout.flex.row, gap.all[4]]}>{footer.right}</View>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/js/app/components/settings/webhook-manager.tsx
+++ b/js/app/components/settings/webhook-manager.tsx
@@ -9,10 +9,11 @@ import {
 import { usePDSAgent } from "@streamplace/components/src/streamplace-store/xrpc";
 import AQLink from "components/aqlink";
 import Loading from "components/loading/loading";
-import { Edit3, Plus, RefreshCw, Trash2, X } from "lucide-react-native";
-import { useEffect, useState } from "react";
+import { Plus, RefreshCw, X } from "lucide-react-native";
+import { ReactNode, useEffect, useState } from "react";
 import { Alert, Pressable, ScrollView, Switch, View } from "react-native";
 import { timeAgo } from "utils/timeAgo";
+import { SettingsListItem } from "./settings-list-item";
 
 const {
   atoms,
@@ -84,145 +85,59 @@ function WebhookRow({
   onDelete: (id: string) => void;
   isDeleting: boolean;
 }) {
-  const { theme } = zero.useTheme();
   const isDiscord = webhook.url
     .toLowerCase()
     .startsWith("https://discord.com/api/webhooks");
 
+  const badges = isDiscord
+    ? [{ text: "Discord", color: "#6366f1", bgColor: "#312e81" }]
+    : [];
+
+  const metadata = [
+    {
+      label: "Events",
+      value: webhook.events.map(
+        (event) =>
+          EVENT_OPTIONS.find((opt) => opt.value === event)?.label || event,
+      ),
+    },
+  ];
+
+  const getFooterRight = () => {
+    const items: ReactNode[] = [];
+    if (webhook.errorCount !== undefined && webhook.errorCount > 0) {
+      items.push(
+        <Text key="errors" style={[text.red[600], { fontSize: 11 }]}>
+          {webhook.errorCount} errors
+        </Text>,
+      );
+    }
+    if (webhook.lastTriggered) {
+      items.push(
+        <Text key="triggered" style={[text.gray[400], { fontSize: 11 }]}>
+          Last triggered {timeAgo(new Date(webhook.lastTriggered))}
+        </Text>,
+      );
+    }
+    return items.length > 0 ? <>{items}</> : null;
+  };
+
   return (
-    <View
-      style={[
-        flex.shrink[1],
-        borders.width.thin,
-        borders.color.gray[200],
-        bg.neutral[800],
-        r.xl,
-        p[4],
-        mb[3],
-        layout.flex.column,
-        gap.all[3],
-        { opacity: isDeleting ? 0.5 : webhook.active ? 1 : 0.7 },
-      ]}
-    >
-      {/* Header */}
-      <View
-        style={[
-          layout.flex.row,
-          layout.flex.spaceBetween,
-          layout.flex.alignCenter,
-        ]}
-      >
-        <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
-          <View
-            style={[
-              w[3],
-              h[3],
-              r.full,
-              { backgroundColor: webhook.active ? "#22c55e" : "#6b7280" },
-            ]}
-          />
-          <Text style={[{ fontSize: 16, fontWeight: "600" }]}>
-            {webhook.name || "Untitled Webhook"}
-          </Text>
-          {isDiscord && (
-            <View style={[bg.indigo[800], px[2], r.full]}>
-              <Text style={[text.indigo[300], { fontSize: 12 }]}>Discord</Text>
-            </View>
-          )}
-        </View>
-
-        <View style={[layout.flex.row, gap.all[2]]}>
-          <Pressable
-            style={[
-              bg.blue[600],
-              p[2],
-              r.md,
-              layout.flex.center,
-              { minWidth: 32, minHeight: 32 },
-            ]}
-            onPress={() => onEdit(webhook)}
-            disabled={isDeleting}
-          >
-            <Edit3 size={16} color={theme.colors.text} />
-          </Pressable>
-
-          <Pressable
-            style={[
-              bg.red[800],
-              p[2],
-              r.md,
-              layout.flex.center,
-              { minWidth: 32, minHeight: 32 },
-            ]}
-            onPress={() => onDelete(webhook.id)}
-            disabled={isDeleting}
-          >
-            <Trash2 size={16} color={theme.colors.text} />
-          </Pressable>
-        </View>
-      </View>
-
-      {/* Description */}
-      {webhook.description && (
-        <Text style={[text.gray[300], { fontSize: 14 }]}>
-          {webhook.description}
-        </Text>
-      )}
-
-      {/* URL */}
-      <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
-        <Text style={[text.gray[300], { fontSize: 12 }]}>URL:</Text>
-        <Text
-          style={[text.gray[400], { fontSize: 12, fontFamily: "monospace" }]}
-          numberOfLines={1}
-        >
-          {webhook.url.length > 50
-            ? webhook.url.slice(0, 45) +
-              "..." +
-              webhook.url.slice(webhook.url.length - 5)
-            : webhook.url}
-        </Text>
-      </View>
-
-      {/* Events */}
-      <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
-        <Text style={[text.gray[300], { fontSize: 12 }]}>Events:</Text>
-        {webhook.events.map((event, index) => (
-          <View key={event} style={[bg.blue[700], px[2], r.full]}>
-            <Text style={[text.blue[300], { fontSize: 11 }]}>
-              {EVENT_OPTIONS.find((opt) => opt.value === event)?.label || event}
-            </Text>
-          </View>
-        ))}
-      </View>
-
-      {/* Status info */}
-      <View
-        style={[
-          layout.flex.row,
-          layout.flex.spaceBetween,
-          pt[2],
-          borders.top.width.thin,
-          borders.top.color.gray[100],
-        ]}
-      >
-        <Text style={[text.gray[400], { fontSize: 11 }]}>
-          Created {timeAgo(new Date(webhook.createdAt))}
-        </Text>
-        <View style={[layout.flex.row, gap.all[4]]}>
-          {webhook.errorCount !== undefined && webhook.errorCount > 0 && (
-            <Text style={[text.red[600], { fontSize: 11 }]}>
-              {webhook.errorCount} errors
-            </Text>
-          )}
-          {webhook.lastTriggered && (
-            <Text style={[text.gray[400], { fontSize: 11 }]}>
-              Last triggered {timeAgo(new Date(webhook.lastTriggered))}
-            </Text>
-          )}
-        </View>
-      </View>
-    </View>
+    <SettingsListItem
+      title={webhook.name || "Untitled Webhook"}
+      subtitle={webhook.description}
+      url={webhook.url}
+      active={webhook.active}
+      isDeleting={isDeleting}
+      badges={badges}
+      metadata={metadata}
+      footer={{
+        left: `Created ${timeAgo(new Date(webhook.createdAt))}`,
+        right: getFooterRight(),
+      }}
+      onEdit={() => onEdit(webhook)}
+      onDelete={() => onDelete(webhook.id)}
+    />
   );
 }
 

--- a/js/components/src/components/dashboard/chat-panel.tsx
+++ b/js/components/src/components/dashboard/chat-panel.tsx
@@ -1,4 +1,4 @@
-import { Text, View } from "react-native";
+import { Text, View } from "../..";
 import emojiData from "../../assets/emoji-data.json";
 import * as zero from "../../ui";
 import { Chat } from "../chat/chat";
@@ -42,9 +42,7 @@ export default function ChatPanel({
           p[4],
         ]}
       >
-        <Text style={[text.white, { fontSize: 18, fontWeight: "600" }]}>
-          Chat
-        </Text>
+        <Text size="xl">Chat</Text>
         <View style={[layout.flex.row, layout.flex.alignCenter]}>
           <View
             style={[


### PR DESCRIPTION
I kind of want settings stuff to land after i18n, as i18n uses settings as an example. if I were to do it in this PR and this PR gets merged i'd have a lot more (imo unnecessary) work to do there.