### PR TITLE
Add the sender key to the DataHandler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,13 +52,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "ac8202ab55fcbf46ca829833f347a82a2a4ce0596f0304ac322c2d100030cd56"
 dependencies = [
  "bytes",
- "crypto-common",
- "generic-array",
+ "crypto-common 0.2.0-rc.4",
+ "inout",
 ]
 
 [[package]]
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "d8b59d472eab27ade8d770dcb11da7201c11234bef9f82ce7aa517be028d462b"
 
 [[package]]
 name = "base32"
@@ -444,6 +444,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
+]
+
+[[package]]
 name = "bounded-integer"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,11 +539,11 @@ dependencies = [
  "config",
  "console_log",
  "const-hex",
- "const-oid",
+ "const-oid 0.9.6",
  "conv",
  "coset",
- "der",
- "ed25519-dalek",
+ "der 0.7.10",
+ "ed25519-dalek 2.2.0",
  "env_logger",
  "extfmt",
  "getrandom 0.2.16",
@@ -556,7 +566,7 @@ dependencies = [
  "openssl",
  "pem",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "png_pong",
  "quick-xml",
  "rand 0.8.5",
@@ -582,8 +592,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha1",
- "sha2",
- "spki",
+ "sha2 0.10.9",
+ "spki 0.7.3",
  "static-iref",
  "tempfile",
  "thiserror 2.0.16",
@@ -668,13 +678,14 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
+version = "0.10.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+checksum = "9bd162f2b8af3e0639d83f28a637e4e55657b7a74508dba5a9bf4da523d5c9e9"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+ "zeroize",
 ]
 
 [[package]]
@@ -720,11 +731,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
 dependencies = [
- "crypto-common",
+ "block-buffer 0.11.0-rc.5",
+ "crypto-common 0.2.0-rc.4",
  "inout",
  "zeroize",
 ]
@@ -793,6 +805,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
 
 [[package]]
 name = "const-random"
@@ -941,20 +959,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
 [[package]]
-name = "crypto_box"
-version = "0.9.1"
+name = "crypto-common"
+version = "0.2.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
+checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
+dependencies = [
+ "hybrid-array",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "crypto_box"
+version = "0.10.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bda4de3e070830cf3a27a394de135b6709aefcc54d1e16f2f029271254a6ed9"
 dependencies = [
  "aead",
  "chacha20",
  "crypto_secretbox",
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0-pre.1",
  "salsa20",
  "serdect",
  "subtle",
@@ -963,14 +990,14 @@ dependencies = [
 
 [[package]]
 name = "crypto_secretbox"
-version = "0.1.1"
+version = "0.2.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+checksum = "54532aae6546084a52cef855593daf9555945719eeeda9974150e0def854873e"
 dependencies = [
  "aead",
  "chacha20",
  "cipher",
- "generic-array",
+ "hybrid-array",
  "poly1305",
  "salsa20",
  "subtle",
@@ -986,9 +1013,25 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rand_core 0.6.4",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.11.0-rc.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.9.3",
  "rustc_version",
  "serde",
  "subtle",
@@ -1070,9 +1113,20 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d8dd2f26c86b27a2a8ea2767ec7f9df7a89516e4794e54ac01ee618dda3aa4"
+dependencies = [
+ "const-oid 0.10.1",
  "der_derive",
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0-rc.3",
  "zeroize",
 ]
 
@@ -1092,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "be645fee2afe89d293b96c19e4456e6ac69520fc9c6b8a58298550138e361ffe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1176,10 +1230,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac89f8a64533a9b0eaa73a68e424db0fb1fd6271c74cc0125336a05f090568d"
+dependencies = [
+ "block-buffer 0.11.0-rc.5",
+ "crypto-common 0.2.0-rc.4",
 ]
 
 [[package]]
@@ -1234,9 +1298,19 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef49c0b20c0ad088893ad2a790a29c06a012b3f05bcfc66661fd22a94b32129"
+dependencies = [
+ "pkcs8 0.11.0-rc.7",
  "serde",
- "signature",
+ "signature 3.0.0-rc.4",
 ]
 
 [[package]]
@@ -1245,12 +1319,28 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "rand_core 0.6.4",
  "serde",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad207ed88a133091f83224265eac21109930db09bedcad05d5252f2af2de20a1"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.1",
+ "ed25519 3.0.0-rc.1",
+ "rand_core 0.9.3",
+ "serde",
+ "sha2 0.11.0-rc.2",
+ "signature 3.0.0-rc.4",
  "subtle",
  "zeroize",
 ]
@@ -1371,6 +1461,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,9 +1490,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1589,7 +1685,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1715,6 +1810,12 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1772,20 +1873,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
+ "bytes",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "h2",
+ "http",
  "idna",
  "ipnet",
  "once_cell",
  "rand 0.9.2",
  "ring",
+ "rustls",
  "thiserror 2.0.16",
  "tinyvec",
  "tokio",
+ "tokio-rustls",
  "tracing",
  "url",
 ]
@@ -1805,9 +1911,11 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "resolv-conf",
+ "rustls",
  "smallvec",
  "thiserror 2.0.16",
  "tokio",
+ "tokio-rustls",
  "tracing",
 ]
 
@@ -1817,7 +1925,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1895,6 +2003,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f471e0a81b2f90ffc0cb2f951ae04da57de8baa46fa99112b062a5173a5088d0"
+dependencies = [
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,7 +2047,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2166,11 +2284,11 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "c7357b6e7aa75618c7864ebd0634b115a7218b0615f4cb1df33ac3eca23943d4"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2248,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.92.0"
+version = "0.93.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ad6b793a5851b9e5435ad36fea63df485f8fd4520a58117e7dc3326a69c15"
+checksum = "5edb130239eba2cabe28fa7a068b6f58ba0599823ca19149ee46e8a099892376"
 dependencies = [
  "aead",
  "backon",
@@ -2258,9 +2376,9 @@ dependencies = [
  "cfg_aliases",
  "crypto_box",
  "data-encoding",
- "der",
+ "der 0.8.0-rc.9",
  "derive_more 2.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0-pre.1",
  "futures-buffered",
  "futures-util",
  "getrandom 0.3.3",
@@ -2274,7 +2392,7 @@ dependencies = [
  "iroh-quinn-proto",
  "iroh-quinn-udp",
  "iroh-relay",
- "n0-future 0.1.3",
+ "n0-future 0.2.0",
  "n0-snafu",
  "n0-watcher",
  "nested_enum_utils",
@@ -2282,8 +2400,9 @@ dependencies = [
  "netwatch",
  "pin-project",
  "pkarr",
+ "pkcs8 0.11.0-rc.7",
  "portmapper",
- "rand 0.8.5",
+ "rand 0.9.2",
  "reqwest",
  "ring",
  "rustls",
@@ -2292,7 +2411,6 @@ dependencies = [
  "serde",
  "smallvec",
  "snafu",
- "spki",
  "strum",
  "stun-rs",
  "surge-ping",
@@ -2304,24 +2422,24 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots 0.26.11",
+ "webpki-roots",
  "z32",
 ]
 
 [[package]]
 name = "iroh-base"
-version = "0.92.0"
+version = "0.93.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ae51a14c9255a735b1db2d8cf29b875b971e96a5b23e4d0d1ee7d85bf32132"
+checksum = "7899388d105980b64c49dd421f9b3ff18fb1f0898983cb8f3d54dbb6772983da"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0-pre.1",
  "data-encoding",
  "derive_more 2.0.1",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0-pre.1",
  "n0-snafu",
  "nested_enum_utils",
  "postcard",
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
  "serde",
  "snafu",
  "url",
@@ -2329,15 +2447,15 @@ dependencies = [
 
 [[package]]
 name = "iroh-gossip"
-version = "0.92.0"
+version = "0.93.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d530166ebdcfe321fb3a406dba62d777c98e1159237c7aaf0591e3758eb013c"
+checksum = "d3a4eb6377aad5f5c815f978e96d8471514c13e7f6a0d22071226dedc3196d4c"
 dependencies = [
  "blake3",
  "bytes",
  "data-encoding",
- "derive_more 1.0.0",
- "ed25519-dalek",
+ "derive_more 2.0.1",
+ "ed25519-dalek 3.0.0-pre.1",
  "futures-concurrency",
  "futures-lite",
  "futures-util",
@@ -2351,8 +2469,7 @@ dependencies = [
  "n0-snafu",
  "nested_enum_utils",
  "postcard",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.9.2",
  "serde",
  "snafu",
  "tokio",
@@ -2362,13 +2479,14 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8922c169f1b84d39d325c02ef1bbe1419d4de6e35f0403462b3c7e60cc19634"
+checksum = "090161e84532a0cb78ab13e70abb882b769ec67cf5a2d2dcea39bd002e1f7172"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
  "postcard",
+ "ryu",
  "serde",
  "snafu",
  "tracing",
@@ -2376,9 +2494,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d12f5c45c4ed2436302a4e03cad9a0ad34b2962ad0c5791e1019c0ee30eeb09"
+checksum = "8a39de3779d200dadde3a27b9fbdb34389a2af1b85ea445afca47bf4d7672573"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2442,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "0.92.0"
+version = "0.93.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "315cb02e660de0de339303296df9a29b27550180bb3979d0753a267649b34a7f"
+checksum = "d3f31a5830127df04d4d54cac933bf34246df6cc47944ff0e168e2e4f2e8d9e5"
 dependencies = [
  "blake3",
  "bytes",
@@ -2461,15 +2579,15 @@ dependencies = [
  "iroh-metrics",
  "iroh-quinn",
  "iroh-quinn-proto",
- "lru",
- "n0-future 0.1.3",
+ "lru 0.16.2",
+ "n0-future 0.2.0",
  "n0-snafu",
  "nested_enum_utils",
  "num_enum",
  "pin-project",
  "pkarr",
  "postcard",
- "rand 0.8.5",
+ "rand 0.9.2",
  "reqwest",
  "rustls",
  "rustls-pki-types",
@@ -2485,19 +2603,20 @@ dependencies = [
  "tokio-websockets",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots",
  "ws_stream_wasm",
  "z32",
 ]
 
 [[package]]
 name = "iroh-smol-kv"
-version = "0.2.0"
-source = "git+https://github.com/n0-computer/iroh-smol-kv#4067d52fd16efc922352e072418bc2cec061b6c4"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2dbad39b6608778da0929428308f45e391afdc385aea7ab3f81a8dfe01e807"
 dependencies = [
  "bytes",
  "chrono",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0-pre.1",
  "hex",
  "iroh",
  "iroh-gossip",
@@ -2505,7 +2624,7 @@ dependencies = [
  "n0-future 0.2.0",
  "peg",
  "postcard",
- "rand 0.8.5",
+ "rand 0.9.2",
  "rpds",
  "serde",
  "serde-big-array",
@@ -2532,7 +2651,7 @@ dependencies = [
  "irpc-iroh",
  "n0-future 0.2.0",
  "postcard",
- "rand 0.8.5",
+ "rand 0.9.2",
  "ref-cast",
  "serde",
  "serde_json",
@@ -2548,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "irpc"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092c0b20697bbc7de4839eebcb49be975cc09221021626d301eea55fc10bfeb7"
+checksum = "3e3fc4aa2bc2c1002655fab4254390f016f8b9bb65390600f9d8b11f9bdac76d"
 dependencies = [
  "anyhow",
  "futures-buffered",
@@ -2571,9 +2690,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209d38d83c0f7043916e90de2d3a8d01035db3a2f49ea7d5fb41b8f43e889924"
+checksum = "7f5706d47257e3f40b9e7dbc1934942b5792cc6a8670b7dda8856c2f5709cf98"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2582,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-iroh"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba5a31134415cdcfe65c309b4d3a9560764ca938e98e8717a25d3973f141ac1"
+checksum = "80e06eb3077e16299f86816ca5f5d795abccf6e5c58340d701ecc4166bdcf2ea"
 dependencies = [
  "anyhow",
  "getrandom 0.3.3",
@@ -2724,8 +2843,14 @@ name = "lru"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+
+[[package]]
+name = "lru"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -3245,12 +3370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl"
 version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,6 +3540,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e58fab693c712c0d4e88f8eb3087b6521d060bcaf76aeb20cb192d809115ba"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,7 +3595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3520,9 +3648,9 @@ checksum = "b6574ffbea793ab0c9a9b09ae99831f1513fdd7732b12aca4c7182c46dc3bc9f"
 
 [[package]]
 name = "pkarr"
-version = "3.10.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb1f2f4311bae1da11f930c804c724c9914cf55ae51a9ee0440fc98826984f7"
+checksum = "792c1328860f6874e90e3b387b4929819cc7783a6bd5a4728e918706eb436a48"
 dependencies = [
  "async-compat",
  "base32",
@@ -3530,12 +3658,12 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "dyn-clone",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0-pre.1",
  "futures-buffered",
  "futures-lite",
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "log",
- "lru",
+ "lru 0.13.0",
  "ntimestamp",
  "reqwest",
  "self_cell",
@@ -3555,9 +3683,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3566,8 +3694,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93eac55f10aceed84769df670ea4a32d2ffad7399400d41ee1c13b1cd8e1b478"
+dependencies = [
+ "der 0.8.0-rc.9",
+ "spki 0.8.0-rc.4",
 ]
 
 [[package]]
@@ -3639,12 +3777,11 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "fb78a635f75d76d856374961deecf61031c0b6f928c83dc9c0924ab6c019c298"
 dependencies = [
  "cpufeatures",
- "opaque-debug",
  "universal-hash",
 ]
 
@@ -3656,9 +3793,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portmapper"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f99e8cd25cd8ee09fc7da59357fd433c0a19272956ebb4ad7443b21842988d"
+checksum = "90f7313cafd74e95e6a358c1d0a495112f175502cc2e69870d0a5b12b6553059"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4211,7 +4348,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4268,17 +4405,17 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2",
- "signature",
- "spki",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -4395,10 +4532,11 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa20"
-version = "0.10.2"
+version = "0.11.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+checksum = "d3ff3b81c8a6e381bc1673768141383f9328048a60edddcfc752a8291a138443"
 dependencies = [
+ "cfg-if",
  "cipher",
 ]
 
@@ -4661,9 +4799,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+checksum = "d3ef0e35b322ddfaecbc60f34ab448e157e48531288ee49fafbb053696b8ffe2"
 dependencies = [
  "base16ct",
  "serde",
@@ -4677,7 +4815,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4694,7 +4832,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-rc.3",
 ]
 
 [[package]]
@@ -4727,9 +4876,15 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "signature"
+version = "3.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc280a6ff65c79fbd6622f64d7127f32b85563bca8c53cd2e9141d6744a9056d"
 
 [[package]]
 name = "simd-adler32"
@@ -4846,7 +5001,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+dependencies = [
+ "base64ct",
+ "der 0.8.0-rc.9",
 ]
 
 [[package]]
@@ -4881,7 +5046,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.105",
  "thiserror 1.0.69",
 ]
@@ -5665,11 +5830,11 @@ dependencies = [
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "a55be643b40a21558f44806b53ee9319595bc7ca6896372e4e08e5d7d83c9cd6"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.0-rc.4",
  "subtle",
 ]
 
@@ -5694,7 +5859,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
- "webpki-roots 1.0.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5903,15 +6068,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -6356,12 +6512,12 @@ dependencies = [
  "bcder",
  "bytes",
  "chrono",
- "der",
+ "der 0.7.10",
  "hex",
  "pem",
  "ring",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "thiserror 1.0.69",
  "zeroize",
 ]

--- a/pkg/iroh/generated/iroh_streamplace/iroh_streamplace.go
+++ b/pkg/iroh/generated/iroh_streamplace/iroh_streamplace.go
@@ -383,7 +383,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_iroh_streamplace_checksum_method_datahandler_handle_data()
 		})
-		if checksum != 27893 {
+		if checksum != 48772 {
 			// If this happens try cleaning and rebuilding your project
 			panic("iroh_streamplace: uniffi_iroh_streamplace_checksum_method_datahandler_handle_data: UniFFI API checksum mismatch")
 		}
@@ -993,7 +993,7 @@ func (ffiObject *FfiObject) freeRustArcPtr() {
 
 // DataHandler trait that is exported to go for receiving data callbacks.
 type DataHandler interface {
-	HandleData(topic string, data []byte)
+	HandleData(from *PublicKey, topic string, data []byte)
 }
 
 // DataHandler trait that is exported to go for receiving data callbacks.
@@ -1001,7 +1001,7 @@ type DataHandlerImpl struct {
 	ffiObject FfiObject
 }
 
-func (_self *DataHandlerImpl) HandleData(topic string, data []byte) {
+func (_self *DataHandlerImpl) HandleData(from *PublicKey, topic string, data []byte) {
 	_pointer := _self.ffiObject.incrementPointer("DataHandler")
 	defer _self.ffiObject.decrementPointer()
 	uniffiRustCallAsync[error](
@@ -1014,7 +1014,7 @@ func (_self *DataHandlerImpl) HandleData(topic string, data []byte) {
 		// liftFn
 		func(_ struct{}) struct{} { return struct{}{} },
 		C.uniffi_iroh_streamplace_fn_method_datahandler_handle_data(
-			_pointer, FfiConverterStringINSTANCE.Lower(topic), FfiConverterBytesINSTANCE.Lower(data)),
+			_pointer, FfiConverterPublicKeyINSTANCE.Lower(from), FfiConverterStringINSTANCE.Lower(topic), FfiConverterBytesINSTANCE.Lower(data)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
 			C.ffi_iroh_streamplace_rust_future_poll_void(handle, continuation, data)
@@ -1129,7 +1129,7 @@ func (cm *concurrentHandleMap[T]) tryGet(handle uint64) (T, bool) {
 }
 
 //export iroh_streamplace_cgo_dispatchCallbackInterfaceDataHandlerMethod0
-func iroh_streamplace_cgo_dispatchCallbackInterfaceDataHandlerMethod0(uniffiHandle C.uint64_t, topic C.RustBuffer, data C.RustBuffer, uniffiFutureCallback C.UniffiForeignFutureCompleteVoid, uniffiCallbackData C.uint64_t, uniffiOutReturn *C.UniffiForeignFuture) {
+func iroh_streamplace_cgo_dispatchCallbackInterfaceDataHandlerMethod0(uniffiHandle C.uint64_t, from unsafe.Pointer, topic C.RustBuffer, data C.RustBuffer, uniffiFutureCallback C.UniffiForeignFutureCompleteVoid, uniffiCallbackData C.uint64_t, uniffiOutReturn *C.UniffiForeignFuture) {
 	handle := uint64(uniffiHandle)
 	uniffiObj, ok := FfiConverterDataHandlerINSTANCE.handleMap.tryGet(handle)
 	if !ok {
@@ -1161,6 +1161,7 @@ func iroh_streamplace_cgo_dispatchCallbackInterfaceDataHandlerMethod0(uniffiHand
 		}()
 
 		uniffiObj.HandleData(
+			FfiConverterPublicKeyINSTANCE.Lift(from),
 			FfiConverterStringINSTANCE.Lift(GoRustBuffer{
 				inner: topic,
 			}),

--- a/pkg/iroh/generated/iroh_streamplace/iroh_streamplace.h
+++ b/pkg/iroh/generated/iroh_streamplace/iroh_streamplace.h
@@ -380,14 +380,14 @@ static void call_UniffiForeignFutureCompleteVoid(
 #endif
 #ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_DATA_HANDLER_METHOD0
 #define UNIFFI_FFIDEF_CALLBACK_INTERFACE_DATA_HANDLER_METHOD0
-typedef void (*UniffiCallbackInterfaceDataHandlerMethod0)(uint64_t uniffi_handle, RustBuffer topic, RustBuffer data, UniffiForeignFutureCompleteVoid uniffi_future_callback, uint64_t uniffi_callback_data, UniffiForeignFuture* uniffi_out_return);
+typedef void (*UniffiCallbackInterfaceDataHandlerMethod0)(uint64_t uniffi_handle, void* from, RustBuffer topic, RustBuffer data, UniffiForeignFutureCompleteVoid uniffi_future_callback, uint64_t uniffi_callback_data, UniffiForeignFuture* uniffi_out_return);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiCallbackInterfaceDataHandlerMethod0(
-				UniffiCallbackInterfaceDataHandlerMethod0 cb, uint64_t uniffi_handle, RustBuffer topic, RustBuffer data, UniffiForeignFutureCompleteVoid uniffi_future_callback, uint64_t uniffi_callback_data, UniffiForeignFuture* uniffi_out_return)
+				UniffiCallbackInterfaceDataHandlerMethod0 cb, uint64_t uniffi_handle, void* from, RustBuffer topic, RustBuffer data, UniffiForeignFutureCompleteVoid uniffi_future_callback, uint64_t uniffi_callback_data, UniffiForeignFuture* uniffi_out_return)
 {
-	return cb(uniffi_handle, topic, data, uniffi_future_callback, uniffi_callback_data, uniffi_out_return);
+	return cb(uniffi_handle, from, topic, data, uniffi_future_callback, uniffi_callback_data, uniffi_out_return);
 }
 
 
@@ -439,7 +439,7 @@ void uniffi_iroh_streamplace_fn_init_callback_vtable_datahandler(UniffiVTableCal
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_STREAMPLACE_FN_METHOD_DATAHANDLER_HANDLE_DATA
 #define UNIFFI_FFIDEF_UNIFFI_IROH_STREAMPLACE_FN_METHOD_DATAHANDLER_HANDLE_DATA
-uint64_t uniffi_iroh_streamplace_fn_method_datahandler_handle_data(void* ptr, RustBuffer topic, RustBuffer data
+uint64_t uniffi_iroh_streamplace_fn_method_datahandler_handle_data(void* ptr, void* from, RustBuffer topic, RustBuffer data
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IROH_STREAMPLACE_FN_CLONE_DB
@@ -1293,7 +1293,7 @@ uint32_t ffi_iroh_streamplace_uniffi_contract_version(void
 );
 #endif
 
- void iroh_streamplace_cgo_dispatchCallbackInterfaceDataHandlerMethod0(uint64_t uniffi_handle, RustBuffer topic, RustBuffer data, UniffiForeignFutureCompleteVoid uniffi_future_callback, uint64_t uniffi_callback_data, UniffiForeignFuture* uniffi_out_return);
+ void iroh_streamplace_cgo_dispatchCallbackInterfaceDataHandlerMethod0(uint64_t uniffi_handle, void* from, RustBuffer topic, RustBuffer data, UniffiForeignFutureCompleteVoid uniffi_future_callback, uint64_t uniffi_callback_data, UniffiForeignFuture* uniffi_out_return);
  void iroh_streamplace_cgo_dispatchCallbackInterfaceDataHandlerFree(uint64_t handle);
  void iroh_streamplace_cgo_dispatchCallbackInterfaceGoSignerMethod0(uint64_t uniffi_handle, RustBuffer data, RustBuffer* uniffi_out_return, RustCallStatus* callStatus );
  void iroh_streamplace_cgo_dispatchCallbackInterfaceGoSignerFree(uint64_t handle);

--- a/pkg/replication/iroh_replicator/kv.go
+++ b/pkg/replication/iroh_replicator/kv.go
@@ -23,7 +23,7 @@ type IrohSwarm struct {
 	NodeID           string
 	NodeTicket       string
 	activeSubs       map[string]*OriginInfo
-	handleDataScoped func(topic string, data []byte)
+	handleDataScoped func(pubKey *iroh_streamplace.PublicKey, topic string, data []byte)
 }
 
 // A message saying "hey I ingested node data at this time"
@@ -49,7 +49,7 @@ func NewSwarm(ctx context.Context, tickets []string, secret []byte, mm *media.Me
 	}
 
 	// workaround to get context into the HandleData callback
-	swarm.handleDataScoped = func(topic string, data []byte) {
+	swarm.handleDataScoped = func(_ *iroh_streamplace.PublicKey, topic string, data []byte) {
 		if ctx.Err() != nil {
 			return
 		}
@@ -205,8 +205,8 @@ func (swarm *IrohSwarm) startSegmentSender(ctx context.Context) error {
 	}
 }
 
-func (swarm *IrohSwarm) HandleData(topic string, data []byte) {
-	swarm.handleDataScoped(topic, data)
+func (swarm *IrohSwarm) HandleData(pubKey *iroh_streamplace.PublicKey, topic string, data []byte) {
+	swarm.handleDataScoped(pubKey, topic, data)
 }
 
 func (swarm *IrohSwarm) SendSegment(ctx context.Context, not *media.NewSegmentNotification) error {

--- a/rust/iroh-streamplace/Cargo.toml
+++ b/rust/iroh-streamplace/Cargo.toml
@@ -8,7 +8,8 @@ name = "iroh_streamplace"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-iroh = { version = "0.92", features = ["discovery-local-network"] }
+iroh = { version = "0.93", features = ["discovery-local-network"] }
+iroh-base = "0.93.0"
 tokio = "1.47.1"
 
 uniffi = { version = "=0.28.3", features = ["tokio"] }
@@ -21,20 +22,19 @@ snafu = "0.8.6"
 anyhow = "1.0.99"
 serde = { version = "1.0.219", features = ["derive"] }
 postcard = { version = "1.1.3", features = ["use-std"] }
-irpc = "0.8.0"
-irpc-iroh = "0.8.0"
+irpc = "0.9.0"
+irpc-iroh = "0.9.0"
 c2pa = { git = "https://github.com/hyphacoop/c2pa-rs.git", rev = "1b84d40219b27340a30fc309250e774e8a7b7761", features = [
   "openssl",
   "file_io",
 ] }
 thiserror = "2.0.16"
 serde_json = "1.0.145"
-iroh-smol-kv = { version = "0.2.0", git = "https://github.com/n0-computer/iroh-smol-kv" }
+iroh-smol-kv = { version = "0.3.1" }
 hex = "0.4.3"
-iroh-gossip = "0.92.0"
+iroh-gossip = "0.93.1"
 ref-cast = "1.0.25"
-iroh-base = "0.92.0"
-rand = "0.8.5"
+rand = "0.9"
 
 [dev-dependencies]
 testresult = "0.4.1"

--- a/rust/iroh-streamplace/src/lib.rs
+++ b/rust/iroh-streamplace/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use iroh::{NodeId, PublicKey, RelayMode, SecretKey, Watcher};
+use iroh::{NodeId, PublicKey, RelayMode, SecretKey, discovery::static_provider::StaticProvider};
 use iroh_base::ticket::NodeTicket;
 use iroh_gossip::{net::Gossip, proto::TopicId};
 use irpc::{WithChannels, rpc::RemoteService};
@@ -190,6 +190,8 @@ struct Actor {
     connections: ConnectionPool,
     /// How to handle incoming data
     handler: HandlerMode,
+    /// Static provider for node discovery
+    sp: StaticProvider,
     /// Iroh protocol router, I need to keep it around to keep the protocol alive
     router: iroh::protocol::Router,
     /// Metadata db
@@ -257,6 +259,7 @@ impl ConnectionPool {
 impl Actor {
     pub async fn spawn(
         endpoint: iroh::Endpoint,
+        sp: StaticProvider,
         topic: iroh_gossip::proto::TopicId,
         config: Config,
         handler: HandlerMode,
@@ -286,6 +289,7 @@ impl Actor {
             connections: ConnectionPool::new(router.endpoint().clone()),
             handler,
             router,
+            sp,
             write: write.clone(),
             client: client.clone(),
             tasks: FuturesUnordered::new(),
@@ -502,7 +506,7 @@ impl Actor {
                     ..
                 } = msg;
                 for addr in &peers {
-                    self.router.endpoint().add_node_addr(addr.clone()).ok();
+                    self.sp.add_node_info(addr.clone());
                 }
                 // self.client.inner().join_peers(ids).await.ok();
                 tx.send(()).await.ok();
@@ -520,7 +524,7 @@ impl Actor {
                     .filter(|id| *id != self.node_id())
                     .collect::<HashSet<_>>();
                 for addr in &peers {
-                    self.router.endpoint().add_node_addr(addr.clone()).ok();
+                    self.sp.add_node_info(addr.clone());
                 }
                 self.client.inner().join_peers(ids).await.ok();
                 tx.send(()).await.ok();
@@ -530,9 +534,9 @@ impl Actor {
                 let WithChannels { tx, .. } = msg;
                 if !self.config.disable_relay {
                     // don't await home relay if we have disabled relays, this will hang forever
-                    self.router.endpoint().home_relay().initialized().await;
+                    self.router.endpoint().online().await;
                 }
-                let addr = self.router.endpoint().node_addr().initialized().await;
+                let addr = self.router.endpoint().node_addr();
                 tx.send(addr).await.ok();
             }
             ApiMessage::Shutdown(msg) => {
@@ -551,7 +555,11 @@ impl Actor {
         remotes: &BTreeSet<NodeId>,
     ) {
         let me = connections.endpoint.node_id();
-        let msg = rpc::RecvSegment { key, data, from: me };
+        let msg = rpc::RecvSegment {
+            key,
+            data,
+            from: me,
+        };
         for remote in remotes {
             trace!("sending to stream {}: {}", msg.key, remote);
             let conn = connections.get(remote);
@@ -613,15 +621,17 @@ impl Node {
         } else {
             RelayMode::Default
         };
+        let sp = StaticProvider::new();
         let endpoint = iroh::Endpoint::builder()
             .secret_key(secret_key)
             .relay_mode(relay_mode)
+            .discovery(sp.clone())
             .bind()
             .await
             .map_err(|e| CreateError::Bind {
                 message: e.to_string(),
             })?;
-        let (api, actor) = Actor::spawn(endpoint, topic, config, handler)
+        let (api, actor) = Actor::spawn(endpoint, sp, topic, config, handler)
             .await
             .map_err(|e| CreateError::Subscribe {
                 message: e.to_string(),
@@ -639,7 +649,12 @@ impl Node {
 #[uniffi::export(with_foreign)]
 #[async_trait::async_trait]
 pub trait DataHandler: Send + Sync {
-    async fn handle_data(&self, from: Arc<crate::public_key::PublicKey>, topic: String, data: Vec<u8>);
+    async fn handle_data(
+        &self,
+        from: Arc<crate::public_key::PublicKey>,
+        topic: String,
+        data: Vec<u8>,
+    );
 }
 
 #[uniffi::export]

--- a/rust/iroh-streamplace/src/lib.rs
+++ b/rust/iroh-streamplace/src/lib.rs
@@ -62,6 +62,7 @@ mod rpc {
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct RecvSegment {
+        pub from: NodeId,
         pub key: String,
         pub data: Bytes,
     }
@@ -399,7 +400,7 @@ impl Actor {
                 trace!("{:?}", msg.inner);
                 let WithChannels {
                     tx,
-                    inner: rpc::RecvSegment { key, data },
+                    inner: rpc::RecvSegment { key, from, data },
                     ..
                 } = msg;
                 match &self.handler {
@@ -422,7 +423,8 @@ impl Actor {
                     }
                     HandlerMode::Receiver(handler) => {
                         if self.subscriptions.contains_key(&key) {
-                            handler.handle_data(key, data.to_vec()).await;
+                            let from = Arc::new(from.into());
+                            handler.handle_data(from, key, data.to_vec()).await;
                         } else {
                             warn!("received segment for unsubscribed key: {}", key);
                         }
@@ -548,7 +550,8 @@ impl Actor {
         data: Bytes,
         remotes: &BTreeSet<NodeId>,
     ) {
-        let msg = rpc::RecvSegment { key, data };
+        let me = connections.endpoint.node_id();
+        let msg = rpc::RecvSegment { key, data, from: me };
         for remote in remotes {
             trace!("sending to stream {}: {}", msg.key, remote);
             let conn = connections.get(remote);
@@ -636,7 +639,7 @@ impl Node {
 #[uniffi::export(with_foreign)]
 #[async_trait::async_trait]
 pub trait DataHandler: Send + Sync {
-    async fn handle_data(&self, topic: String, data: Vec<u8>);
+    async fn handle_data(&self, from: Arc<crate::public_key::PublicKey>, topic: String, data: Vec<u8>);
 }
 
 #[uniffi::export]

--- a/rust/iroh-streamplace/src/public_key.rs
+++ b/rust/iroh-streamplace/src/public_key.rs
@@ -85,7 +85,7 @@ impl PublicKey {
     /// Convert to a base32 string limited to the first 10 bytes for a friendly string
     /// representation of the key.
     pub fn fmt_short(&self) -> String {
-        iroh::PublicKey::from(self).fmt_short()
+        iroh::PublicKey::from(self).fmt_short().to_string()
     }
 }
 

--- a/rust/iroh-streamplace/src/tests.rs
+++ b/rust/iroh-streamplace/src/tests.rs
@@ -130,7 +130,7 @@ impl<T> TestHandler<T> {
 
 #[async_trait]
 impl<T: Clone + Send + Sync + 'static> DataHandler for TestHandler<T> {
-    async fn handle_data(&self, topic: String, data: Vec<u8>) {
+    async fn handle_data(&self, _from: Arc<public_key::PublicKey>, topic: String, data: Vec<u8>) {
         self.sender
             .send((self.info.clone(), topic, data))
             .await

--- a/rust/iroh-streamplace/src/tests.rs
+++ b/rust/iroh-streamplace/src/tests.rs
@@ -35,7 +35,7 @@ impl TestNode {
     }
 
     async fn new_with_config(handler: HandlerMode, mut config: Config) -> TestResult<TestNode> {
-        let key = iroh::SecretKey::generate(&mut rand::rngs::OsRng);
+        let key = iroh::SecretKey::generate(&mut rand::rng());
         let key = key.to_bytes().to_vec();
         config.key = key.clone();
         let node = Node::new_in_runtime(config, handler).await?;


### PR DESCRIPTION
This adds the sender key to the data handler. It is not yet verified, but that would be something on the rust side we can do without changing the public API.

Also update to the latest iroh version.

Note: I have not yet updated the usages in golang.