### PR TITLE
fix: use useNavigate instead of descriptor in sidebar

### DIFF
--- a/js/app/components/sidebar/sidebar-item.tsx
+++ b/js/app/components/sidebar/sidebar-item.tsx
@@ -105,9 +105,7 @@ export default function SidebarItem({
               },
             ]}
           >
-            <Text style={[{ fontSize: 24, textAlign: "left", color: "#fff" }]}>
-              {label}
-            </Text>
+            <Text>{label}</Text>
           </View>
         )}
       </View>

--- a/js/app/components/sidebar/sidebar.tsx
+++ b/js/app/components/sidebar/sidebar.tsx
@@ -4,6 +4,7 @@ import {
   CommonActions,
   DrawerNavigationState,
   ParamListBase,
+  useNavigation,
 } from "@react-navigation/native";
 import { Text, useTheme } from "@streamplace/components";
 import React from "react";
@@ -44,6 +45,7 @@ export default function Sidebar({
   externalItems = [],
 }: SidebarProps) {
   const theme = useTheme();
+  const navigation = useNavigation();
   // Apply the defined type to the component props
   const animatedSidebarStyle = useAnimatedStyle(() => {
     return {
@@ -106,7 +108,7 @@ export default function Sidebar({
             onPress={() => {
               if (route.name === "Home") {
                 // copy logic for 'Home' to reset the stack
-                descriptor.navigation.dispatch(
+                navigation.dispatch(
                   CommonActions.reset({
                     index: 0,
                     routes: [
@@ -120,7 +122,7 @@ export default function Sidebar({
                   }),
                 );
               } else {
-                descriptor.navigation.navigate(route.name);
+                navigation.navigate(route.name as any);
               }
             }}
             style={options.drawerItemStyle}


### PR DESCRIPTION
This is a fix for the "navigation on navbar not working" issue. From what I can tell, descriptor gets dereferenced or something, so we can't use `descriptor.navigation.dispatch`. This replaces it with `useNavigate()` -> `navigation.dispatch` so it should be there even when descriptor has issues.

I've found one way to forcefully unload the navbar, which is to go into vertical player mode and click the back button. Doing that seems to leave descriptor unloaded for some reason, and thus the navbar unusable.