### PR TITLE
feat: make the Stream Key display less suck

### DIFF
--- a/js/app/components/live-dashboard/stream-key.tsx
+++ b/js/app/components/live-dashboard/stream-key.tsx
@@ -2,17 +2,18 @@ import { Body, Button, Code, Row, View } from "@streamplace/components";
 import { Redirect } from "components/aqlink";
 import Loading from "components/loading/loading";
 import {
-  clearStreamKeyRecord,
-  createStreamKeyRecord,
-  selectIsReady,
-  selectUserProfile,
+    clearStreamKeyRecord,
+    createStreamKeyRecord,
+    selectIsReady,
+    selectUserProfile,
 } from "features/bluesky/blueskySlice";
 import { useEffect, useState } from "react";
+import { TextInput } from "react-native";
 import { useAppDispatch, useAppSelector } from "store/hooks";
 
 const FormRow = ({ children }: { children: React.ReactNode }) => {
   return (
-    <Row fullWidth padding="lg" align="start">
+    <Row fullWidth align="start">
       {children}
     </Row>
   );
@@ -66,18 +67,16 @@ export function StreamKeyScreen() {
             WHIP
           </Button>
         </FormRow>
-
         {protocol === "whip" && <WHIPDescription url={url} />}
         {protocol === "rtmp" && <RTMPDescription url={url} />}
-
         <FormRow>
           <Label>Output Settings</Label>
           <Content>
-            <Body>Output mode: Advanced</Body>
             <Body>
+              Output mode: Advanced
+              <br />
               Keyframe Interval: <Code>1s</Code>
-            </Body>
-            <Body>
+              <br />
               x264 Options: <Code>bframes=0</Code>
             </Body>
           </Content>
@@ -99,7 +98,20 @@ export function WHIPDescription({ url }: { url: string }) {
       <FormRow>
         <Label>Server</Label>
         <Content>
-          <Body>{url}</Body>
+          <TextInput
+            value={url}
+            readOnly={true}
+            style={[
+              {
+                backgroundColor: "#1a1a1a",
+                borderWidth: 1,
+                borderColor: "#333",
+                borderRadius: 8,
+                padding: 12,
+                color: "white",
+              },
+            ]}
+          />
         </Content>
       </FormRow>
       <FormRow>
@@ -127,7 +139,20 @@ export function RTMPDescription({ url }: { url: string }) {
       <FormRow>
         <Label>Server</Label>
         <Content>
-          <Body>{rtmpUrl}</Body>
+          <TextInput
+            value={rtmpUrl}
+            readOnly={true}
+            style={[
+              {
+                backgroundColor: "#1a1a1a",
+                borderWidth: 1,
+                borderColor: "#333",
+                borderRadius: 8,
+                padding: 12,
+                color: "white",
+              },
+            ]}
+          />
         </Content>
       </FormRow>
       <FormRow>
@@ -145,6 +170,8 @@ export default StreamKeyScreen;
 export function StreamKey() {
   const dispatch = useAppDispatch();
   const [generating, setGenerating] = useState(false);
+  const [hidekey, setHidekey] = useState(true);
+  const [didcopy, setDidcopy] = useState(false);
   const newKey = useAppSelector((state) => state.bluesky.newKey);
 
   useEffect(() => {
@@ -168,12 +195,95 @@ export function StreamKey() {
     };
   }, [newKey, dispatch]);
 
+  const handleCopy = async () => {
+    if (!newKey) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(newKey.privateKey);
+      // TODO: Replace with custom toast implementation
+      console.log("Bearer token copied to clipboard");
+      setDidcopy(true);
+    } catch (e) {
+      // not allowed. oh well.
+      console.log("Could not copy to clipboard");
+    }
+  };
+
   if (generating) {
     return <Loading />;
   }
 
   if (newKey) {
-    return <Code>{newKey.privateKey}</Code>;
+
+    return (
+      <Row
+        fullWidth
+        flex={1}
+        align="start"
+      >
+        <TextInput
+          value={newKey.privateKey}
+          secureTextEntry={hidekey}
+          readOnly={true}
+          style={[
+            {
+              backgroundColor: "#1a1a1a",
+              borderWidth: 1,
+              borderColor: "#333",
+              borderRadius: 8,
+              padding: 12,
+              color: "white",
+              flex: 1,
+              borderTopRightRadius: "0px",
+              borderBottomRightRadius: "0px",
+            },
+          ]}
+          onFocus={(e) => {
+            setHidekey(false);
+          }}
+          onBlur={() => {
+            setHidekey(true);
+          }}
+          selectTextOnFocus={true}
+        />
+        <Button
+          onPress={handleCopy}
+          style={[
+            {
+              borderTopLeftRadius: "0px",
+              borderBottomLeftRadius: "0px",
+            },
+          ]}
+        >
+          {didcopy ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="currentColor"
+              viewBox="0 0 16 16"
+            >
+              <path d="M9.5 0a.5.5 0 0 1 .5.5.5.5 0 0 0 .5.5.5.5 0 0 1 .5.5V2a.5.5 0 0 1-.5.5h-5A.5.5 0 0 1 5 2v-.5a.5.5 0 0 1 .5-.5.5.5 0 0 0 .5-.5.5.5 0 0 1 .5-.5z" />
+              <path d="M3 2.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 0 0-1h-.5A1.5 1.5 0 0 0 2 2.5v12A1.5 1.5 0 0 0 3.5 16h9a1.5 1.5 0 0 0 1.5-1.5v-12A1.5 1.5 0 0 0 12.5 1H12a.5.5 0 0 0 0 1h.5a.5.5 0 0 1 .5.5v12a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5z" />
+              <path d="M10.854 7.854a.5.5 0 0 0-.708-.708L7.5 9.793 6.354 8.646a.5.5 0 1 0-.708.708l1.5 1.5a.5.5 0 0 0 .708 0z" />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="currentColor"
+              viewBox="0 0 16 16"
+            >
+              <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z" />
+              <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0z" />
+            </svg>
+          )}
+        </Button>
+      </Row>
+    );
   }
 
   return (
@@ -181,6 +291,7 @@ export function StreamKey() {
       onPress={async () => {
         try {
           setGenerating(true);
+          setDidcopy(false);
           await dispatch(createStreamKeyRecord({ store: false }));
         } catch (e) {
           console.error("failed to generate stream key", e);

--- a/js/app/components/live-dashboard/stream-key.tsx
+++ b/js/app/components/live-dashboard/stream-key.tsx
@@ -217,10 +217,16 @@ export function StreamKey() {
       await navigator.clipboard.writeText(newKey.privateKey);
       setDidcopy(true);
 
-      toast.show('Stream Key', 'Stream Key was copied to your clipboard', { duration: 4 });
+      toast.show("Stream Key", "Stream Key was copied to your clipboard", {
+        duration: 4,
+      });
     } catch (e) {
       // not allowed. oh well.
-      toast.show('Stream Key', 'Failed to copy the Stream Key to your clipboard', { duration: 4 });
+      toast.show(
+        "Stream Key",
+        "Failed to copy the Stream Key to your clipboard",
+        { duration: 4 },
+      );
     }
   };
 

--- a/js/app/components/live-dashboard/stream-key.tsx
+++ b/js/app/components/live-dashboard/stream-key.tsx
@@ -8,7 +8,7 @@ import {
     selectUserProfile,
 } from "features/bluesky/blueskySlice";
 import { useEffect, useState } from "react";
-import { TextInput } from "react-native";
+import { ScrollView, TextInput } from "react-native";
 import { useAppDispatch, useAppSelector } from "store/hooks";
 
 const FormRow = ({ children }: { children: React.ReactNode }) => {
@@ -51,38 +51,40 @@ export function StreamKeyScreen() {
   const url = useAppSelector((state) => state.streamplace.url);
 
   return (
-    <View flex={1} centered fullWidth padding="lg">
-      <View fullWidth style={{ maxWidth: 600 }}>
-        <FormRow>
-          <Button
-            variant={protocol !== "rtmp" ? "secondary" : "primary"}
-            onPress={() => setProtocol("rtmp")}
-          >
-            RTMP
-          </Button>
-          <Button
-            variant={protocol !== "whip" ? "secondary" : "primary"}
-            onPress={() => setProtocol("whip")}
-          >
-            WHIP
-          </Button>
-        </FormRow>
-        {protocol === "whip" && <WHIPDescription url={url} />}
-        {protocol === "rtmp" && <RTMPDescription url={url} />}
-        <FormRow>
-          <Label>Output Settings</Label>
-          <Content>
-            <Body>
-              Output mode: Advanced
-              <br />
-              Keyframe Interval: <Code>1s</Code>
-              <br />
-              x264 Options: <Code>bframes=0</Code>
-            </Body>
-          </Content>
-        </FormRow>
+    <ScrollView>
+      <View flex={1} align="center" justify="start" padding="md" fullWidth>
+        <View fullWidth style={{ maxWidth: 600 }}>
+          <FormRow>
+            <Button
+              variant={protocol !== "rtmp" ? "secondary" : "primary"}
+              onPress={() => setProtocol("rtmp")}
+            >
+              RTMP
+            </Button>
+            <Button
+              variant={protocol !== "whip" ? "secondary" : "primary"}
+              onPress={() => setProtocol("whip")}
+            >
+              WHIP
+            </Button>
+          </FormRow>
+          {protocol === "whip" && <WHIPDescription url={url} />}
+          {protocol === "rtmp" && <RTMPDescription url={url} />}
+          <FormRow>
+            <Label>Output Settings</Label>
+            <Content>
+              <Body>
+                Output mode: Advanced
+                <br />
+                Keyframe Interval: <Code>1s</Code>
+                <br />
+                x264 Options: <Code>bframes=0</Code>
+              </Body>
+            </Content>
+          </FormRow>
+        </View>
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
@@ -216,13 +218,8 @@ export function StreamKey() {
   }
 
   if (newKey) {
-
     return (
-      <Row
-        fullWidth
-        flex={1}
-        align="start"
-      >
+      <Row fullWidth flex={1} align="start">
         <TextInput
           value={newKey.privateKey}
           secureTextEntry={hidekey}

--- a/js/app/components/live-dashboard/stream-key.tsx
+++ b/js/app/components/live-dashboard/stream-key.tsx
@@ -1,4 +1,4 @@
-import { Body, Button, Code, Row, View } from "@streamplace/components";
+import { Body, Button, Code, Row, View, useTheme } from "@streamplace/components";
 import { Redirect } from "components/aqlink";
 import Loading from "components/loading/loading";
 import {
@@ -7,6 +7,7 @@ import {
     selectIsReady,
     selectUserProfile,
 } from "features/bluesky/blueskySlice";
+import { Clipboard, ClipboardCheck } from "lucide-react-native";
 import { useEffect, useState } from "react";
 import { ScrollView, TextInput } from "react-native";
 import { useAppDispatch, useAppSelector } from "store/hooks";
@@ -170,11 +171,15 @@ export function RTMPDescription({ url }: { url: string }) {
 export default StreamKeyScreen;
 
 export function StreamKey() {
+  const theme = useTheme();
+
   const dispatch = useAppDispatch();
   const [generating, setGenerating] = useState(false);
   const [hidekey, setHidekey] = useState(true);
   const [didcopy, setDidcopy] = useState(false);
   const newKey = useAppSelector((state) => state.bluesky.newKey);
+
+  let foregroundColor = theme.theme.colors.text || "#fff";
 
   useEffect(() => {
     if (!newKey) {
@@ -255,28 +260,9 @@ export function StreamKey() {
           ]}
         >
           {didcopy ? (
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              fill="currentColor"
-              viewBox="0 0 16 16"
-            >
-              <path d="M9.5 0a.5.5 0 0 1 .5.5.5.5 0 0 0 .5.5.5.5 0 0 1 .5.5V2a.5.5 0 0 1-.5.5h-5A.5.5 0 0 1 5 2v-.5a.5.5 0 0 1 .5-.5.5.5 0 0 0 .5-.5.5.5 0 0 1 .5-.5z" />
-              <path d="M3 2.5a.5.5 0 0 1 .5-.5H4a.5.5 0 0 0 0-1h-.5A1.5 1.5 0 0 0 2 2.5v12A1.5 1.5 0 0 0 3.5 16h9a1.5 1.5 0 0 0 1.5-1.5v-12A1.5 1.5 0 0 0 12.5 1H12a.5.5 0 0 0 0 1h.5a.5.5 0 0 1 .5.5v12a.5.5 0 0 1-.5.5h-9a.5.5 0 0 1-.5-.5z" />
-              <path d="M10.854 7.854a.5.5 0 0 0-.708-.708L7.5 9.793 6.354 8.646a.5.5 0 1 0-.708.708l1.5 1.5a.5.5 0 0 0 .708 0z" />
-            </svg>
+            <ClipboardCheck color={foregroundColor} size={24} />
           ) : (
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              fill="currentColor"
-              viewBox="0 0 16 16"
-            >
-              <path d="M4 1.5H3a2 2 0 0 0-2 2V14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V3.5a2 2 0 0 0-2-2h-1v1h1a1 1 0 0 1 1 1V14a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V3.5a1 1 0 0 1 1-1h1z" />
-              <path d="M9.5 1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5v-1a.5.5 0 0 1 .5-.5zm-3-1A1.5 1.5 0 0 0 5 1.5v1A1.5 1.5 0 0 0 6.5 4h3A1.5 1.5 0 0 0 11 2.5v-1A1.5 1.5 0 0 0 9.5 0z" />
-            </svg>
+            <Clipboard color={foregroundColor} size={24} />
           )}
         </Button>
       </Row>

--- a/js/app/components/live-dashboard/stream-key.tsx
+++ b/js/app/components/live-dashboard/stream-key.tsx
@@ -1,11 +1,19 @@
-import { Body, Button, Code, Row, View, useTheme } from "@streamplace/components";
+import {
+  Body,
+  Button,
+  Code,
+  Row,
+  View,
+  useTheme,
+  useToast,
+} from "@streamplace/components";
 import { Redirect } from "components/aqlink";
 import Loading from "components/loading/loading";
 import {
-    clearStreamKeyRecord,
-    createStreamKeyRecord,
-    selectIsReady,
-    selectUserProfile,
+  clearStreamKeyRecord,
+  createStreamKeyRecord,
+  selectIsReady,
+  selectUserProfile,
 } from "features/bluesky/blueskySlice";
 import { Clipboard, ClipboardCheck } from "lucide-react-native";
 import { useEffect, useState } from "react";
@@ -59,12 +67,20 @@ export function StreamKeyScreen() {
             <Button
               variant={protocol !== "rtmp" ? "secondary" : "primary"}
               onPress={() => setProtocol("rtmp")}
+              style={{
+                borderTopRightRadius: "0px",
+                borderBottomRightRadius: "0px",
+              }}
             >
               RTMP
             </Button>
             <Button
               variant={protocol !== "whip" ? "secondary" : "primary"}
               onPress={() => setProtocol("whip")}
+              style={{
+                borderTopLeftRadius: "0px",
+                borderBottomLeftRadius: "0px",
+              }}
             >
               WHIP
             </Button>
@@ -172,6 +188,7 @@ export default StreamKeyScreen;
 
 export function StreamKey() {
   const theme = useTheme();
+  const toast = useToast();
 
   const dispatch = useAppDispatch();
   const [generating, setGenerating] = useState(false);
@@ -186,17 +203,6 @@ export function StreamKey() {
       return;
     }
 
-    (async () => {
-      try {
-        await navigator.clipboard.writeText(newKey.privateKey);
-        // TODO: Replace with custom toast implementation
-        console.log("Bearer token copied to clipboard");
-      } catch (e) {
-        // not allowed. oh well.
-        console.log("Could not copy to clipboard");
-      }
-    })();
-
     return () => {
       dispatch(clearStreamKeyRecord());
     };
@@ -209,12 +215,12 @@ export function StreamKey() {
 
     try {
       await navigator.clipboard.writeText(newKey.privateKey);
-      // TODO: Replace with custom toast implementation
-      console.log("Bearer token copied to clipboard");
       setDidcopy(true);
+
+      toast.show('Stream Key', 'Stream Key was copied to your clipboard', { duration: 4 });
     } catch (e) {
       // not allowed. oh well.
-      console.log("Could not copy to clipboard");
+      toast.show('Stream Key', 'Failed to copy the Stream Key to your clipboard', { duration: 4 });
     }
   };
 


### PR DESCRIPTION
# Reasoning:

1. Theres way too much padding on the fields in the Stream settings zone.

2. The first thing I did when using stream.place was leak my stream key as I was live on Twitch at the time. Protect the ID 10 T's.

3. This ads an explict copy to clip board button/function. Without the need to show the key first. (similar in function to Twitch's)

<img width="1075" height="148" alt="image" src="https://github.com/user-attachments/assets/7387bf03-fa6b-4f4b-bb65-cc87d4e7e3dc" />

4. Remove forced to clip board of the key as thats bad User behaviour
5. Add Toast on clipboard yay/nay from streamplace/components
6. Tweak border raidus on RTMP/Whip button group

# Additional:

~~I'd be inclined to remove the "auto copy to clipboard" as this is a bad user UX. I didn't but I suggest we should and can add this to the PR.~~

I didn't also add a copy button to the Server URL but that could be added easily enough.
Both setting fields are easier to to copy from now anyway. (When I did my intial setup I err'ed and had a space at the start of the Server URI when added to OBS)

# Commit:

- Remove the slew of padding in this box
- Change the server and stream key display to readonly inputs Add an explict copy to clipboard button
- Change streamkey field to password and show it/select all on click
- Throw it into a ScrollView on the box so it scrolls on smoll height browsers and Tweak padding
- RTMP/Whip button group tidy
- Remove forced clipboard on key gen

# Screenshots

<img width="715" height="466" alt="image" src="https://github.com/user-attachments/assets/ee8b95af-d247-44bc-aec8-105c3163e98f" />
<img width="716" height="462" alt="image" src="https://github.com/user-attachments/assets/d8104a5c-bf83-44d7-816b-54cca6b8bfa7" />

fix:
<img width="618" height="481" alt="image" src="https://github.com/user-attachments/assets/74bc2b74-18bf-4c9a-963e-101f68f72e60" />
to:
<img width="576" height="414" alt="image" src="https://github.com/user-attachments/assets/de3abb51-53b0-44ca-9257-215638e70c13" />
