### PR TITLE
fix: make all app.bsky proxied requests unauthed

### DIFF
--- a/pkg/spxrpc/spxrpc.go
+++ b/pkg/spxrpc/spxrpc.go
@@ -92,8 +92,6 @@ func makeUnauthenticatedRequest(ctx context.Context, service, method string, par
 	}
 	u.RawQuery = query.Encode()
 
-	log.Error(ctx, "making unauthenticated request", "url", u.String())
-
 	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)

--- a/pkg/spxrpc/wildcard.go
+++ b/pkg/spxrpc/wildcard.go
@@ -16,21 +16,27 @@ func (s *Server) HandleWildcard(c echo.Context) error {
 	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandleWildcard")
 	defer span.End()
 
-	session, client := oatproxy.GetOAuthSession(ctx)
-	if session == nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "oauth session not found")
-	}
-
-	var out map[string]any
-
 	// Get the last path segment in the URL
 	path := c.Request().URL.Path
 	segments := strings.Split(path, "/")
 	lastSegment := segments[len(segments)-1]
 
+	session, client := oatproxy.GetOAuthSession(ctx)
+
+	// Allow app.bsky.* GET requests without authentication
+	isAppBskyMethod := strings.HasPrefix(lastSegment, "app.bsky.")
+	isGetRequest := c.Request().Method == "GET"
+
+	// Require authentication for non-app.bsky methods and all POST requests
+	if !isAppBskyMethod && session == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "oauth session not found")
+	}
+
+	var out map[string]any
 	var xrpcType string
 	var err error
-	if c.Request().Method == "GET" {
+
+	if isGetRequest {
 		xrpcType = xrpc.Query
 		queryParams := make(map[string]any)
 		for k, v := range c.QueryParams() {
@@ -38,8 +44,23 @@ func (s *Server) HandleWildcard(c echo.Context) error {
 				queryParams[k] = vv
 			}
 		}
-		err = client.Do(ctx, xrpcType, "application/json", lastSegment, queryParams, nil, &out)
+
+		// make unauthed request if this is an app.bsky method
+		if client != nil && !isAppBskyMethod {
+			err = client.Do(ctx, xrpcType, "application/json", lastSegment, queryParams, nil, &out)
+		} else if isAppBskyMethod {
+			log.Log(ctx, "making unauthenticated request for app.bsky method", "method", lastSegment)
+			err = makeUnauthenticatedRequest(ctx, "https://public.api.bsky.app", lastSegment, queryParams, &out)
+		} else {
+			// just in case?
+			return echo.NewHTTPError(http.StatusUnauthorized, "oauth session not found for non-app.bsky method")
+		}
 	} else {
+		// POST/PUT/DELETE requests require authentication
+		if session == nil {
+			return echo.NewHTTPError(http.StatusUnauthorized, "oauth session not found")
+		}
+
 		xrpcType = xrpc.Procedure
 		var body map[string]any
 		if err := c.Bind(&body); err != nil {

--- a/pkg/spxrpc/wildcard.go
+++ b/pkg/spxrpc/wildcard.go
@@ -23,11 +23,10 @@ func (s *Server) HandleWildcard(c echo.Context) error {
 
 	session, client := oatproxy.GetOAuthSession(ctx)
 
-	// Allow app.bsky.* GET requests without authentication
 	isAppBskyMethod := strings.HasPrefix(lastSegment, "app.bsky.")
 	isGetRequest := c.Request().Method == "GET"
 
-	// Require authentication for non-app.bsky methods and all POST requests
+	// if not an app.bsky method, we need an oauth session
 	if !isAppBskyMethod && session == nil {
 		return echo.NewHTTPError(http.StatusUnauthorized, "oauth session not found")
 	}
@@ -36,6 +35,7 @@ func (s *Server) HandleWildcard(c echo.Context) error {
 	var xrpcType string
 	var err error
 
+	// make unauthed request if this is a get and app.bsky method
 	if isGetRequest {
 		xrpcType = xrpc.Query
 		queryParams := make(map[string]any)
@@ -45,7 +45,6 @@ func (s *Server) HandleWildcard(c echo.Context) error {
 			}
 		}
 
-		// make unauthed request if this is an app.bsky method
 		if client != nil && !isAppBskyMethod {
 			err = client.Do(ctx, xrpcType, "application/json", lastSegment, queryParams, nil, &out)
 		} else if isAppBskyMethod {
@@ -56,7 +55,6 @@ func (s *Server) HandleWildcard(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusUnauthorized, "oauth session not found for non-app.bsky method")
 		}
 	} else {
-		// POST/PUT/DELETE requests require authentication
 		if session == nil {
 			return echo.NewHTTPError(http.StatusUnauthorized, "oauth session not found")
 		}


### PR DESCRIPTION
Attempt to fix "signature doesn't match issuer" by making unauthed requests?