### PR TITLE
feat: sonner-like toast component

### DIFF
--- a/js/app/components/settings/settings.tsx
+++ b/js/app/components/settings/settings.tsx
@@ -1,5 +1,12 @@
 import { useNavigation } from "@react-navigation/native";
-import { Button, Input, Text, View, zero } from "@streamplace/components";
+import {
+  Button,
+  Input,
+  Text,
+  useToast,
+  View,
+  zero,
+} from "@streamplace/components";
 import AQLink from "components/aqlink";
 import {
   createServerSettingsRecord,
@@ -21,6 +28,7 @@ export function Settings() {
   const defaultUrl = DEFAULT_URL;
   const [newUrl, setNewUrl] = useState("");
   const [overrideEnabled, setOverrideEnabled] = useState(false);
+  const t = useToast();
 
   // are we logged in?
   const loggedIn = useAppSelector(
@@ -164,6 +172,7 @@ export function Settings() {
             </>
           )}
         </View>
+        <Button onPress={() => t.show("toast")}>tost</Button>
       </View>
     </ScrollView>
   );

--- a/js/app/components/settings/settings.tsx
+++ b/js/app/components/settings/settings.tsx
@@ -172,7 +172,6 @@ export function Settings() {
             </>
           )}
         </View>
-        <Button onPress={() => t.show("toast")}>tost</Button>
       </View>
     </ScrollView>
   );

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -388,12 +388,6 @@ export function StreamplaceDrawer() {
   // are we in the live dashboard?
   const [isLiveDashboard, setIsLiveDashboard] = useState(false);
   useEffect(() => {
-    console.log({
-      isLiveDashboard,
-      userIsLive,
-      livePopup,
-      navi: navigation.getState()?.routes,
-    });
     if (!isLiveDashboard && userIsLive) {
       toast.show("You are live!", "Do you want to go to your Live Dashboard?", {
         actionLabel: "Go",

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -15,11 +15,10 @@ import {
   useRoute,
 } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import { Text, useTheme } from "@streamplace/components";
+import { Text, useTheme, useToast } from "@streamplace/components";
 import { Provider, Settings } from "components";
 import AQLink from "components/aqlink";
 import Login from "components/login/login";
-import Popup from "components/popup";
 import Sidebar, { ExternalDrawerItem } from "components/sidebar/sidebar";
 import * as ExpoLinking from "expo-linking";
 import { hydrate, selectHydrated } from "features/base/baseSlice";
@@ -337,6 +336,8 @@ export function StreamplaceDrawer() {
 
   const sidebar = useSidebarControl();
 
+  const toast = useToast();
+
   SystemBars.setStyle("dark");
 
   // Top-level stuff to handle push notification registration
@@ -397,6 +398,19 @@ export function StreamplaceDrawer() {
   if (!hydrated) {
     return <View />;
   }
+
+  if (isWeb && livePopup) {
+    toast.show("You are live!", "Do you want to go to the Live Dashboard?", {
+      actionLabel: "Go",
+      onAction: () => {
+        navigation.navigate("LiveDashboard");
+        setLivePopup(false);
+      },
+      onClose: () => setLivePopup(false),
+      variant: "error",
+    });
+  }
+
   return (
     <>
       <StatusBar barStyle="light-content" />
@@ -589,35 +603,6 @@ export function StreamplaceDrawer() {
           }}
         />
       </Drawer.Navigator>
-      {isWeb && livePopup && (
-        <Popup
-          onPress={() => {
-            navigation.navigate("LiveDashboard");
-            setLivePopup(false);
-          }}
-          onClose={() => {
-            setLivePopup(false);
-          }}
-          containerProps={{
-            style: { bottom: 32 },
-          }}
-          bubbleProps={{
-            style: { backgroundColor: "#cc0000" },
-          }}
-        >
-          <Text
-            style={[
-              { textAlign: "center" },
-              { fontSize: 24, fontWeight: "bold" },
-            ]}
-          >
-            ✨YOU ARE LIVE!!!✨
-          </Text>
-          <Text>
-            {isNative ? "Tap" : "Click"} here to go to the live dashboard
-          </Text>
-        </Popup>
-      )}
     </>
   );
 }

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -331,7 +331,6 @@ export function StreamplaceDrawer() {
   const { isWeb, isElectron, isNative, isBrowser } = usePlatform();
   const navigation = useNavigation();
   const dispatch = useAppDispatch();
-  const [poppedUp, setPoppedUp] = useState(false);
   const [livePopup, setLivePopup] = useState(false);
 
   const sidebar = useSidebarControl();
@@ -386,29 +385,32 @@ export function StreamplaceDrawer() {
 
   let foregroundColor = theme.theme.colors.text || "#fff";
 
-  const [isLiveDashboard, setIsLiveDashboard] = useState(true);
+  // are we in the live dashboard?
+  const [isLiveDashboard, setIsLiveDashboard] = useState(false);
   useEffect(() => {
-    if (!isLiveDashboard && userIsLive && !poppedUp) {
-      setPoppedUp(true);
-      setLivePopup(true);
+    console.log({
+      isLiveDashboard,
+      userIsLive,
+      livePopup,
+      navi: navigation.getState()?.routes,
+    });
+    if (!isLiveDashboard && userIsLive) {
+      toast.show("You are live!", "Do you want to go to your Live Dashboard?", {
+        actionLabel: "Go",
+        onAction: () => {
+          navigation.navigate("LiveDashboard");
+          setLivePopup(false);
+        },
+        onClose: () => setLivePopup(false),
+        variant: "error",
+        duration: 8,
+      });
     }
-  }, [userIsLive, poppedUp]);
+  }, [userIsLive]);
   const externalItems = useExternalItems();
 
   if (!hydrated) {
     return <View />;
-  }
-
-  if (isWeb && livePopup) {
-    toast.show("You are live!", "Do you want to go to the Live Dashboard?", {
-      actionLabel: "Go",
-      onAction: () => {
-        navigation.navigate("LiveDashboard");
-        setLivePopup(false);
-      },
-      onClose: () => setLivePopup(false),
-      variant: "error",
-    });
   }
 
   return (

--- a/js/components/src/components/ui/toast.tsx
+++ b/js/components/src/components/ui/toast.tsx
@@ -22,7 +22,17 @@ import Animated, {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Circle, Svg } from "react-native-svg";
 import { useTheme } from "../../ui";
+import { Button } from "./button";
 import { Text } from "./text";
+
+type Position =
+  | "auto"
+  | "top-left"
+  | "top-center"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-center"
+  | "bottom-right";
 
 type ToastConfig = {
   title?: string;
@@ -36,6 +46,7 @@ type ToastConfig = {
     close: () => void;
     action?: () => void;
   }) => React.ReactNode;
+  position?: Position;
 };
 
 type ToastState = {
@@ -52,6 +63,7 @@ type ToastState = {
     close: () => void;
     action?: () => void;
   }) => React.ReactNode;
+  position: Position;
 };
 
 class ToastManager {
@@ -73,6 +85,7 @@ class ToastManager {
       onClose: config.onClose,
       variant: config.variant ?? "default",
       render: config.render,
+      position: config.position ?? "auto",
     };
 
     this.toasts = [...this.toasts, toast];
@@ -139,6 +152,7 @@ export const toast = {
       onAction?: () => void;
       onClose?: () => void;
       variant?: "default" | "success" | "error" | "info";
+      position?: Position;
     },
   ) => {
     toastManager.show({
@@ -168,6 +182,7 @@ export const toast = {
       onAction?: () => void;
       onClose?: () => void;
       variant?: "default" | "success" | "error" | "info";
+      position?: Position;
     },
   ) => {
     toastManager.show({
@@ -192,97 +207,211 @@ export function useToast() {
 
 export function ToastProvider() {
   const [toasts, setToasts] = useState<ToastState[]>([]);
-  const insets = useSafeAreaInsets();
-  const { theme } = useTheme();
-  const isWeb = Platform.OS === "web";
-  const { width } = useWindowDimensions();
-  const isDesktop = isWeb && width >= 768;
 
   useEffect(() => {
     return toastManager.subscribe(setToasts);
   }, []);
 
+  const toastsByPosition = toasts.reduce(
+    (acc, toast) => {
+      const { position } = toast;
+      if (!acc[position]) {
+        acc[position] = [];
+      }
+      acc[position].push(toast);
+      return acc;
+    },
+    {} as Record<Position, ToastState[]>,
+  );
+
+  return (
+    <>
+      {Object.entries(toastsByPosition).map(([position, toasts]) => (
+        <ToastContainer
+          key={position}
+          position={position as Position}
+          toasts={toasts}
+        />
+      ))}
+    </>
+  );
+}
+
+function ToastContainer({
+  position = "auto",
+  toasts,
+}: {
+  position?: Position;
+  toasts: ToastState[];
+}) {
+  const insets = useSafeAreaInsets();
+  const { theme } = useTheme();
+  const isWeb = Platform.OS === "web";
+  const { width } = useWindowDimensions();
+  const isDesktop = isWeb && width >= 768;
+  const isTop = position.includes("top");
+  const visibleToasts = toasts.slice(-4);
+  const prevToastIds = useRef<string[]>(visibleToasts.map((t) => t.id));
+  const allKnownToastIds = useRef<Set<string>>(
+    new Set(toasts.map((t) => t.id)),
+  );
+  const [isHovered, setIsHovered] = useState(false);
+
+  useEffect(() => {
+    return toastManager.subscribeHover(setIsHovered);
+  }, []);
+
+  useEffect(() => {
+    const currentIds = visibleToasts.map((t) => t.id);
+    const hasNewToast = currentIds.some(
+      (id) => !allKnownToastIds.current.has(id),
+    );
+
+    if (hasNewToast && isHovered) {
+      // Brand new toast arrived while expanded - collapse momentarily
+      toastManager.setHovered(false);
+      setTimeout(() => {
+        toastManager.setHovered(true);
+      }, 700);
+    } else if (isHovered) {
+      toastManager.setHovered(true);
+      setTimeout(() => {
+        toastManager.setHovered(true);
+      }, 700);
+    }
+
+    // Update known toast IDs
+    toasts.forEach((t) => allKnownToastIds.current.add(t.id));
+    prevToastIds.current = currentIds;
+  }, [visibleToasts, isHovered, toasts]);
+
+  const setHovered = (value: boolean) => toastManager.setHovered(value);
+
+  const pan = Gesture.Pan()
+    .onUpdate((event) => {
+      const velocity = isTop ? -event.velocityY : event.velocityY;
+      if (velocity > 500) {
+        runOnJS(setHovered)(true);
+      } else if (velocity < -500) {
+        runOnJS(setHovered)(false);
+      }
+    })
+    .onEnd((event) => {
+      const translationY = isTop ? -event.translationY : event.translationY;
+      if (translationY > 50) {
+        runOnJS(setHovered)(true);
+      } else if (translationY < -50) {
+        runOnJS(setHovered)(false);
+      }
+    });
+
   const gesture =
     Platform.OS === "web"
       ? Gesture.Hover()
           .onStart(() => {
-            runOnJS(toastManager.setHovered)(true);
+            runOnJS(setHovered)(true);
           })
           .onEnd(() => {
-            runOnJS(toastManager.setHovered)(false);
+            runOnJS(setHovered)(false);
           })
-      : Gesture.LongPress()
-          .onStart(() => {
-            runOnJS(toastManager.setHovered)(true);
-          })
-          .onEnd(() => {
-            runOnJS(toastManager.setHovered)(false);
-          });
+      : pan;
 
-  const containerPosition: ViewStyle = isDesktop
-    ? {
-        bottom: theme.spacing[4],
-        right: theme.spacing[4],
-        alignItems: "flex-end",
-        minWidth: 400,
-        width: 400,
-      }
-    : {
-        bottom: insets.bottom + theme.spacing[1],
-        left: 0,
-        right: 0,
-        alignItems: "center",
-        width: "100%",
-      };
+  const getPositionStyle = (): ViewStyle => {
+    const resolvedPosition =
+      position === "auto"
+        ? isDesktop
+          ? "bottom-right"
+          : "top-center"
+        : position;
+
+    const styles: ViewStyle = {
+      position: "absolute",
+      zIndex: 1000,
+      width: isDesktop ? 400 : "100%",
+      paddingHorizontal: isDesktop ? 0 : theme.spacing[4],
+    };
+
+    if (resolvedPosition.includes("top")) {
+      styles.top = insets.top + theme.spacing[4];
+    }
+    if (resolvedPosition.includes("bottom")) {
+      styles.bottom = insets.bottom + theme.spacing[4];
+    }
+    if (resolvedPosition.includes("left")) {
+      styles.left = insets.left + theme.spacing[4];
+      styles.alignItems = "flex-start";
+    }
+    if (resolvedPosition.includes("right")) {
+      styles.right = insets.right + theme.spacing[4];
+      styles.alignItems = "flex-end";
+    }
+    if (resolvedPosition.includes("center")) {
+      styles.left = 0;
+      styles.right = 0;
+      styles.alignItems = "center";
+    }
+
+    return styles;
+  };
 
   return (
     <Portal name="toasties">
       <GestureDetector gesture={gesture}>
-        <View style={[styles.providerContainer, containerPosition]}>
-          {toasts
-            .slice(-4)
-            .reverse()
-            .map((toastState, index) => (
-              <Toast
-                key={toastState.id}
-                open={toastState.open}
-                onOpenChange={(open) => {
-                  if (!open) toastManager.hide(toastState.id);
-                }}
-                title={toastState.title}
-                description={toastState.description}
-                actionLabel={toastState.actionLabel}
-                onAction={toastState.onAction}
-                duration={toastState.duration}
-                index={index}
-                isLatest={index === 0}
-                totalToasts={toasts.length}
-                variant={toastState.variant}
-                render={toastState.render}
-              />
-            ))}
+        <View style={getPositionStyle()}>
+          {visibleToasts.reverse().map((toastState, index) => (
+            <Toast
+              key={toastState.id}
+              {...toastState}
+              onOpenChange={(open) => {
+                if (!open) toastManager.hide(toastState.id);
+              }}
+              index={index}
+              isLatest={index === 0}
+              totalToasts={toasts.length}
+              position={
+                position === "auto"
+                  ? isDesktop
+                    ? "bottom-right"
+                    : "top-center"
+                  : position
+              }
+            />
+          ))}
         </View>
       </GestureDetector>
     </Portal>
   );
 }
 
-type ToastProps = {
+export function AndMore({ more }: { more: number }) {
+  const { theme } = useTheme();
+  return (
+    <View
+      style={{
+        padding: theme.spacing[2],
+        paddingHorizontal: theme.spacing[4],
+        backgroundColor: theme.colors.muted,
+        borderRadius: theme.borderRadius.xl,
+        marginTop: theme.spacing[2],
+        alignSelf: "center",
+      }}
+    >
+      <Text size="sm" style={{ color: theme.colors.mutedForeground }}>
+        and {more} more notification
+        {more === 1 ? "" : "s"}
+      </Text>
+    </View>
+  );
+}
+
+type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+type ToastProps = PartialBy<Omit<ToastState, "id" | "open">, "position"> & {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  title?: string;
-  description?: string;
-  actionLabel?: string;
-  onAction?: () => void;
-  duration?: number;
   index?: number;
   isLatest?: boolean;
   totalToasts?: number;
-  variant?: "default" | "success" | "error" | "info";
-  render?: (props: {
-    close: () => void;
-    action?: () => void;
-  }) => React.ReactNode;
 };
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
@@ -300,6 +429,7 @@ export function Toast({
   totalToasts = 0,
   variant = "default",
   render,
+  position = "auto",
 }: ToastProps) {
   const [isHovered, setIsHovered] = useState(false);
   const progress = useSharedValue(1);
@@ -311,7 +441,11 @@ export function Toast({
   const { width } = useWindowDimensions();
   const isDesktop = isWeb && width >= 768;
 
-  const RADIUS = 8;
+  const { top, bottom } = useSafeAreaInsets();
+
+  const isTop = position.includes("top");
+
+  const RADIUS = 12;
   const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
   const animatedCircleProps = useAnimatedProps(() => {
@@ -321,7 +455,7 @@ export function Toast({
   });
 
   const opacity = useSharedValue(0);
-  const translateY = useSharedValue(100);
+  const translateY = useSharedValue(isTop ? -100 : 100);
   const scale = useSharedValue(1 - index * 0.05);
 
   useEffect(() => {
@@ -339,14 +473,14 @@ export function Toast({
     if (!open) {
       // Close animation
       opacity.value = withTiming(0, { duration: 250 });
-      translateY.value = withTiming(100, { duration: 250 });
+      translateY.value = withTiming(isTop ? -100 : 100, { duration: 250 });
       return;
     }
 
     if (isHovered) {
       // Stack vertically with proper spacing when hovered
-      const spacing = height + 20; // Height of each toast + gap
-      translateY.value = withTiming(-index * spacing, {
+      const spacing = height + 8; // Height of each toast + gap
+      translateY.value = withTiming((isTop ? index : -index) * spacing, {
         duration: 750,
         easing: Easing.out(Easing.exp),
       });
@@ -360,7 +494,7 @@ export function Toast({
       });
     } else {
       // Compact stacked view when not hovered
-      translateY.value = withTiming(-index * 15, {
+      translateY.value = withTiming((isTop ? index : -index) * 15, {
         duration: 750,
         easing: Easing.out(Easing.exp),
       });
@@ -368,7 +502,7 @@ export function Toast({
         duration: 750,
         easing: Easing.out(Easing.exp),
       });
-      opacity.value = withTiming(isLatest ? 1 : 0.8, {
+      opacity.value = withTiming(isLatest ? 1 : 0.95, {
         duration: 750,
         easing: Easing.out(Easing.exp),
       });
@@ -406,7 +540,11 @@ export function Toast({
   const animatedStyle = useAnimatedStyle(() => {
     return {
       opacity: opacity.value,
-      transform: [{ translateY: translateY.value }, { scale: scale.value }],
+      transform: [
+        // +22 is to get it just below the header
+        { translateY: translateY.value + (isTop ? top / 2 : -bottom) },
+        { scale: scale.value },
+      ],
       zIndex: 1000 - index,
     };
   });
@@ -430,10 +568,20 @@ export function Toast({
     },
   };
 
+  const buttonTypeMap = {
+    default: "primary",
+    success: "success",
+    error: "primary",
+    info: "secondary",
+  } as const;
+
   return (
     <Animated.View
       onLayout={(l) => setHeight(l.nativeEvent.layout.height)}
-      style={[styles.container, animatedStyle]}
+      style={[
+        isTop ? styles.containerTop : styles.containerBottom,
+        animatedStyle,
+      ]}
     >
       <View
         style={[
@@ -462,23 +610,9 @@ export function Toast({
                 gap: theme.spacing[4],
               }}
             >
-              <View style={{ flex: 1, gap: theme.spacing[1] }}>
-                <Text
-                  style={{
-                    color: theme.colors.foreground,
-                    fontSize: 16,
-                    fontWeight: "500",
-                  }}
-                >
-                  {title}
-                </Text>
-                {description ? (
-                  <Text
-                    style={{ color: theme.colors.foreground, fontSize: 14 }}
-                  >
-                    {description}
-                  </Text>
-                ) : null}
+              <View>
+                <Text size="lg">{title}</Text>
+                {description ? <Text>{description}</Text> : null}
               </View>
               {isLatest && duration > 0 ? (
                 <Pressable
@@ -488,14 +622,18 @@ export function Toast({
                     justifyContent: "center",
                   }}
                 >
-                  <Svg width="24" height="24" viewBox="0 0 24 24">
+                  <Svg
+                    width={RADIUS * 2}
+                    height={RADIUS * 2}
+                    viewBox={`0 0 ${RADIUS * 2 + 2} ${RADIUS * 2 + 2}`}
+                  >
                     <AnimatedCircle
                       stroke={theme.colors.border}
                       fill="transparent"
                       strokeWidth="2"
                       r={RADIUS}
-                      cx="12"
-                      cy="12"
+                      cx={RADIUS + 1}
+                      cy={RADIUS + 1}
                     />
                     <AnimatedCircle
                       animatedProps={animatedCircleProps}
@@ -504,11 +642,11 @@ export function Toast({
                       strokeWidth="2"
                       strokeDasharray={CIRCUMFERENCE}
                       r={RADIUS}
-                      cx="12"
-                      cy="12"
+                      cx={RADIUS + 1}
+                      cy={RADIUS + 1}
                       rotation="-90"
-                      originX="12"
-                      originY="12"
+                      originX={RADIUS + 1}
+                      originY={RADIUS + 1}
                       strokeLinecap="round"
                     />
                   </Svg>
@@ -538,7 +676,7 @@ export function Toast({
                   </Svg>
                   {!onAction && (
                     <View style={{ position: "absolute" }}>
-                      <X color={theme.colors.foreground} size={12} />
+                      <X color="white" size={12} />
                     </View>
                   )}
                 </Pressable>
@@ -553,34 +691,14 @@ export function Toast({
                   width: "100%",
                 }}
               >
-                <Pressable
-                  style={[
-                    styles.button,
-                    {
-                      borderColor: theme.colors.primary,
-                      paddingHorizontal: theme.spacing[4],
-                      paddingVertical: theme.spacing[2],
-                    },
-                  ]}
-                  onPress={onAction}
-                >
+                <Button variant={buttonTypeMap[variant]} onPress={onAction}>
                   <Text style={{ color: theme.colors.foreground }}>
                     {actionLabel}
                   </Text>
-                </Pressable>
-                <Pressable
-                  style={[
-                    styles.button,
-                    {
-                      borderColor: theme.colors.primary,
-                      paddingHorizontal: theme.spacing[4],
-                      paddingVertical: theme.spacing[2],
-                    },
-                  ]}
-                  onPress={() => onOpenChange(false)}
-                >
+                </Button>
+                <Button variant="secondary" onPress={() => onOpenChange(false)}>
                   <Text style={{ color: theme.colors.foreground }}>Close</Text>
-                </Pressable>
+                </Button>
               </View>
             )}
           </>
@@ -595,15 +713,22 @@ const styles = StyleSheet.create({
     position: "absolute",
     zIndex: 1000,
   },
-  container: {
+  containerBottom: {
     position: "absolute",
     bottom: 0,
     left: 0,
     right: 0,
     alignItems: "center",
   },
+  containerTop: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    alignItems: "center",
+  },
   toast: {
-    opacity: 0.95,
+    opacity: 0.99,
     borderWidth: 1,
     gap: 8,
   },

--- a/js/components/src/components/ui/toast.tsx
+++ b/js/components/src/components/ui/toast.tsx
@@ -1,4 +1,5 @@
 import { Portal } from "@rn-primitives/portal";
+import { X } from "lucide-react-native";
 import { useEffect, useRef, useState } from "react";
 import {
   Platform,
@@ -8,14 +9,18 @@ import {
   View,
   ViewStyle,
 } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
+  cancelAnimation,
   Easing,
   runOnJS,
+  useAnimatedProps,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Circle, Svg } from "react-native-svg";
 import { useTheme } from "../../ui";
 import { Text } from "./text";
 
@@ -42,7 +47,7 @@ type ToastState = {
 class ToastManager {
   private listeners: Set<(state: ToastState[]) => void> = new Set();
   private toasts: ToastState[] = [];
-  private timeoutIds: Map<string, ReturnType<typeof setTimeout>> = new Map();
+
   private hoverListeners: Set<(isHovered: boolean) => void> = new Set();
   private isHovered: boolean = false;
 
@@ -60,13 +65,6 @@ class ToastManager {
 
     this.toasts = [...this.toasts, toast];
     this.notifyListeners();
-
-    if (toast.duration > 0) {
-      const timeoutId = setTimeout(() => {
-        this.hide(toast.id);
-      }, toast.duration * 1000);
-      this.timeoutIds.set(toast.id, timeoutId);
-    }
   }
 
   getToasts() {
@@ -78,12 +76,6 @@ class ToastManager {
       toast.id === id ? { ...toast, open: false } : toast,
     );
     this.notifyListeners();
-
-    const timeoutId = this.timeoutIds.get(id);
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-      this.timeoutIds.delete(id);
-    }
 
     setTimeout(() => {
       this.toasts = this.toasts.filter((toast) => toast.id !== id);
@@ -165,123 +157,32 @@ export function useToast() {
 
 export function ToastProvider() {
   const [toasts, setToasts] = useState<ToastState[]>([]);
-
-  useEffect(() => {
-    return toastManager.subscribe(setToasts);
-  }, []);
-
-  return (
-    <>
-      {toasts
-        .slice(-4)
-        .reverse()
-        .map((toastState, index) => (
-          <Toast
-            key={toastState.id}
-            open={toastState.open}
-            onOpenChange={(open) => {
-              if (!open) toastManager.hide(toastState.id);
-            }}
-            title={toastState.title}
-            description={toastState.description}
-            actionLabel={toastState.actionLabel}
-            onAction={toastState.onAction}
-            duration={toastState.duration}
-            index={index}
-            isLatest={index === 0}
-            totalToasts={toasts.length}
-            variant={toastState.variant}
-          />
-        ))}
-    </>
-  );
-}
-
-type ToastProps = {
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
-  title?: string;
-  description?: string;
-  actionLabel?: string;
-  onAction?: () => void;
-  duration?: number;
-  index?: number;
-  isLatest?: boolean;
-  totalToasts?: number;
-  variant?: "default" | "success" | "error" | "info";
-};
-
-export function Toast({
-  open = false,
-  onOpenChange = () => {},
-  title = "",
-  description,
-  actionLabel = "Action",
-  onAction,
-  duration = 60,
-  index = 0,
-  isLatest = true,
-  totalToasts = 0,
-  variant = "default",
-}: ToastProps) {
-  const [seconds, setSeconds] = useState(duration);
-  const [isHovered, setIsHovered] = useState(false);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const [height, setHeight] = useState(100);
   const insets = useSafeAreaInsets();
   const { theme } = useTheme();
   const isWeb = Platform.OS === "web";
   const { width } = useWindowDimensions();
   const isDesktop = isWeb && width >= 768;
 
-  const opacity = useSharedValue(0);
-  const translateY = useSharedValue(100);
-  const scale = useSharedValue(1 - index * 0.05);
-
   useEffect(() => {
-    return toastManager.subscribeHover(setIsHovered);
+    return toastManager.subscribe(setToasts);
   }, []);
 
-  useEffect(() => {
-    if (isHovered) {
-      // Stack vertically with proper spacing when hovered
-      const spacing = height + 20; // Height of each toast + gap
-      translateY.value = withTiming(-index * spacing, {
-        duration: 300,
-        easing: Easing.out(Easing.exp),
-      });
-      scale.value = withTiming(1, {
-        duration: 300,
-        easing: Easing.out(Easing.exp),
-      });
-      opacity.value = withTiming(1, {
-        duration: 300,
-        easing: Easing.out(Easing.exp),
-      });
-    } else {
-      // Compact stacked view when not hovered
-      translateY.value = withTiming(index * 10, {
-        duration: 300,
-        easing: Easing.out(Easing.exp),
-      });
-      scale.value = withTiming(1 - index * 0.05, {
-        duration: 300,
-        easing: Easing.out(Easing.exp),
-      });
-      opacity.value = withTiming(isLatest ? 1 : 0.8, {
-        duration: 300,
-        easing: Easing.out(Easing.exp),
-      });
-    }
-  }, [isHovered, index, isLatest]);
-
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      opacity: opacity.value,
-      transform: [{ translateY: translateY.value }, { scale: scale.value }],
-      zIndex: 1000 - index,
-    };
-  });
+  const gesture =
+    Platform.OS === "web"
+      ? Gesture.Hover()
+          .onStart(() => {
+            runOnJS(toastManager.setHovered)(true);
+          })
+          .onEnd(() => {
+            runOnJS(toastManager.setHovered)(false);
+          })
+      : Gesture.LongPress()
+          .onStart(() => {
+            runOnJS(toastManager.setHovered)(true);
+          })
+          .onEnd(() => {
+            runOnJS(toastManager.setHovered)(false);
+          });
 
   const containerPosition: ViewStyle = isDesktop
     ? {
@@ -299,58 +200,175 @@ export function Toast({
         width: "100%",
       };
 
+  return (
+    <Portal name="toasties">
+      <GestureDetector gesture={gesture}>
+        <View style={[styles.providerContainer, containerPosition]}>
+          {toasts
+            .slice(-4)
+            .reverse()
+            .map((toastState, index) => (
+              <Toast
+                key={toastState.id}
+                open={toastState.open}
+                onOpenChange={(open) => {
+                  if (!open) toastManager.hide(toastState.id);
+                }}
+                title={toastState.title}
+                description={toastState.description}
+                actionLabel={toastState.actionLabel}
+                onAction={toastState.onAction}
+                duration={toastState.duration}
+                index={index}
+                isLatest={index === 0}
+                totalToasts={toasts.length}
+                variant={toastState.variant}
+              />
+            ))}
+        </View>
+      </GestureDetector>
+    </Portal>
+  );
+}
+
+type ToastProps = {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  title?: string;
+  description?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  duration?: number;
+  index?: number;
+  isLatest?: boolean;
+  totalToasts?: number;
+  variant?: "default" | "success" | "error" | "info";
+};
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+
+export function Toast({
+  open = false,
+  onOpenChange = () => {},
+  title = "",
+  description,
+  actionLabel = "Action",
+  onAction,
+  duration = 60,
+  index = 0,
+  isLatest = true,
+  totalToasts = 0,
+  variant = "default",
+}: ToastProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const progress = useSharedValue(1);
+  const remainingTime = useSharedValue(duration * 1000);
+  const wasOpen = useRef(open);
+  const [height, setHeight] = useState(100);
+  const { theme } = useTheme();
+  const isWeb = Platform.OS === "web";
+  const { width } = useWindowDimensions();
+  const isDesktop = isWeb && width >= 768;
+
+  const RADIUS = 8;
+  const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+  const animatedCircleProps = useAnimatedProps(() => {
+    return {
+      strokeDashoffset: CIRCUMFERENCE * (1 - progress.value),
+    };
+  });
+
+  const opacity = useSharedValue(0);
+  const translateY = useSharedValue(100);
+  const scale = useSharedValue(1 - index * 0.05);
+
   useEffect(() => {
-    if (open && !isHovered) {
-      // Start or resume the timer
-      intervalRef.current = setInterval(() => {
-        setSeconds((prev) => {
-          if (prev <= 1) {
-            runOnJS(onOpenChange)(false);
-            if (intervalRef.current) clearInterval(intervalRef.current);
-            return duration;
-          }
-          return prev - 1;
-        });
-      }, 1000);
-    } else {
-      // Pause timer when hovered or not open
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
+    return toastManager.subscribeHover(setIsHovered);
+  }, []);
+
+  useEffect(() => {
+    if (open && !wasOpen.current) {
+      // Toast just opened
+      progress.value = 1;
+      remainingTime.value = duration * 1000;
     }
+    wasOpen.current = open;
 
     if (!open) {
-      opacity.value = withTiming(0, { duration: 150 });
-      translateY.value = withTiming(100, { duration: 150 });
+      // Close animation
+      opacity.value = withTiming(0, { duration: 250 });
+      translateY.value = withTiming(100, { duration: 250 });
+      return;
+    }
+
+    if (isHovered) {
+      // Stack vertically with proper spacing when hovered
+      const spacing = height + 20; // Height of each toast + gap
+      translateY.value = withTiming(-index * spacing, {
+        duration: 750,
+        easing: Easing.out(Easing.exp),
+      });
+      scale.value = withTiming(1, {
+        duration: 750,
+        easing: Easing.out(Easing.exp),
+      });
+      opacity.value = withTiming(1, {
+        duration: 750,
+        easing: Easing.out(Easing.exp),
+      });
+    } else {
+      // Compact stacked view when not hovered
+      translateY.value = withTiming(-index * 15, {
+        duration: 750,
+        easing: Easing.out(Easing.exp),
+      });
+      scale.value = withTiming(1 - index * 0.1, {
+        duration: 750,
+        easing: Easing.out(Easing.exp),
+      });
+      opacity.value = withTiming(isLatest ? 1 : 0.8, {
+        duration: 750,
+        easing: Easing.out(Easing.exp),
+      });
+    }
+  }, [open, isHovered, index, isLatest, height, duration]);
+
+  useEffect(() => {
+    if (open && isLatest && duration > 0) {
+      if (isHovered) {
+        cancelAnimation(progress);
+        remainingTime.value = progress.value * duration * 1000;
+      } else {
+        progress.value = withTiming(
+          0,
+          {
+            duration: remainingTime.value,
+            easing: Easing.linear,
+          },
+          (finished) => {
+            if (finished) {
+              runOnJS(onOpenChange)(false);
+            }
+          },
+        );
+      }
+    } else {
+      cancelAnimation(progress);
     }
 
     return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
+      cancelAnimation(progress);
     };
-  }, [open, isHovered]);
+  }, [open, isLatest, isHovered, duration]);
 
-  useEffect(() => {
-    if (open) {
-      setSeconds(duration);
-
-      opacity.value = withTiming(isLatest ? 1 : 0.8, {
-        duration: 200,
-        easing: Easing.out(Easing.exp),
-      });
-      translateY.value = withTiming(index * 10, {
-        duration: 200,
-        easing: Easing.out(Easing.exp),
-      });
-      scale.value = withTiming(1 - index * 0.05, {
-        duration: 250,
-        easing: Easing.out(Easing.exp),
-      });
-    }
-  }, [open, duration, index]);
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      opacity: opacity.value,
+      transform: [{ translateY: translateY.value }, { scale: scale.value }],
+      zIndex: 1000 - index,
+    };
+  });
 
   const variantStyles = {
     default: {
@@ -372,28 +390,34 @@ export function Toast({
   };
 
   return (
-    <Portal name={`toast-${index}`}>
-      <Animated.View
-        onLayout={(l) => setHeight(l.nativeEvent.layout.height)}
-        style={[styles.container, containerPosition, animatedStyle]}
+    <Animated.View
+      onLayout={(l) => setHeight(l.nativeEvent.layout.height)}
+      style={[styles.container, animatedStyle]}
+    >
+      <View
+        style={[
+          styles.toast,
+          {
+            borderRadius: theme.borderRadius.xl,
+            flexDirection: "column",
+            justifyContent: "space-between",
+            alignItems: "center",
+            padding: theme.spacing[4],
+            width: isDesktop ? "100%" : "95%",
+          },
+          variantStyles[variant],
+        ]}
       >
-        <Pressable
-          onHoverIn={() => isWeb && toastManager.setHovered(true)}
-          onHoverOut={() => isWeb && toastManager.setHovered(false)}
-          style={[
-            styles.toast,
-            {
-              borderRadius: theme.borderRadius.xl,
-              flexDirection: "column",
-              justifyContent: "space-between",
-              alignItems: "center",
-              padding: theme.spacing[4],
-              width: isDesktop ? "100%" : "95%",
-            },
-            variantStyles[variant],
-          ]}
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            width: "100%",
+            gap: theme.spacing[4],
+          }}
         >
-          <View style={{ gap: theme.spacing[1], width: "100%" }}>
+          <View style={{ flex: 1, gap: theme.spacing[1] }}>
             <Text
               style={{
                 color: theme.colors.foreground,
@@ -409,7 +433,71 @@ export function Toast({
               </Text>
             ) : null}
           </View>
-
+          {isLatest && duration > 0 ? (
+            <Pressable
+              onPress={() => onOpenChange(false)}
+              style={{
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Svg width="24" height="24" viewBox="0 0 24 24">
+                <AnimatedCircle
+                  stroke={theme.colors.border}
+                  fill="transparent"
+                  strokeWidth="2"
+                  r={RADIUS}
+                  cx="12"
+                  cy="12"
+                />
+                <AnimatedCircle
+                  animatedProps={animatedCircleProps}
+                  stroke={theme.colors.primary}
+                  fill="transparent"
+                  strokeWidth="2"
+                  strokeDasharray={CIRCUMFERENCE}
+                  r={RADIUS}
+                  cx="12"
+                  cy="12"
+                  rotation="-90"
+                  originX="12"
+                  originY="12"
+                  strokeLinecap="round"
+                />
+              </Svg>
+              {!onAction && (
+                <View style={{ position: "absolute" }}>
+                  <X color={theme.colors.foreground} size={12} />
+                </View>
+              )}
+            </Pressable>
+          ) : (
+            <Pressable
+              onPress={() => onOpenChange(false)}
+              style={{
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <Svg width="24" height="24" viewBox="0 0 24 24">
+                <AnimatedCircle
+                  stroke={theme.colors.border}
+                  fill={theme.colors.muted}
+                  strokeWidth="2"
+                  r={RADIUS}
+                  cx="12"
+                  cy="12"
+                />
+              </Svg>
+              {!onAction && (
+                <View style={{ position: "absolute" }}>
+                  <X color={theme.colors.foreground} size={12} />
+                </View>
+              )}
+            </Pressable>
+          )}
+        </View>
+        {onAction && (
           <View
             style={{
               gap: theme.spacing[1],
@@ -418,23 +506,21 @@ export function Toast({
               width: "100%",
             }}
           >
-            {onAction && (
-              <Pressable
-                style={[
-                  styles.button,
-                  {
-                    borderColor: theme.colors.primary,
-                    paddingHorizontal: theme.spacing[4],
-                    paddingVertical: theme.spacing[2],
-                  },
-                ]}
-                onPress={onAction}
-              >
-                <Text style={{ color: theme.colors.foreground }}>
-                  {actionLabel}
-                </Text>
-              </Pressable>
-            )}
+            <Pressable
+              style={[
+                styles.button,
+                {
+                  borderColor: theme.colors.primary,
+                  paddingHorizontal: theme.spacing[4],
+                  paddingVertical: theme.spacing[2],
+                },
+              ]}
+              onPress={onAction}
+            >
+              <Text style={{ color: theme.colors.foreground }}>
+                {actionLabel}
+              </Text>
+            </Pressable>
             <Pressable
               style={[
                 styles.button,
@@ -449,17 +535,23 @@ export function Toast({
               <Text style={{ color: theme.colors.foreground }}>Close</Text>
             </Pressable>
           </View>
-        </Pressable>
-      </Animated.View>
-    </Portal>
+        )}
+      </View>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  providerContainer: {
     position: "absolute",
     zIndex: 1000,
-    paddingHorizontal: 16,
+  },
+  container: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    alignItems: "center",
   },
   toast: {
     opacity: 0.95,

--- a/js/components/src/components/ui/toast.tsx
+++ b/js/components/src/components/ui/toast.tsx
@@ -351,9 +351,16 @@ function ToastContainer({
     const styles: ViewStyle = {
       position: "absolute",
       zIndex: 1000,
-      width: isDesktop ? 400 : "100%",
       paddingHorizontal: isDesktop ? 0 : theme.spacing[4],
     };
+
+    // Set width/maxWidth
+    if (isDesktop) {
+      styles.width = 400;
+    } else {
+      styles.width = "100%";
+      styles.maxWidth = 400;
+    }
 
     if (resolvedPosition.includes("top")) {
       styles.top = insets.top + theme.spacing[4];
@@ -370,9 +377,15 @@ function ToastContainer({
       styles.alignItems = "flex-end";
     }
     if (resolvedPosition.includes("center")) {
-      styles.left = 0;
-      styles.right = 0;
       styles.alignItems = "center";
+      // Center the container itself when it has maxWidth
+      if (!isDesktop) {
+        styles.left = "50%";
+        styles.transform = [{ translateX: "-50%" }];
+      } else {
+        styles.left = 0;
+        styles.right = 0;
+      }
     }
 
     return styles;
@@ -790,7 +803,7 @@ export function Toast({
               justifyContent: "space-between",
               alignItems: "center",
               padding: theme.spacing[4],
-              width: isDesktop ? "100%" : "95%",
+              width: "100%",
             },
             variantStyles[variant],
           ]}

--- a/js/components/src/components/ui/toast.tsx
+++ b/js/components/src/components/ui/toast.tsx
@@ -30,6 +30,7 @@ type ToastConfig = {
   duration?: number;
   actionLabel?: string;
   onAction?: () => void;
+  onClose?: () => void;
   variant?: "default" | "success" | "error" | "info";
 };
 
@@ -41,6 +42,7 @@ type ToastState = {
   duration: number;
   actionLabel?: string;
   onAction?: () => void;
+  onClose?: () => void;
   variant?: "default" | "success" | "error" | "info";
 };
 
@@ -60,6 +62,7 @@ class ToastManager {
       duration: config.duration ?? 3,
       actionLabel: config.actionLabel,
       onAction: config.onAction,
+      onClose: config.onClose,
       variant: config.variant ?? "default",
     };
 
@@ -72,6 +75,10 @@ class ToastManager {
   }
 
   hide(id: string) {
+    const toast = this.toasts.find((t) => t.id === id);
+    if (toast?.onClose) {
+      toast.onClose();
+    }
     this.toasts = this.toasts.map((toast) =>
       toast.id === id ? { ...toast, open: false } : toast,
     );
@@ -121,6 +128,7 @@ export const toast = {
       duration?: number;
       actionLabel?: string;
       onAction?: () => void;
+      onClose?: () => void;
       variant?: "default" | "success" | "error" | "info";
     },
   ) => {

--- a/js/components/src/components/ui/toast.tsx
+++ b/js/components/src/components/ui/toast.tsx
@@ -69,6 +69,7 @@ type ToastState = {
 class ToastManager {
   private listeners: Set<(state: ToastState[]) => void> = new Set();
   private toasts: ToastState[] = [];
+  private toastHeights: Map<string, number> = new Map();
 
   private hoverListeners: Set<(isHovered: boolean) => void> = new Set();
   private isHovered: boolean = false;
@@ -129,6 +130,14 @@ class ToastManager {
   setHovered(hovered: boolean) {
     this.isHovered = hovered;
     this.notifyHoverListeners();
+  }
+
+  updateToastHeight(id: string, height: number) {
+    this.toastHeights.set(id, height);
+  }
+
+  getToastHeight(id: string): number {
+    return this.toastHeights.get(id) || 100; // Default fallback height
   }
 
   private notifyListeners() {
@@ -367,7 +376,6 @@ function ToastContainer({
               }}
               index={index}
               isLatest={index === 0}
-              totalToasts={toasts.length}
               position={
                 position === "auto"
                   ? isDesktop
@@ -407,11 +415,11 @@ export function AndMore({ more }: { more: number }) {
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 type ToastProps = PartialBy<Omit<ToastState, "id" | "open">, "position"> & {
+  id?: string;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   index?: number;
   isLatest?: boolean;
-  totalToasts?: number;
 };
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
@@ -426,16 +434,16 @@ export function Toast({
   duration = 60,
   index = 0,
   isLatest = true,
-  totalToasts = 0,
   variant = "default",
   render,
   position = "auto",
+  id,
 }: ToastProps) {
   const [isHovered, setIsHovered] = useState(false);
   const progress = useSharedValue(1);
   const remainingTime = useSharedValue(duration * 1000);
   const wasOpen = useRef(open);
-  const [height, setHeight] = useState(100);
+  const [measuredHeight, setMeasuredHeight] = useState(100);
   const { theme } = useTheme();
   const isWeb = Platform.OS === "web";
   const { width } = useWindowDimensions();
@@ -479,11 +487,22 @@ export function Toast({
 
     if (isHovered) {
       // Stack vertically with proper spacing when hovered
-      const spacing = height + 8; // Height of each toast + gap
-      translateY.value = withTiming((isTop ? index : -index) * spacing, {
-        duration: 750,
-        easing: Easing.out(Easing.exp),
-      });
+      // Calculate cumulative height of all toasts before this one
+      let cumulativeHeight = 0;
+      const allToasts = toastManager.getToasts().slice(-4).reverse(); // Get visible toasts in same order as rendered
+      for (let i = 0; i < index; i++) {
+        if (allToasts[i]) {
+          cumulativeHeight += toastManager.getToastHeight(allToasts[i].id) + 8; // height + gap
+        }
+      }
+
+      translateY.value = withTiming(
+        isTop ? cumulativeHeight : -cumulativeHeight,
+        {
+          duration: 750,
+          easing: Easing.out(Easing.exp),
+        },
+      );
       scale.value = withTiming(1, {
         duration: 750,
         easing: Easing.out(Easing.exp),
@@ -507,7 +526,7 @@ export function Toast({
         easing: Easing.out(Easing.exp),
       });
     }
-  }, [open, isHovered, index, isLatest, height, duration]);
+  }, [open, isHovered, index, isLatest, measuredHeight, duration, id]);
 
   useEffect(() => {
     if (open && isLatest && duration > 0) {
@@ -577,7 +596,13 @@ export function Toast({
 
   return (
     <Animated.View
-      onLayout={(l) => setHeight(l.nativeEvent.layout.height)}
+      onLayout={(l) => {
+        const height = l.nativeEvent.layout.height;
+        setMeasuredHeight(height);
+        if (id) {
+          toastManager.updateToastHeight(id, height);
+        }
+      }}
       style={[
         isTop ? styles.containerTop : styles.containerBottom,
         animatedStyle,
@@ -610,7 +635,7 @@ export function Toast({
                 gap: theme.spacing[4],
               }}
             >
-              <View>
+              <View style={{ flex: 1 }}>
                 <Text size="lg">{title}</Text>
                 {description ? <Text>{description}</Text> : null}
               </View>
@@ -667,7 +692,7 @@ export function Toast({
                   <Svg width="24" height="24" viewBox="0 0 24 24">
                     <AnimatedCircle
                       stroke={theme.colors.border}
-                      fill={theme.colors.muted}
+                      fill="transparent"
                       strokeWidth="2"
                       r={RADIUS}
                       cx="12"

--- a/js/components/src/components/ui/toast.tsx
+++ b/js/components/src/components/ui/toast.tsx
@@ -439,6 +439,68 @@ type ToastProps = PartialBy<Omit<ToastState, "id" | "open">, "position"> & {
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
 
+function CloseButton({
+  onPress,
+  isLatest,
+  duration,
+  animatedCircleProps,
+  theme,
+  RADIUS,
+  CIRCUMFERENCE,
+}: {
+  onPress: () => void;
+  isLatest: boolean;
+  duration: number;
+  animatedCircleProps: any;
+  theme: any;
+  RADIUS: number;
+  CIRCUMFERENCE: number;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={{
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Svg
+        width={RADIUS * 2}
+        height={RADIUS * 2}
+        viewBox={`0 0 ${RADIUS * 2 + 2} ${RADIUS * 2 + 2}`}
+      >
+        <AnimatedCircle
+          stroke={theme.colors.border}
+          fill="transparent"
+          strokeWidth="2"
+          r={RADIUS}
+          cx={RADIUS + 1}
+          cy={RADIUS + 1}
+        />
+        {isLatest && duration > 0 && (
+          <AnimatedCircle
+            animatedProps={animatedCircleProps}
+            stroke={theme.colors.primary}
+            fill="transparent"
+            strokeWidth="2"
+            strokeDasharray={CIRCUMFERENCE}
+            r={RADIUS}
+            cx={RADIUS + 1}
+            cy={RADIUS + 1}
+            rotation="-90"
+            originX={RADIUS + 1}
+            originY={RADIUS + 1}
+            strokeLinecap="round"
+          />
+        )}
+      </Svg>
+      <View style={{ position: "absolute" }}>
+        <X color={theme.colors.foreground} size={12} />
+      </View>
+    </Pressable>
+  );
+}
+
 export function Toast({
   open = false,
   onOpenChange = () => {},
@@ -774,134 +836,26 @@ export function Toast({
                     <Pressable onPress={onToastPress}>
                       <FinalIconRight color={theme.colors.foreground} />
                     </Pressable>
-                    {isLatest && duration > 0 ? (
-                      <Pressable
-                        onPress={() => onOpenChange(false)}
-                        style={{
-                          alignItems: "center",
-                          justifyContent: "center",
-                        }}
-                      >
-                        <Svg
-                          width={RADIUS * 2}
-                          height={RADIUS * 2}
-                          viewBox={`0 0 ${RADIUS * 2 + 2} ${RADIUS * 2 + 2}`}
-                        >
-                          <AnimatedCircle
-                            stroke={theme.colors.border}
-                            fill="transparent"
-                            strokeWidth="2"
-                            r={RADIUS}
-                            cx={RADIUS + 1}
-                            cy={RADIUS + 1}
-                          />
-                          <AnimatedCircle
-                            animatedProps={animatedCircleProps}
-                            stroke={theme.colors.primary}
-                            fill="transparent"
-                            strokeWidth="2"
-                            strokeDasharray={CIRCUMFERENCE}
-                            r={RADIUS}
-                            cx={RADIUS + 1}
-                            cy={RADIUS + 1}
-                            rotation="-90"
-                            originX={RADIUS + 1}
-                            originY={RADIUS + 1}
-                            strokeLinecap="round"
-                          />
-                        </Svg>
-                        <View style={{ position: "absolute" }}>
-                          <X color={theme.colors.foreground} size={12} />
-                        </View>
-                      </Pressable>
-                    ) : (
-                      <Pressable
-                        onPress={() => onOpenChange(false)}
-                        style={{
-                          alignItems: "center",
-                          justifyContent: "center",
-                        }}
-                      >
-                        <Svg width="24" height="24" viewBox="0 0 24 24">
-                          <AnimatedCircle
-                            stroke={theme.colors.border}
-                            fill="transparent"
-                            strokeWidth="2"
-                            r={RADIUS}
-                            cx="12"
-                            cy="12"
-                          />
-                        </Svg>
-                        <View style={{ position: "absolute" }}>
-                          <X color="white" size={12} />
-                        </View>
-                      </Pressable>
-                    )}
+                    <CloseButton
+                      onPress={() => onOpenChange(false)}
+                      isLatest={isLatest}
+                      duration={duration}
+                      animatedCircleProps={animatedCircleProps}
+                      theme={theme}
+                      RADIUS={RADIUS}
+                      CIRCUMFERENCE={CIRCUMFERENCE}
+                    />
                   </View>
                 ) : !onAction ? (
-                  isLatest && duration > 0 ? (
-                    <Pressable
-                      onPress={() => onOpenChange(false)}
-                      style={{
-                        alignItems: "center",
-                        justifyContent: "center",
-                      }}
-                    >
-                      <Svg
-                        width={RADIUS * 2}
-                        height={RADIUS * 2}
-                        viewBox={`0 0 ${RADIUS * 2 + 2} ${RADIUS * 2 + 2}`}
-                      >
-                        <AnimatedCircle
-                          stroke={theme.colors.border}
-                          fill="transparent"
-                          strokeWidth="2"
-                          r={RADIUS}
-                          cx={RADIUS + 1}
-                          cy={RADIUS + 1}
-                        />
-                        <AnimatedCircle
-                          animatedProps={animatedCircleProps}
-                          stroke={theme.colors.primary}
-                          fill="transparent"
-                          strokeWidth="2"
-                          strokeDasharray={CIRCUMFERENCE}
-                          r={RADIUS}
-                          cx={RADIUS + 1}
-                          cy={RADIUS + 1}
-                          rotation="-90"
-                          originX={RADIUS + 1}
-                          originY={RADIUS + 1}
-                          strokeLinecap="round"
-                        />
-                      </Svg>
-                      <View style={{ position: "absolute" }}>
-                        <X color={theme.colors.foreground} size={12} />
-                      </View>
-                    </Pressable>
-                  ) : (
-                    <Pressable
-                      onPress={() => onOpenChange(false)}
-                      style={{
-                        alignItems: "center",
-                        justifyContent: "center",
-                      }}
-                    >
-                      <Svg width="24" height="24" viewBox="0 0 24 24">
-                        <AnimatedCircle
-                          stroke={theme.colors.border}
-                          fill="transparent"
-                          strokeWidth="2"
-                          r={RADIUS}
-                          cx="12"
-                          cy="12"
-                        />
-                      </Svg>
-                      <View style={{ position: "absolute" }}>
-                        <X color="white" size={12} />
-                      </View>
-                    </Pressable>
-                  )
+                  <CloseButton
+                    onPress={() => onOpenChange(false)}
+                    isLatest={isLatest}
+                    duration={duration}
+                    animatedCircleProps={animatedCircleProps}
+                    theme={theme}
+                    RADIUS={RADIUS}
+                    CIRCUMFERENCE={CIRCUMFERENCE}
+                  />
                 ) : null}
               </View>
               {onAction && (

--- a/js/components/src/components/ui/toast.tsx
+++ b/js/components/src/components/ui/toast.tsx
@@ -1,18 +1,23 @@
 import { Portal } from "@rn-primitives/portal";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
-  Animated,
   Platform,
   Pressable,
   StyleSheet,
-  Text,
   useWindowDimensions,
   View,
   ViewStyle,
 } from "react-native";
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-
 import { useTheme } from "../../ui";
+import { Text } from "./text";
 
 type ToastConfig = {
   title: string;
@@ -20,6 +25,7 @@ type ToastConfig = {
   duration?: number;
   actionLabel?: string;
   onAction?: () => void;
+  variant?: "default" | "success" | "error" | "info";
 };
 
 type ToastState = {
@@ -30,56 +36,86 @@ type ToastState = {
   duration: number;
   actionLabel?: string;
   onAction?: () => void;
+  variant?: "default" | "success" | "error" | "info";
 };
 
 class ToastManager {
-  private listeners: Set<(state: ToastState | null) => void> = new Set();
-  private currentToast: ToastState | null = null;
-  private timeoutId: ReturnType<typeof setTimeout> | null = null;
+  private listeners: Set<(state: ToastState[]) => void> = new Set();
+  private toasts: ToastState[] = [];
+  private timeoutIds: Map<string, ReturnType<typeof setTimeout>> = new Map();
+  private hoverListeners: Set<(isHovered: boolean) => void> = new Set();
+  private isHovered: boolean = false;
 
   show(config: ToastConfig) {
-    if (this.timeoutId) {
-      clearTimeout(this.timeoutId);
-    }
-
     const toast: ToastState = {
-      id: Math.random().toString(36).substr(2, 9),
+      id: Math.random().toString(36).slice(2, 12),
       open: true,
       title: config.title,
       description: config.description,
       duration: config.duration ?? 3,
       actionLabel: config.actionLabel,
       onAction: config.onAction,
+      variant: config.variant ?? "default",
     };
 
-    this.currentToast = toast;
+    this.toasts = [...this.toasts, toast];
     this.notifyListeners();
 
     if (toast.duration > 0) {
-      this.timeoutId = setTimeout(() => {
-        this.hide();
+      const timeoutId = setTimeout(() => {
+        this.hide(toast.id);
       }, toast.duration * 1000);
+      this.timeoutIds.set(toast.id, timeoutId);
     }
   }
 
-  hide() {
-    if (this.timeoutId) {
-      clearTimeout(this.timeoutId);
-      this.timeoutId = null;
-    }
-    this.currentToast = null;
+  getToasts() {
+    return this.toasts;
+  }
+
+  hide(id: string) {
+    this.toasts = this.toasts.map((toast) =>
+      toast.id === id ? { ...toast, open: false } : toast,
+    );
     this.notifyListeners();
+
+    const timeoutId = this.timeoutIds.get(id);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      this.timeoutIds.delete(id);
+    }
+
+    setTimeout(() => {
+      this.toasts = this.toasts.filter((toast) => toast.id !== id);
+      this.notifyListeners();
+    }, 500);
   }
 
-  subscribe(listener: (state: ToastState | null) => void) {
+  subscribe(listener: (state: ToastState[]) => void) {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
     };
   }
 
+  subscribeHover(listener: (isHovered: boolean) => void) {
+    this.hoverListeners.add(listener);
+    return () => {
+      this.hoverListeners.delete(listener);
+    };
+  }
+
+  setHovered(hovered: boolean) {
+    this.isHovered = hovered;
+    this.notifyHoverListeners();
+  }
+
   private notifyListeners() {
-    this.listeners.forEach((listener) => listener(this.currentToast));
+    this.listeners.forEach((listener) => listener(this.toasts));
+  }
+
+  private notifyHoverListeners() {
+    this.hoverListeners.forEach((listener) => listener(this.isHovered));
   }
 }
 
@@ -93,6 +129,7 @@ export const toast = {
       duration?: number;
       actionLabel?: string;
       onAction?: () => void;
+      variant?: "default" | "success" | "error" | "info";
     },
   ) => {
     toastManager.show({
@@ -101,82 +138,158 @@ export const toast = {
       ...options,
     });
   },
-  hide: () => toastManager.hide(),
+  hide: (id?: string) => {
+    if (id) {
+      toastManager.hide(id);
+    } else {
+      const toasts = toastManager.getToasts();
+      if (toasts.length > 0) {
+        toastManager.hide(toasts[toasts.length - 1].id);
+      }
+    }
+  },
 };
 
 export function useToast() {
-  const [toastState, setToastState] = useState<ToastState | null>(null);
+  const [toasts, setToasts] = useState<ToastState[]>([]);
 
   useEffect(() => {
-    return toastManager.subscribe(setToastState);
+    return toastManager.subscribe(setToasts);
   }, []);
 
   return {
-    toast: toastState,
+    toasts,
     ...toast,
   };
 }
 
 export function ToastProvider() {
-  const [toastState, setToastState] = useState<ToastState | null>(null);
+  const [toasts, setToasts] = useState<ToastState[]>([]);
 
   useEffect(() => {
-    return toastManager.subscribe(setToastState);
+    return toastManager.subscribe(setToasts);
   }, []);
 
-  if (!toastState?.open) return null;
-
   return (
-    <Toast
-      open={toastState.open}
-      onOpenChange={(open) => {
-        if (!open) toastManager.hide();
-      }}
-      title={toastState.title}
-      description={toastState.description}
-      actionLabel={toastState.actionLabel}
-      onAction={toastState.onAction}
-      duration={toastState.duration}
-    />
+    <>
+      {toasts
+        .slice(-4)
+        .reverse()
+        .map((toastState, index) => (
+          <Toast
+            key={toastState.id}
+            open={toastState.open}
+            onOpenChange={(open) => {
+              if (!open) toastManager.hide(toastState.id);
+            }}
+            title={toastState.title}
+            description={toastState.description}
+            actionLabel={toastState.actionLabel}
+            onAction={toastState.onAction}
+            duration={toastState.duration}
+            index={index}
+            isLatest={index === 0}
+            totalToasts={toasts.length}
+            variant={toastState.variant}
+          />
+        ))}
+    </>
   );
 }
 
 type ToastProps = {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  title: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  title?: string;
   description?: string;
   actionLabel?: string;
   onAction?: () => void;
-  duration?: number; // seconds
+  duration?: number;
+  index?: number;
+  isLatest?: boolean;
+  totalToasts?: number;
+  variant?: "default" | "success" | "error" | "info";
 };
 
 export function Toast({
-  open,
-  onOpenChange,
-  title,
+  open = false,
+  onOpenChange = () => {},
+  title = "",
   description,
   actionLabel = "Action",
   onAction,
-  duration = 3,
+  duration = 60,
+  index = 0,
+  isLatest = true,
+  totalToasts = 0,
+  variant = "default",
 }: ToastProps) {
   const [seconds, setSeconds] = useState(duration);
+  const [isHovered, setIsHovered] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [height, setHeight] = useState(100);
   const insets = useSafeAreaInsets();
   const { theme } = useTheme();
-  const [fadeAnim] = useState(new Animated.Value(0));
-  const { width } = useWindowDimensions();
   const isWeb = Platform.OS === "web";
+  const { width } = useWindowDimensions();
   const isDesktop = isWeb && width >= 768;
+
+  const opacity = useSharedValue(0);
+  const translateY = useSharedValue(100);
+  const scale = useSharedValue(1 - index * 0.05);
+
+  useEffect(() => {
+    return toastManager.subscribeHover(setIsHovered);
+  }, []);
+
+  useEffect(() => {
+    if (isHovered) {
+      // Stack vertically with proper spacing when hovered
+      const spacing = height + 20; // Height of each toast + gap
+      translateY.value = withTiming(-index * spacing, {
+        duration: 300,
+        easing: Easing.out(Easing.exp),
+      });
+      scale.value = withTiming(1, {
+        duration: 300,
+        easing: Easing.out(Easing.exp),
+      });
+      opacity.value = withTiming(1, {
+        duration: 300,
+        easing: Easing.out(Easing.exp),
+      });
+    } else {
+      // Compact stacked view when not hovered
+      translateY.value = withTiming(index * 10, {
+        duration: 300,
+        easing: Easing.out(Easing.exp),
+      });
+      scale.value = withTiming(1 - index * 0.05, {
+        duration: 300,
+        easing: Easing.out(Easing.exp),
+      });
+      opacity.value = withTiming(isLatest ? 1 : 0.8, {
+        duration: 300,
+        easing: Easing.out(Easing.exp),
+      });
+    }
+  }, [isHovered, index, isLatest]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      opacity: opacity.value,
+      transform: [{ translateY: translateY.value }, { scale: scale.value }],
+      zIndex: 1000 - index,
+    };
+  });
 
   const containerPosition: ViewStyle = isDesktop
     ? {
-        top: undefined,
         bottom: theme.spacing[4],
-        right: theme.spacing[4], // <-- use spacing, not 1
+        right: theme.spacing[4],
         alignItems: "flex-end",
         minWidth: 400,
         width: 400,
-        // Do NOT set left at all
       }
     : {
         bottom: insets.bottom + theme.spacing[1],
@@ -184,60 +297,92 @@ export function Toast({
         right: 0,
         alignItems: "center",
         width: "100%",
-        maxWidth: undefined,
       };
 
   useEffect(() => {
-    let interval: ReturnType<typeof setInterval> | null = null;
-
-    if (open) {
-      setSeconds(duration);
-      Animated.timing(fadeAnim, {
-        toValue: 1,
-        duration: 200,
-        useNativeDriver: true,
-      }).start();
-
-      interval = setInterval(() => {
+    if (open && !isHovered) {
+      // Start or resume the timer
+      intervalRef.current = setInterval(() => {
         setSeconds((prev) => {
           if (prev <= 1) {
-            onOpenChange(false);
-            if (interval) clearInterval(interval);
+            runOnJS(onOpenChange)(false);
+            if (intervalRef.current) clearInterval(intervalRef.current);
             return duration;
           }
           return prev - 1;
         });
       }, 1000);
     } else {
-      if (interval) clearInterval(interval);
-      Animated.timing(fadeAnim, {
-        toValue: 0,
-        duration: 150,
-        useNativeDriver: true,
-      }).start();
-      setSeconds(duration);
+      // Pause timer when hovered or not open
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }
+
+    if (!open) {
+      opacity.value = withTiming(0, { duration: 150 });
+      translateY.value = withTiming(100, { duration: 150 });
     }
 
     return () => {
-      if (interval) clearInterval(interval);
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
     };
-    // eslint-disable-next-line
-  }, [open, duration]);
+  }, [open, isHovered]);
 
-  if (!open) return null;
+  useEffect(() => {
+    if (open) {
+      setSeconds(duration);
+
+      opacity.value = withTiming(isLatest ? 1 : 0.8, {
+        duration: 200,
+        easing: Easing.out(Easing.exp),
+      });
+      translateY.value = withTiming(index * 10, {
+        duration: 200,
+        easing: Easing.out(Easing.exp),
+      });
+      scale.value = withTiming(1 - index * 0.05, {
+        duration: 250,
+        easing: Easing.out(Easing.exp),
+      });
+    }
+  }, [open, duration, index]);
+
+  const variantStyles = {
+    default: {
+      backgroundColor: theme.colors.secondary,
+      borderColor: theme.colors.border,
+    },
+    success: {
+      backgroundColor: theme.colors.success,
+      borderColor: theme.colors.success,
+    },
+    error: {
+      backgroundColor: theme.colors.destructive,
+      borderColor: theme.colors.destructive,
+    },
+    info: {
+      backgroundColor: theme.colors.info,
+      borderColor: theme.colors.info,
+    },
+  };
 
   return (
-    <Portal name="toast">
+    <Portal name={`toast-${index}`}>
       <Animated.View
-        style={[styles.container, containerPosition, { opacity: fadeAnim }]}
-        pointerEvents="box-none"
+        onLayout={(l) => setHeight(l.nativeEvent.layout.height)}
+        style={[styles.container, containerPosition, animatedStyle]}
       >
-        <View
+        <Pressable
+          onHoverIn={() => isWeb && toastManager.setHovered(true)}
+          onHoverOut={() => isWeb && toastManager.setHovered(false)}
           style={[
             styles.toast,
             {
-              backgroundColor: theme.colors.secondary,
-              borderColor: theme.colors.border,
               borderRadius: theme.borderRadius.xl,
               flexDirection: "column",
               justifyContent: "space-between",
@@ -245,26 +390,26 @@ export function Toast({
               padding: theme.spacing[4],
               width: isDesktop ? "100%" : "95%",
             },
+            variantStyles[variant],
           ]}
         >
           <View style={{ gap: theme.spacing[1], width: "100%" }}>
             <Text
-              style={[
-                {
-                  color: theme.colors.foreground,
-                  fontSize: 16,
-                  fontWeight: "500",
-                },
-              ]}
+              style={{
+                color: theme.colors.foreground,
+                fontSize: 16,
+                fontWeight: "500",
+              }}
             >
               {title}
             </Text>
             {description ? (
-              <Text style={[{ color: theme.colors.foreground, fontSize: 14 }]}>
+              <Text style={{ color: theme.colors.foreground, fontSize: 14 }}>
                 {description}
               </Text>
             ) : null}
           </View>
+
           <View
             style={{
               gap: theme.spacing[1],
@@ -304,7 +449,7 @@ export function Toast({
               <Text style={{ color: theme.colors.foreground }}>Close</Text>
             </Pressable>
           </View>
-        </View>
+        </Pressable>
       </Animated.View>
     </Portal>
   );

--- a/js/components/src/components/ui/toast.tsx
+++ b/js/components/src/components/ui/toast.tsx
@@ -25,25 +25,33 @@ import { useTheme } from "../../ui";
 import { Text } from "./text";
 
 type ToastConfig = {
-  title: string;
+  title?: string;
   description?: string;
   duration?: number;
   actionLabel?: string;
   onAction?: () => void;
   onClose?: () => void;
   variant?: "default" | "success" | "error" | "info";
+  render?: (props: {
+    close: () => void;
+    action?: () => void;
+  }) => React.ReactNode;
 };
 
 type ToastState = {
   id: string;
   open: boolean;
-  title: string;
+  title?: string;
   description?: string;
   duration: number;
   actionLabel?: string;
   onAction?: () => void;
   onClose?: () => void;
   variant?: "default" | "success" | "error" | "info";
+  render?: (props: {
+    close: () => void;
+    action?: () => void;
+  }) => React.ReactNode;
 };
 
 class ToastManager {
@@ -64,6 +72,7 @@ class ToastManager {
       onAction: config.onAction,
       onClose: config.onClose,
       variant: config.variant ?? "default",
+      render: config.render,
     };
 
     this.toasts = [...this.toasts, toast];
@@ -148,6 +157,24 @@ export const toast = {
       }
     }
   },
+  showManual: (
+    render: (props: {
+      close: () => void;
+      action?: () => void;
+    }) => React.ReactNode,
+    options?: {
+      duration?: number;
+      actionLabel?: string;
+      onAction?: () => void;
+      onClose?: () => void;
+      variant?: "default" | "success" | "error" | "info";
+    },
+  ) => {
+    toastManager.show({
+      render,
+      ...options,
+    });
+  },
 };
 
 export function useToast() {
@@ -231,6 +258,7 @@ export function ToastProvider() {
                 isLatest={index === 0}
                 totalToasts={toasts.length}
                 variant={toastState.variant}
+                render={toastState.render}
               />
             ))}
         </View>
@@ -251,6 +279,10 @@ type ToastProps = {
   isLatest?: boolean;
   totalToasts?: number;
   variant?: "default" | "success" | "error" | "info";
+  render?: (props: {
+    close: () => void;
+    action?: () => void;
+  }) => React.ReactNode;
 };
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle);
@@ -267,6 +299,7 @@ export function Toast({
   isLatest = true,
   totalToasts = 0,
   variant = "default",
+  render,
 }: ToastProps) {
   const [isHovered, setIsHovered] = useState(false);
   const progress = useSharedValue(1);
@@ -416,133 +449,141 @@ export function Toast({
           variantStyles[variant],
         ]}
       >
-        <View
-          style={{
-            flexDirection: "row",
-            alignItems: "flex-start",
-            justifyContent: "space-between",
-            width: "100%",
-            gap: theme.spacing[4],
-          }}
-        >
-          <View style={{ flex: 1, gap: theme.spacing[1] }}>
-            <Text
+        {render ? (
+          render({ close: () => onOpenChange(false), action: onAction })
+        ) : (
+          <>
+            <View
               style={{
-                color: theme.colors.foreground,
-                fontSize: 16,
-                fontWeight: "500",
+                flexDirection: "row",
+                alignItems: "flex-start",
+                justifyContent: "space-between",
+                width: "100%",
+                gap: theme.spacing[4],
               }}
             >
-              {title}
-            </Text>
-            {description ? (
-              <Text style={{ color: theme.colors.foreground, fontSize: 14 }}>
-                {description}
-              </Text>
-            ) : null}
-          </View>
-          {isLatest && duration > 0 ? (
-            <Pressable
-              onPress={() => onOpenChange(false)}
-              style={{
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <Svg width="24" height="24" viewBox="0 0 24 24">
-                <AnimatedCircle
-                  stroke={theme.colors.border}
-                  fill="transparent"
-                  strokeWidth="2"
-                  r={RADIUS}
-                  cx="12"
-                  cy="12"
-                />
-                <AnimatedCircle
-                  animatedProps={animatedCircleProps}
-                  stroke={theme.colors.primary}
-                  fill="transparent"
-                  strokeWidth="2"
-                  strokeDasharray={CIRCUMFERENCE}
-                  r={RADIUS}
-                  cx="12"
-                  cy="12"
-                  rotation="-90"
-                  originX="12"
-                  originY="12"
-                  strokeLinecap="round"
-                />
-              </Svg>
-              {!onAction && (
-                <View style={{ position: "absolute" }}>
-                  <X color={theme.colors.foreground} size={12} />
-                </View>
+              <View style={{ flex: 1, gap: theme.spacing[1] }}>
+                <Text
+                  style={{
+                    color: theme.colors.foreground,
+                    fontSize: 16,
+                    fontWeight: "500",
+                  }}
+                >
+                  {title}
+                </Text>
+                {description ? (
+                  <Text
+                    style={{ color: theme.colors.foreground, fontSize: 14 }}
+                  >
+                    {description}
+                  </Text>
+                ) : null}
+              </View>
+              {isLatest && duration > 0 ? (
+                <Pressable
+                  onPress={() => onOpenChange(false)}
+                  style={{
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Svg width="24" height="24" viewBox="0 0 24 24">
+                    <AnimatedCircle
+                      stroke={theme.colors.border}
+                      fill="transparent"
+                      strokeWidth="2"
+                      r={RADIUS}
+                      cx="12"
+                      cy="12"
+                    />
+                    <AnimatedCircle
+                      animatedProps={animatedCircleProps}
+                      stroke={theme.colors.primary}
+                      fill="transparent"
+                      strokeWidth="2"
+                      strokeDasharray={CIRCUMFERENCE}
+                      r={RADIUS}
+                      cx="12"
+                      cy="12"
+                      rotation="-90"
+                      originX="12"
+                      originY="12"
+                      strokeLinecap="round"
+                    />
+                  </Svg>
+                  {!onAction && (
+                    <View style={{ position: "absolute" }}>
+                      <X color={theme.colors.foreground} size={12} />
+                    </View>
+                  )}
+                </Pressable>
+              ) : (
+                <Pressable
+                  onPress={() => onOpenChange(false)}
+                  style={{
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Svg width="24" height="24" viewBox="0 0 24 24">
+                    <AnimatedCircle
+                      stroke={theme.colors.border}
+                      fill={theme.colors.muted}
+                      strokeWidth="2"
+                      r={RADIUS}
+                      cx="12"
+                      cy="12"
+                    />
+                  </Svg>
+                  {!onAction && (
+                    <View style={{ position: "absolute" }}>
+                      <X color={theme.colors.foreground} size={12} />
+                    </View>
+                  )}
+                </Pressable>
               )}
-            </Pressable>
-          ) : (
-            <Pressable
-              onPress={() => onOpenChange(false)}
-              style={{
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <Svg width="24" height="24" viewBox="0 0 24 24">
-                <AnimatedCircle
-                  stroke={theme.colors.border}
-                  fill={theme.colors.muted}
-                  strokeWidth="2"
-                  r={RADIUS}
-                  cx="12"
-                  cy="12"
-                />
-              </Svg>
-              {!onAction && (
-                <View style={{ position: "absolute" }}>
-                  <X color={theme.colors.foreground} size={12} />
-                </View>
-              )}
-            </Pressable>
-          )}
-        </View>
-        {onAction && (
-          <View
-            style={{
-              gap: theme.spacing[1],
-              flexDirection: "row",
-              justifyContent: "flex-end",
-              width: "100%",
-            }}
-          >
-            <Pressable
-              style={[
-                styles.button,
-                {
-                  borderColor: theme.colors.primary,
-                  paddingHorizontal: theme.spacing[4],
-                  paddingVertical: theme.spacing[2],
-                },
-              ]}
-              onPress={onAction}
-            >
-              <Text style={{ color: theme.colors.foreground }}>
-                {actionLabel}
-              </Text>
-            </Pressable>
-            <Pressable
-              style={[
-                styles.button,
-                {
-                  borderColor: theme.colors.primary,
-                  paddingHorizontal: theme.spacing[4],
-                  paddingVertical: theme.spacing[2],
-                },
-              ]}
-              onPress={() => onOpenChange(false)}
-            >
-              <Text style={{ color: theme.colors.foreground }}>Close</Text>
-            </Pressable>
-          </View>
+            </View>
+            {onAction && (
+              <View
+                style={{
+                  gap: theme.spacing[1],
+                  flexDirection: "row",
+                  justifyContent: "flex-end",
+                  width: "100%",
+                }}
+              >
+                <Pressable
+                  style={[
+                    styles.button,
+                    {
+                      borderColor: theme.colors.primary,
+                      paddingHorizontal: theme.spacing[4],
+                      paddingVertical: theme.spacing[2],
+                    },
+                  ]}
+                  onPress={onAction}
+                >
+                  <Text style={{ color: theme.colors.foreground }}>
+                    {actionLabel}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  style={[
+                    styles.button,
+                    {
+                      borderColor: theme.colors.primary,
+                      paddingHorizontal: theme.spacing[4],
+                      paddingVertical: theme.spacing[2],
+                    },
+                  ]}
+                  onPress={() => onOpenChange(false)}
+                >
+                  <Text style={{ color: theme.colors.foreground }}>Close</Text>
+                </Pressable>
+              </View>
+            )}
+          </>
         )}
       </View>
     </Animated.View>

--- a/js/components/src/components/ui/toast.tsx
+++ b/js/components/src/components/ui/toast.tsx
@@ -1,5 +1,5 @@
 import { Portal } from "@rn-primitives/portal";
-import { X } from "lucide-react-native";
+import { CheckCircle, Info, X, XCircle } from "lucide-react-native";
 import { useEffect, useRef, useState } from "react";
 import {
   Platform,
@@ -47,6 +47,9 @@ type ToastConfig = {
     action?: () => void;
   }) => React.ReactNode;
   position?: Position;
+  iconLeft?: React.ComponentType<any>;
+  iconRight?: React.ComponentType<any>;
+  onToastPress?: () => void;
 };
 
 type ToastState = {
@@ -64,6 +67,9 @@ type ToastState = {
     action?: () => void;
   }) => React.ReactNode;
   position: Position;
+  iconLeft?: React.ComponentType<any>;
+  iconRight?: React.ComponentType<any>;
+  onToastPress?: () => void;
 };
 
 class ToastManager {
@@ -87,6 +93,9 @@ class ToastManager {
       variant: config.variant ?? "default",
       render: config.render,
       position: config.position ?? "auto",
+      iconLeft: config.iconLeft,
+      iconRight: config.iconRight,
+      onToastPress: config.onToastPress,
     };
 
     this.toasts = [...this.toasts, toast];
@@ -162,6 +171,9 @@ export const toast = {
       onClose?: () => void;
       variant?: "default" | "success" | "error" | "info";
       position?: Position;
+      iconLeft?: React.ComponentType<any>;
+      iconRight?: React.ComponentType<any>;
+      onToastPress?: () => void;
     },
   ) => {
     toastManager.show({
@@ -192,6 +204,9 @@ export const toast = {
       onClose?: () => void;
       variant?: "default" | "success" | "error" | "info";
       position?: Position;
+      iconLeft?: React.ComponentType<any>;
+      iconRight?: React.ComponentType<any>;
+      onToastPress?: () => void;
     },
   ) => {
     toastManager.show({
@@ -438,6 +453,9 @@ export function Toast({
   render,
   position = "auto",
   id,
+  iconLeft: IconLeft,
+  iconRight: IconRight,
+  onToastPress,
 }: ToastProps) {
   const [isHovered, setIsHovered] = useState(false);
   const progress = useSharedValue(1);
@@ -455,6 +473,23 @@ export function Toast({
 
   const RADIUS = 12;
   const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+  const dismissTranslateY = useSharedValue(0);
+  const dismissTranslateX = useSharedValue(0);
+
+  // Auto-select iconLeft based on variant if not provided
+  const defaultIconLeft =
+    !IconLeft && !onAction
+      ? variant === "success"
+        ? CheckCircle
+        : variant === "error"
+          ? XCircle
+          : variant === "info"
+            ? Info
+            : null
+      : null;
+  const FinalIconLeft = IconLeft || defaultIconLeft;
+  const FinalIconRight = IconRight;
 
   const animatedCircleProps = useAnimatedProps(() => {
     return {
@@ -556,12 +591,85 @@ export function Toast({
     };
   }, [open, isLatest, isHovered, duration]);
 
+  const dismissGestureVertical = Gesture.Pan()
+    .enabled(isLatest && !isHovered)
+    .activeOffsetY(isTop ? [-10, 999999] : [-999999, 10])
+    .onUpdate((event) => {
+      const direction = isTop ? -1 : 1;
+      const movement = event.translationY * direction;
+      if (movement > 0) {
+        dismissTranslateY.value = event.translationY;
+        dismissTranslateX.value = 0;
+      }
+    })
+    .onEnd((event) => {
+      const direction = isTop ? -1 : 1;
+      const movement = event.translationY * direction;
+      const velocity = event.velocityY * direction;
+
+      if (movement > 50 || velocity > 500) {
+        // Dismiss - slide out in expansion direction
+        dismissTranslateY.value = withTiming(
+          isTop ? -200 : 200,
+          { duration: 250 },
+          (finished) => {
+            if (finished) {
+              runOnJS(onOpenChange)(false);
+            }
+          },
+        );
+        opacity.value = withTiming(0, { duration: 250 });
+      } else {
+        // Spring back
+        dismissTranslateY.value = withTiming(0, { duration: 200 });
+      }
+    });
+
+  const dismissGestureHorizontal = Gesture.Pan()
+    .enabled(isLatest || isHovered)
+    .activeOffsetX([-10, 10])
+    .onUpdate((event) => {
+      if (event.translationX < 0) {
+        dismissTranslateX.value = event.translationX;
+        dismissTranslateY.value = 0;
+      }
+    })
+    .onEnd((event) => {
+      // Check for horizontal swipe left
+      if (event.translationX < -100 || event.velocityX < -500) {
+        dismissTranslateX.value = withTiming(
+          -400,
+          { duration: 250 },
+          (finished) => {
+            if (finished) {
+              runOnJS(onOpenChange)(false);
+            }
+          },
+        );
+        opacity.value = withTiming(0, { duration: 250 });
+      } else {
+        // Spring back
+        dismissTranslateX.value = withTiming(0, { duration: 200 });
+      }
+    });
+
+  const dismissGesture = Gesture.Race(
+    dismissGestureVertical,
+    dismissGestureHorizontal,
+  );
+
   const animatedStyle = useAnimatedStyle(() => {
     return {
       opacity: opacity.value,
       transform: [
         // +22 is to get it just below the header
-        { translateY: translateY.value + (isTop ? top / 2 : -bottom) },
+        {
+          translateY:
+            translateY.value +
+            dismissTranslateY.value +
+            (isTop ? top / 2 : -bottom),
+        },
+        { translateX: dismissTranslateX.value },
         { scale: scale.value },
       ],
       zIndex: 1000 - index,
@@ -608,127 +716,222 @@ export function Toast({
         animatedStyle,
       ]}
     >
-      <View
-        style={[
-          styles.toast,
-          {
-            borderRadius: theme.borderRadius.xl,
-            flexDirection: "column",
-            justifyContent: "space-between",
-            alignItems: "center",
-            padding: theme.spacing[4],
-            width: isDesktop ? "100%" : "95%",
-          },
-          variantStyles[variant],
-        ]}
-      >
-        {render ? (
-          render({ close: () => onOpenChange(false), action: onAction })
-        ) : (
-          <>
-            <View
-              style={{
-                flexDirection: "row",
-                alignItems: "flex-start",
-                justifyContent: "space-between",
-                width: "100%",
-                gap: theme.spacing[4],
-              }}
-            >
-              <View style={{ flex: 1 }}>
-                <Text size="lg">{title}</Text>
-                {description ? <Text>{description}</Text> : null}
-              </View>
-              {isLatest && duration > 0 ? (
-                <Pressable
-                  onPress={() => onOpenChange(false)}
-                  style={{
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  <Svg
-                    width={RADIUS * 2}
-                    height={RADIUS * 2}
-                    viewBox={`0 0 ${RADIUS * 2 + 2} ${RADIUS * 2 + 2}`}
-                  >
-                    <AnimatedCircle
-                      stroke={theme.colors.border}
-                      fill="transparent"
-                      strokeWidth="2"
-                      r={RADIUS}
-                      cx={RADIUS + 1}
-                      cy={RADIUS + 1}
-                    />
-                    <AnimatedCircle
-                      animatedProps={animatedCircleProps}
-                      stroke={theme.colors.primary}
-                      fill="transparent"
-                      strokeWidth="2"
-                      strokeDasharray={CIRCUMFERENCE}
-                      r={RADIUS}
-                      cx={RADIUS + 1}
-                      cy={RADIUS + 1}
-                      rotation="-90"
-                      originX={RADIUS + 1}
-                      originY={RADIUS + 1}
-                      strokeLinecap="round"
-                    />
-                  </Svg>
-                  {!onAction && (
-                    <View style={{ position: "absolute" }}>
-                      <X color={theme.colors.foreground} size={12} />
-                    </View>
-                  )}
-                </Pressable>
-              ) : (
-                <Pressable
-                  onPress={() => onOpenChange(false)}
-                  style={{
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  <Svg width="24" height="24" viewBox="0 0 24 24">
-                    <AnimatedCircle
-                      stroke={theme.colors.border}
-                      fill="transparent"
-                      strokeWidth="2"
-                      r={RADIUS}
-                      cx="12"
-                      cy="12"
-                    />
-                  </Svg>
-                  {!onAction && (
-                    <View style={{ position: "absolute" }}>
-                      <X color="white" size={12} />
-                    </View>
-                  )}
-                </Pressable>
-              )}
-            </View>
-            {onAction && (
+      <GestureDetector gesture={dismissGesture}>
+        <Pressable
+          onPress={onToastPress}
+          disabled={!onToastPress}
+          style={[
+            styles.toast,
+            {
+              borderRadius: theme.borderRadius.xl,
+              flexDirection: "column",
+              justifyContent: "space-between",
+              alignItems: "center",
+              padding: theme.spacing[4],
+              width: isDesktop ? "100%" : "95%",
+            },
+            variantStyles[variant],
+          ]}
+        >
+          {render ? (
+            render({ close: () => onOpenChange(false), action: onAction })
+          ) : (
+            <>
               <View
                 style={{
-                  gap: theme.spacing[1],
                   flexDirection: "row",
-                  justifyContent: "flex-end",
+                  alignItems: "flex-start",
+                  justifyContent: "space-between",
                   width: "100%",
+                  gap: theme.spacing[4],
                 }}
               >
-                <Button variant={buttonTypeMap[variant]} onPress={onAction}>
-                  <Text style={{ color: theme.colors.foreground }}>
-                    {actionLabel}
-                  </Text>
-                </Button>
-                <Button variant="secondary" onPress={() => onOpenChange(false)}>
-                  <Text style={{ color: theme.colors.foreground }}>Close</Text>
-                </Button>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    flex: 1,
+                    gap: theme.spacing[3],
+                  }}
+                >
+                  {FinalIconLeft && (
+                    <View style={{ paddingTop: 2 }}>
+                      <FinalIconLeft color={theme.colors.foreground} />
+                    </View>
+                  )}
+                  <View style={{ flex: 1 }}>
+                    <Text size="lg">{title}</Text>
+                    {description ? <Text>{description}</Text> : null}
+                  </View>
+                </View>
+                {FinalIconRight && !onAction ? (
+                  <View
+                    style={{
+                      gap: theme.spacing[2],
+                      height: "100%",
+                      justifyContent: "space-between",
+                    }}
+                  >
+                    <Pressable onPress={onToastPress}>
+                      <FinalIconRight color={theme.colors.foreground} />
+                    </Pressable>
+                    {isLatest && duration > 0 ? (
+                      <Pressable
+                        onPress={() => onOpenChange(false)}
+                        style={{
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        <Svg
+                          width={RADIUS * 2}
+                          height={RADIUS * 2}
+                          viewBox={`0 0 ${RADIUS * 2 + 2} ${RADIUS * 2 + 2}`}
+                        >
+                          <AnimatedCircle
+                            stroke={theme.colors.border}
+                            fill="transparent"
+                            strokeWidth="2"
+                            r={RADIUS}
+                            cx={RADIUS + 1}
+                            cy={RADIUS + 1}
+                          />
+                          <AnimatedCircle
+                            animatedProps={animatedCircleProps}
+                            stroke={theme.colors.primary}
+                            fill="transparent"
+                            strokeWidth="2"
+                            strokeDasharray={CIRCUMFERENCE}
+                            r={RADIUS}
+                            cx={RADIUS + 1}
+                            cy={RADIUS + 1}
+                            rotation="-90"
+                            originX={RADIUS + 1}
+                            originY={RADIUS + 1}
+                            strokeLinecap="round"
+                          />
+                        </Svg>
+                        <View style={{ position: "absolute" }}>
+                          <X color={theme.colors.foreground} size={12} />
+                        </View>
+                      </Pressable>
+                    ) : (
+                      <Pressable
+                        onPress={() => onOpenChange(false)}
+                        style={{
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        <Svg width="24" height="24" viewBox="0 0 24 24">
+                          <AnimatedCircle
+                            stroke={theme.colors.border}
+                            fill="transparent"
+                            strokeWidth="2"
+                            r={RADIUS}
+                            cx="12"
+                            cy="12"
+                          />
+                        </Svg>
+                        <View style={{ position: "absolute" }}>
+                          <X color="white" size={12} />
+                        </View>
+                      </Pressable>
+                    )}
+                  </View>
+                ) : !onAction ? (
+                  isLatest && duration > 0 ? (
+                    <Pressable
+                      onPress={() => onOpenChange(false)}
+                      style={{
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <Svg
+                        width={RADIUS * 2}
+                        height={RADIUS * 2}
+                        viewBox={`0 0 ${RADIUS * 2 + 2} ${RADIUS * 2 + 2}`}
+                      >
+                        <AnimatedCircle
+                          stroke={theme.colors.border}
+                          fill="transparent"
+                          strokeWidth="2"
+                          r={RADIUS}
+                          cx={RADIUS + 1}
+                          cy={RADIUS + 1}
+                        />
+                        <AnimatedCircle
+                          animatedProps={animatedCircleProps}
+                          stroke={theme.colors.primary}
+                          fill="transparent"
+                          strokeWidth="2"
+                          strokeDasharray={CIRCUMFERENCE}
+                          r={RADIUS}
+                          cx={RADIUS + 1}
+                          cy={RADIUS + 1}
+                          rotation="-90"
+                          originX={RADIUS + 1}
+                          originY={RADIUS + 1}
+                          strokeLinecap="round"
+                        />
+                      </Svg>
+                      <View style={{ position: "absolute" }}>
+                        <X color={theme.colors.foreground} size={12} />
+                      </View>
+                    </Pressable>
+                  ) : (
+                    <Pressable
+                      onPress={() => onOpenChange(false)}
+                      style={{
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <Svg width="24" height="24" viewBox="0 0 24 24">
+                        <AnimatedCircle
+                          stroke={theme.colors.border}
+                          fill="transparent"
+                          strokeWidth="2"
+                          r={RADIUS}
+                          cx="12"
+                          cy="12"
+                        />
+                      </Svg>
+                      <View style={{ position: "absolute" }}>
+                        <X color="white" size={12} />
+                      </View>
+                    </Pressable>
+                  )
+                ) : null}
               </View>
-            )}
-          </>
-        )}
-      </View>
+              {onAction && (
+                <View
+                  style={{
+                    gap: theme.spacing[1],
+                    flexDirection: "row",
+                    justifyContent: "flex-end",
+                    width: "100%",
+                  }}
+                >
+                  <Button variant={buttonTypeMap[variant]} onPress={onAction}>
+                    <Text style={{ color: theme.colors.foreground }}>
+                      {actionLabel}
+                    </Text>
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onPress={() => onOpenChange(false)}
+                  >
+                    <Text style={{ color: theme.colors.foreground }}>
+                      Close
+                    </Text>
+                  </Button>
+                </View>
+              )}
+            </>
+          )}
+        </Pressable>
+      </GestureDetector>
     </Animated.View>
   );
 }

--- a/js/components/src/lib/theme/theme.tsx
+++ b/js/components/src/lib/theme/theme.tsx
@@ -348,16 +348,16 @@ function generateThemeColorsFromPalette(
     accent: isDark ? palette[800] : palette[100],
     accentForeground: isDark ? palette[50] : palette[900],
 
-    destructive: colors.destructive[800],
+    destructive: colors.destructive[700],
     destructiveForeground: colors.white,
 
-    success: colors.success[800],
+    success: colors.success[700],
     successForeground: colors.white,
 
-    warning: colors.warning[800],
+    warning: colors.warning[700],
     warningForeground: colors.white,
 
-    info: colors.blue[800],
+    info: colors.blue[700],
     infoForeground: isDark ? palette[50] : palette[900],
 
     border: isDark ? palette[500] + "30" : palette[200] + "30",

--- a/js/components/src/lib/theme/theme.tsx
+++ b/js/components/src/lib/theme/theme.tsx
@@ -84,6 +84,10 @@ export interface Theme {
     warning: string;
     warningForeground: string;
 
+    // Info colors
+    info: string;
+    infoForeground: string;
+
     // Border and input colors
     border: string;
     input: string;
@@ -355,6 +359,9 @@ function generateThemeColorsFromPalette(
     warning:
       Platform.OS === "ios" ? colors.ios.systemOrange : colors.warning[500],
     warningForeground: colors.white,
+
+    info: Platform.OS === "ios" ? colors.ios.systemTeal : colors.teal[500],
+    infoForeground: isDark ? palette[50] : palette[900],
 
     border: isDark ? palette[500] + "30" : palette[200] + "30",
     input: isDark ? palette[800] : palette[200],

--- a/js/components/src/lib/theme/theme.tsx
+++ b/js/components/src/lib/theme/theme.tsx
@@ -348,19 +348,16 @@ function generateThemeColorsFromPalette(
     accent: isDark ? palette[800] : palette[100],
     accentForeground: isDark ? palette[50] : palette[900],
 
-    destructive:
-      Platform.OS === "ios" ? colors.ios.systemRed : colors.destructive[500],
+    destructive: colors.destructive[800],
     destructiveForeground: colors.white,
 
-    success:
-      Platform.OS === "ios" ? colors.ios.systemGreen : colors.success[500],
+    success: colors.success[800],
     successForeground: colors.white,
 
-    warning:
-      Platform.OS === "ios" ? colors.ios.systemOrange : colors.warning[500],
+    warning: colors.warning[800],
     warningForeground: colors.white,
 
-    info: Platform.OS === "ios" ? colors.ios.systemTeal : colors.teal[500],
+    info: colors.blue[800],
     infoForeground: isDark ? palette[50] : palette[900],
 
     border: isDark ? palette[500] + "30" : palette[200] + "30",


### PR DESCRIPTION
Improvements to toasts with stacking, gestures, and overall better UX.

Stacking:
- Toasts stack vertically, with the latest on top (stack DS internally)
- Hover or swipe to expand
- Swipe left to dismiss on mobile

Icons and theming:
- iconLeft and iconRight props for custom icons
- Auto theming based on variant

| Collapsed | Expanded | Landscape |
| ---------- | ---------- | ----------- |
| <img width="603" height="1311" alt="IMG_0310" src="https://github.com/user-attachments/assets/4e12b0f8-e968-465b-8939-8f965c3404d7" />|<img width="603" height="1311" alt="IMG_0309" src="https://github.com/user-attachments/assets/ffa48c4b-2939-4cc0-9b4c-2264702f1f14" />|<img width="2622" height="1206" alt="image" src="https://github.com/user-attachments/assets/9c7502f7-7110-4fd1-a412-0313cd2e7a9f" />|