### PR TITLE
nit: Set vscode settings tabSize to 2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
   "editor.codeActionsOnSave": {
     "source.addMissingImports": "explicit",
     "source.organizeImports": "explicit"
-  }
+  },
+  "editor.tabSize": 2
 }


### PR DESCRIPTION
My vscode was resetting itself to 4 and messing up indenting. (my default is 4 but the project uses 2)

So set at project level for all vscode users