### PR TITLE
fix: readd CTA to embed

### DIFF
--- a/js/app/components/mobile/desktop-ui.tsx
+++ b/js/app/components/mobile/desktop-ui.tsx
@@ -63,6 +63,7 @@ export function DesktopUi({
   const showMetrics = usePlayerStore((state) => state.showDebugInfo);
   const pipAction = usePlayerStore((state) => state.pipAction);
   const videoRef = usePlayerStore((state) => state.videoRef);
+  const embedded = usePlayerStore((state) => state.embedded);
 
   const segment = useSegment();
 
@@ -213,6 +214,7 @@ export function DesktopUi({
               isChatOpen={isChatOpen || false}
               onToggleChat={toggleChat}
               safeAreaInsets={safeAreaInsets}
+              embedded={embedded}
             />
           </Animated.View>
 

--- a/js/app/components/mobile/desktop-ui/top-controls.tsx
+++ b/js/app/components/mobile/desktop-ui/top-controls.tsx
@@ -9,10 +9,16 @@ import {
   zero,
 } from "@streamplace/components";
 import { ChevronLeft, MessageSquare, SwitchCamera } from "lucide-react-native";
-import { Image, Platform, Pressable } from "react-native";
+import {
+  Image,
+  Linking,
+  Platform,
+  Pressable,
+  useWindowDimensions,
+} from "react-native";
 import { LiveBubble } from "./live-bubble";
 
-const { borders, colors, gap, layout, p, r, text } = zero;
+const { borders, colors, gap, layout, p, px, py, r, text } = zero;
 
 interface TopControlBarProps {
   offline: boolean;
@@ -21,6 +27,7 @@ interface TopControlBarProps {
   isChatOpen: boolean;
   onToggleChat: () => void;
   safeAreaInsets: { top: number };
+  embedded?: boolean;
 }
 
 export function TopControlBar({
@@ -30,11 +37,15 @@ export function TopControlBar({
   isChatOpen,
   onToggleChat,
   safeAreaInsets,
+  embedded = false,
 }: TopControlBarProps) {
   const navigation = useNavigation();
   const { profile } = useLivestreamInfo();
   const { doSetIngestCamera } = useCameraToggle();
   const avatars = useAvatars(profile?.did ? [profile?.did] : []);
+  const { width } = useWindowDimensions();
+  const isTinyScreen = width < 450;
+  const isSmallScreen = width < 600;
 
   return (
     <View
@@ -84,6 +95,35 @@ export function TopControlBar({
       </View>
 
       <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[3]]}>
+        {embedded && Platform.OS === "web" && (
+          <Pressable
+            onPress={() => {
+              const url = window.location.href.replace("/embed/", "/");
+              Linking.openURL(url);
+            }}
+            style={[
+              layout.flex.row,
+              layout.flex.alignCenter,
+              gap.all[2],
+              py[2],
+              px[3],
+              r.xl,
+              {
+                backgroundColor: "rgba(75,75,75, 0.65)",
+              },
+            ]}
+          >
+            {!isSmallScreen && <Text size="lg">Powered by</Text>}
+            <Image
+              source={require("assets/images/cube_small.png")}
+              style={{
+                width: 24,
+                height: 24,
+              }}
+            />
+            {!isTinyScreen && <Text size="lg">Streamplace</Text>}
+          </Pressable>
+        )}
         {isActivelyLive && (
           <>
             <PlayerUI.Viewers />

--- a/js/app/src/screens/embed.tsx
+++ b/js/app/src/screens/embed.tsx
@@ -37,7 +37,7 @@ export default function EmbedScreen({ route }) {
   return (
     <LivestreamProvider src={src}>
       <PlayerProvider {...extraProps}>
-        <Player src={src} {...extraProps}>
+        <Player src={src} embedded={true} {...extraProps}>
           <DesktopUi />
         </Player>
       </PlayerProvider>

--- a/js/components/src/components/mobile-player/player.tsx
+++ b/js/components/src/components/mobile-player/player.tsx
@@ -23,6 +23,7 @@ export function Player(
   const clearControlsTimeout = usePlayerStore((x) => x.clearControlsTimeout);
 
   const setReportingURL = usePlayerStore((x) => x.setReportingURL);
+  const setEmbedded = usePlayerStore((x) => x.setEmbedded);
 
   const reportModalOpen = usePlayerStore((x) => x.reportModalOpen);
   const setReportModalOpen = usePlayerStore((x) => x.setReportModalOpen);
@@ -31,6 +32,10 @@ export function Player(
   useEffect(() => {
     setReportingURL(props.reportingURL ?? null);
   }, [props.reportingURL]);
+
+  useEffect(() => {
+    setEmbedded(props.embedded ?? false);
+  }, [props.embedded]);
 
   // Will call back every few seconds to send health updates
   usePlayerStatus();


### PR DESCRIPTION
I forgot to add the CTA when I rewrote the player, and I know at least someone is using the embed, so here it is. It's built into the top bar on desktop, so it fades out when the UI hasn't been interacted with in ~5s or so.

Three modes:

| Thinner | Thin | Normal |
|--------|------|---------|
|<img width="824" height="1830" alt="image" src="https://github.com/user-attachments/assets/bd6c10f1-6404-4e13-8529-1ed5eb129490" />|<img width="962" height="848" alt="image" src="https://github.com/user-attachments/assets/c0c5bf83-cac7-495d-a116-f072e13ceae8" />|<img width="1766" height="824" alt="image" src="https://github.com/user-attachments/assets/49e32836-2903-4fd2-8a36-67dd2f87463b" />|

Note that these are taken with ~iphone pro-series resolution so on desktop the cta and general UI is a lot smaller.
