### PR TITLE
golive: add bluesky push checkboxes, remove edit

### DIFF
--- a/js/app/components/live-dashboard/livestream-panel.tsx
+++ b/js/app/components/live-dashboard/livestream-panel.tsx
@@ -1,15 +1,19 @@
 import {
   Button,
   ContentMetadataForm,
+  Input,
   Textarea,
   useCreateStreamRecord,
   useLivestream,
   useToast,
   useUpdateStreamRecord,
+  useUrl,
   zero,
 } from "@streamplace/components";
+import { Checkbox } from "@streamplace/components/src/components/ui/checkbox";
+import { Tooltip } from "@streamplace/components/src/components/ui/tooltip";
 import { ImagePlus, X } from "lucide-react-native";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Image,
   Platform,
@@ -165,22 +169,48 @@ function LivestreamPanel() {
   const livestream = useLivestream();
   const createStreamRecord = useCreateStreamRecord();
   const updateStreamRecord = useUpdateStreamRecord();
+  const url = useUrl();
 
   const [title, setTitle] = useState("");
   const [loading, setLoading] = useState(false);
   const [selectedImage, setSelectedImage] = useState<
     string | File | Blob | undefined
   >();
-  const [mode, setMode] = useState<"create" | "edit" | "metadata">(
-    livestream ? "edit" : "create",
-  );
+  const [mode, setMode] = useState<"create" | "metadata">("create");
 
-  const handleModeChange = useCallback(
-    (newMode: "create" | "edit" | "metadata") => {
-      setMode(newMode);
-    },
-    [],
+  const [createPost, setCreatePost] = useState(true);
+  const [sendPushNotification, setSendPushNotification] = useState(true);
+  const [canonicalUrl, setCanonicalUrl] = useState<string>(
+    livestream?.record.canonicalUrl || "",
   );
+  const defaultCanonicalUrl = useMemo(() => {
+    return `${url}/${profile?.handle}`;
+  }, [url, profile?.handle]);
+
+  useEffect(() => {
+    if (!livestream) {
+      return;
+    }
+    if (
+      livestream.record.canonicalUrl &&
+      livestream.record.canonicalUrl !== defaultCanonicalUrl
+    ) {
+      setCanonicalUrl(livestream.record.canonicalUrl);
+    }
+    if (
+      typeof livestream.record.notificationSettings?.pushNotification ===
+      "boolean"
+    ) {
+      setSendPushNotification(
+        livestream.record.notificationSettings.pushNotification,
+      );
+    }
+    setCreatePost(typeof livestream.record.post !== "undefined");
+  }, [livestream, defaultCanonicalUrl]);
+
+  const handleModeChange = useCallback((newMode: "create" | "metadata") => {
+    setMode(newMode);
+  }, []);
 
   const handleSubmit = useCallback(async () => {
     if (!title.trim()) return;
@@ -206,7 +236,11 @@ function LivestreamPanel() {
         await createStreamRecord({
           title: title.trim(),
           customThumbnail: thumbnailToUse as Blob | undefined,
-          submitPost: true,
+          submitPost: createPost,
+          notificationSettings: {
+            pushNotification: sendPushNotification,
+          },
+          canonicalUrl: canonicalUrl || undefined,
         });
       } else {
         await updateStreamRecord(
@@ -278,11 +312,9 @@ function LivestreamPanel() {
     setSelectedImage(undefined);
   }, []);
 
-  const noLivestream = mode === "edit" && !livestream;
-
   const disabled = useMemo(
-    () => !userIsLive || loading || title.trim() === "" || noLivestream,
-    [userIsLive, loading, title, noLivestream],
+    () => !userIsLive || loading || title.trim() === "",
+    [userIsLive, loading, title],
   );
 
   const buttonText = useMemo(() => {
@@ -330,31 +362,16 @@ function LivestreamPanel() {
             <ButtonSelector
               values={[
                 { label: "Create", value: "create" },
-                { label: "Edit", value: "edit" },
                 { label: "Metadata", value: "metadata" },
               ]}
               style={[{ marginVertical: -2 }]}
               selectedValue={mode}
               setSelectedValue={handleModeChange as any}
-              disabledValues={livestream ? [] : ["edit"]}
+              disabledValues={[]}
             />
           </View>
 
-          {mode === "edit" && (
-            <Text
-              style={[p[4], text.white, typography.universal?.xl || text.white]}
-            >
-              Change your Current Livestream Title
-            </Text>
-          )}
-
-          {noLivestream ? (
-            <View style={[layout.flex.center, p[4]]}>
-              <Text style={[text.neutral[400], { fontSize: 16 }]}>
-                No active livestream to edit. Start a livestream first!
-              </Text>
-            </View>
-          ) : mode === "metadata" ? (
+          {mode === "metadata" ? (
             // Metadata view
             <View style={[flex.values[1], p[4]]}>
               <ContentMetadataForm
@@ -455,7 +472,11 @@ function LivestreamPanel() {
                     </View>
                   </View>
                 </View>
-                {mode === "edit" && (
+
+                <Tooltip
+                  content="Set this to have the livestream announced with a link to this URL instead of the default URL."
+                  position="top"
+                >
                   <View
                     style={[
                       layout.flex.row,
@@ -463,14 +484,64 @@ function LivestreamPanel() {
                       w.percent[100],
                     ]}
                   >
+                    <Text
+                      style={[
+                        text.neutral[300],
+                        {
+                          minWidth: 100,
+                          textAlign: "left",
+                          paddingBottom: 8,
+                          fontSize: 14,
+                        },
+                      ]}
+                    >
+                      Canonical URL
+                    </Text>
                     <View style={[flex.values[1]]}>
-                      <Text style={[text.neutral[400], { fontSize: 12 }]}>
-                        Updating will not send out notifications to viewers or
-                        create a new social media post.
-                      </Text>
+                      <Input
+                        value={canonicalUrl}
+                        onChange={(value) => setCanonicalUrl(value)}
+                        placeholder={defaultCanonicalUrl}
+                        variant="filled"
+                        inputStyle={[
+                          p[3],
+                          r.md,
+                          bg.neutral[800],
+                          text.white,
+                          borders.width.thin,
+                          borders.color.neutral[600],
+                          w.percent[100],
+                        ]}
+                      />
                     </View>
                   </View>
-                )}
+                </Tooltip>
+
+                <Tooltip
+                  content="Create a Bluesky post announcing you're live with a link to the stream."
+                  position="top"
+                >
+                  <Checkbox
+                    checked={createPost}
+                    onCheckedChange={(checked) => setCreatePost(checked)}
+                    label={"Create Bluesky post"}
+                    style={[{ fontSize: 12 }]}
+                  />
+                </Tooltip>
+
+                <Tooltip
+                  content="Send a push notification to your followers on the Streamplace iOS/Android app."
+                  position="top"
+                >
+                  <Checkbox
+                    checked={sendPushNotification}
+                    onCheckedChange={(checked) =>
+                      setSendPushNotification(checked)
+                    }
+                    label={"Send push notification"}
+                    style={[{ fontSize: 12 }]}
+                  />
+                </Tooltip>
               </View>
 
               {/* Image upload for create mode */}

--- a/js/app/components/live-dashboard/livestream-panel.tsx
+++ b/js/app/components/live-dashboard/livestream-panel.tsx
@@ -1,8 +1,10 @@
 import {
   Button,
+  Checkbox,
   ContentMetadataForm,
   Input,
   Textarea,
+  Tooltip,
   useCreateStreamRecord,
   useLivestream,
   useToast,
@@ -10,8 +12,6 @@ import {
   useUrl,
   zero,
 } from "@streamplace/components";
-import { Checkbox } from "@streamplace/components/src/components/ui/checkbox";
-import { Tooltip } from "@streamplace/components/src/components/ui/tooltip";
 import { ImagePlus, X } from "lucide-react-native";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {

--- a/js/components/src/components/ui/index.ts
+++ b/js/components/src/components/ui/index.ts
@@ -6,6 +6,7 @@ export * from "./primitives/text";
 
 // Export styled components
 export * from "./button";
+export * from "./checkbox";
 export * from "./dialog";
 export * from "./dropdown";
 export * from "./icons";
@@ -18,6 +19,7 @@ export * from "./slider";
 export * from "./text";
 export * from "./textarea";
 export * from "./toast";
+export * from "./tooltip";
 export * from "./view";
 
 // Component collections for easy importing

--- a/js/components/src/hooks/useLivestreamInfo.ts
+++ b/js/components/src/hooks/useLivestreamInfo.ts
@@ -23,7 +23,7 @@ export function useLivestreamInfo(url?: string) {
         // Create the livestream record with title and custom url if available
         await createStreamRecord({
           title,
-          customUrl: url || null,
+          canonicalUrl: url || undefined,
         });
       }
     } catch (error) {

--- a/js/components/src/streamplace-store/stream.tsx
+++ b/js/components/src/streamplace-store/stream.tsx
@@ -131,18 +131,17 @@ export function useCreateStreamRecord() {
     title,
     customThumbnail,
     submitPost,
-    customUrl,
+    canonicalUrl,
+    notificationSettings,
   }: {
     title: string;
     customThumbnail?: Blob;
     submitPost?: boolean;
-    customUrl?: string | null;
+    canonicalUrl?: string;
+    notificationSettings?: PlaceStreamLivestream.NotificationSettings;
   }) => {
-    if (!submitPost) {
+    if (typeof submitPost !== "boolean") {
       submitPost = true;
-    }
-    if (!customUrl) {
-      customUrl = null;
     }
     if (!agent) {
       throw new Error("No PDS agent found");
@@ -152,8 +151,6 @@ export function useCreateStreamRecord() {
       throw new Error("No user DID found, assuming not logged in");
     }
 
-    // Use customUrl if provided, otherwise fall back to the store URL
-    const finalUrl = customUrl || url;
     const u = new URL(url);
 
     let thumbnail: BlobRef | undefined = undefined;
@@ -247,19 +244,28 @@ export function useCreateStreamRecord() {
       platVersion = getBrowserName(window.navigator.userAgent);
     }
 
+    const thisUrl = `${url}/${profile.data.handle}`;
+    if (!canonicalUrl) {
+      canonicalUrl = thisUrl;
+    }
+
     const record: PlaceStreamLivestream.Record = {
       $type: "place.stream.livestream",
       title: title,
-      url: finalUrl,
+      url: thisUrl,
       createdAt: new Date().toISOString(),
       // would match up with e.g. https://stream.place/iame.li
-      canonicalUrl: `${finalUrl}/${profile.data.handle}`,
+      canonicalUrl: canonicalUrl,
       // user agent style string
       // e.g. `@streamplace/components/0.1.0 (ios, 32.0)`
       agent: `@streamplace/components/${PackageJson.version} (${platform}, ${platVersion})`,
       post: newPost,
       thumb: thumbnail,
     };
+
+    if (notificationSettings) {
+      record.notificationSettings = notificationSettings;
+    }
 
     await agent.com.atproto.repo.createRecord({
       repo: agent.did,

--- a/js/docs/src/content/docs/lex-reference/place-stream-livestream.md
+++ b/js/docs/src/content/docs/lex-reference/place-stream-livestream.md
@@ -19,15 +19,30 @@ Record announcing a livestream is happening
 
 **Record Properties:**
 
-| Name           | Type                                                                                                                                   | Req'd | Description                                                                                                                              | Constraints                                   |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| `title`        | `string`                                                                                                                               | ✅    | The title of the livestream, as it will be announced to followers.                                                                       | Max Length: 1400<br/>Max Graphemes: 140       |
-| `url`          | `string`                                                                                                                               | ❌    | The URL where this stream can be found. This is primarily a hint for other Streamplace nodes to locate and replicate the stream.         | Format: `uri`                                 |
-| `createdAt`    | `string`                                                                                                                               | ✅    | Client-declared timestamp when this livestream started.                                                                                  | Format: `datetime`                            |
-| `post`         | [`com.atproto.repo.strongRef`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/repo/strongref.json#undefined) | ❌    | The post that announced this livestream.                                                                                                 |                                               |
-| `agent`        | `string`                                                                                                                               | ❌    | The source of the livestream, if available, in a User Agent format: `<product> / <product-version> <comment>` e.g. Streamplace/0.7.5 iOS |                                               |
-| `canonicalUrl` | `string`                                                                                                                               | ❌    | The primary URL where this livestream can be viewed, if available.                                                                       | Format: `uri`                                 |
-| `thumb`        | `blob`                                                                                                                                 | ❌    |                                                                                                                                          | Accept: `image/*`<br/>Max Size: 1000000 bytes |
+| Name                   | Type                                                                                                                                   | Req'd | Description                                                                                                                              | Constraints                                   |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `title`                | `string`                                                                                                                               | ✅    | The title of the livestream, as it will be announced to followers.                                                                       | Max Length: 1400<br/>Max Graphemes: 140       |
+| `url`                  | `string`                                                                                                                               | ❌    | The URL where this stream can be found. This is primarily a hint for other Streamplace nodes to locate and replicate the stream.         | Format: `uri`                                 |
+| `createdAt`            | `string`                                                                                                                               | ✅    | Client-declared timestamp when this livestream started.                                                                                  | Format: `datetime`                            |
+| `post`                 | [`com.atproto.repo.strongRef`](https://github.com/bluesky-social/atproto/tree/main/lexicons/com/atproto/repo/strongref.json#undefined) | ❌    | The post that announced this livestream.                                                                                                 |                                               |
+| `agent`                | `string`                                                                                                                               | ❌    | The source of the livestream, if available, in a User Agent format: `<product> / <product-version> <comment>` e.g. Streamplace/0.7.5 iOS |                                               |
+| `canonicalUrl`         | `string`                                                                                                                               | ❌    | The primary URL where this livestream can be viewed, if available.                                                                       | Format: `uri`                                 |
+| `thumb`                | `blob`                                                                                                                                 | ❌    |                                                                                                                                          | Accept: `image/*`<br/>Max Size: 1000000 bytes |
+| `notificationSettings` | [`place.stream.livestream#notificationSettings`](/lex-reference/place-stream-livestream#notificationsettings)                          | ❌    |                                                                                                                                          |                                               |
+
+---
+
+<a name="notificationsettings"></a>
+
+### `notificationSettings`
+
+**Type:** `object`
+
+**Properties:**
+
+| Name               | Type      | Req'd | Description                                                              | Constraints |
+| ------------------ | --------- | ----- | ------------------------------------------------------------------------ | ----------- |
+| `pushNotification` | `boolean` | ❌    | Whether this livestream should trigger a push notification to followers. |             |
 
 ---
 
@@ -127,7 +142,21 @@ Record announcing a livestream is happening
             "type": "blob",
             "accept": ["image/*"],
             "maxSize": 1000000
+          },
+          "notificationSettings": {
+            "type": "ref",
+            "ref": "place.stream.livestream#notificationSettings"
           }
+        }
+      }
+    },
+    "notificationSettings": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "pushNotification": {
+          "type": "boolean",
+          "description": "Whether this livestream should trigger a push notification to followers."
         }
       }
     },

--- a/lexicons/place/stream/livestream.json
+++ b/lexicons/place/stream/livestream.json
@@ -44,7 +44,21 @@
             "type": "blob",
             "accept": ["image/*"],
             "maxSize": 1000000
+          },
+          "notificationSettings": {
+            "type": "ref",
+            "ref": "place.stream.livestream#notificationSettings"
           }
+        }
+      }
+    },
+    "notificationSettings": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "pushNotification": {
+          "type": "boolean",
+          "description": "Whether this livestream should trigger a push notification to followers."
         }
       }
     },

--- a/pkg/atproto/sync.go
+++ b/pkg/atproto/sync.go
@@ -365,13 +365,6 @@ func (atsync *ATProtoSynchronizer) handleCreateUpdate(ctx context.Context, userD
 			task.ChatProfile = spcp
 		}
 
-		if !isUpdate && !isFirstSync {
-			_, err = atsync.StatefulDB.EnqueueTask(ctx, statedb.TaskNotification, task, statedb.WithTaskKey(fmt.Sprintf("notification-blast::%s", aturi.String())))
-			if err != nil {
-				log.Error(ctx, "failed to enqueue notification task", "err", err)
-			}
-		}
-
 	case *streamplace.Key:
 		log.Debug(ctx, "creating key", "key", rec)
 		time, err := aqtime.FromString(rec.CreatedAt)

--- a/pkg/director/stream_session.go
+++ b/pkg/director/stream_session.go
@@ -137,7 +137,7 @@ func (ss *StreamSession) Go(ctx context.Context, f func() error) {
 	ss.g.Go(func() error {
 		err := f()
 		if err != nil {
-			log.Error(ctx, "error in goroutine", "error", err)
+			log.Error(ctx, "error in stream_session goroutine", "error", err)
 		}
 		return nil
 	})
@@ -198,7 +198,71 @@ func (ss *StreamSession) NewSegment(ctx context.Context, notif *media.NewSegment
 		})
 	}
 
+	// trigger a notification blast if this is a new livestream
+	if notif.Metadata.Livestream != nil {
+		ss.Go(ctx, func() error {
+			r, err := ss.mod.GetRepoByHandleOrDID(spseg.Creator)
+			if err != nil {
+				return fmt.Errorf("failed to get repo: %w", err)
+			}
+			livestreamModel, err := ss.mod.GetLatestLivestreamForRepo(spseg.Creator)
+			if err != nil {
+				return fmt.Errorf("failed to get latest livestream for repo: %w", err)
+			}
+			if livestreamModel == nil {
+				log.Warn(ctx, "no livestream found, skipping notification blast", "repoDID", spseg.Creator)
+				return nil
+			}
+			lsv, err := livestreamModel.ToLivestreamView()
+			if err != nil {
+				return fmt.Errorf("failed to convert livestream to streamplace livestream: %w", err)
+			}
+			if !shouldNotify(lsv) {
+				log.Warn(ctx, "is not set to notify", "repoDID", spseg.Creator)
+				return nil
+			}
+			task := &statedb.NotificationTask{
+				Livestream: lsv,
+				PDSURL:     r.PDS,
+			}
+			cp, err := ss.mod.GetChatProfile(ctx, spseg.Creator)
+			if err != nil {
+				return fmt.Errorf("failed to get chat profile: %w", err)
+			}
+			if cp != nil {
+				spcp, err := cp.ToStreamplaceChatProfile()
+				if err != nil {
+					return fmt.Errorf("failed to convert chat profile to streamplace chat profile: %w", err)
+				}
+				task.ChatProfile = spcp
+			}
+
+			_, err = ss.statefulDB.EnqueueTask(ctx, statedb.TaskNotification, task, statedb.WithTaskKey(fmt.Sprintf("notification-blast::%s", lsv.Uri)))
+			if err != nil {
+				log.Error(ctx, "failed to enqueue notification task", "err", err)
+			}
+			return ss.UpdateStatus(ctx, spseg.Creator)
+		})
+	} else {
+		log.Warn(ctx, "no livestream detected in stream, skipping notification blast", "repoDID", spseg.Creator)
+	}
+
 	return nil
+}
+
+func shouldNotify(lsv *streamplace.Livestream_LivestreamView) bool {
+	lsvr, ok := lsv.Record.Val.(*streamplace.Livestream)
+	if !ok {
+		return true
+	}
+	if lsvr.NotificationSettings == nil {
+		return true
+	}
+	settings := lsvr.NotificationSettings
+	if settings.PushNotification == nil {
+		return true
+	}
+	return *settings.PushNotification
 }
 
 func (ss *StreamSession) Thumbnail(ctx context.Context, repoDID string, not *media.NewSegmentNotification) error {
@@ -239,29 +303,6 @@ func (ss *StreamSession) Thumbnail(ctx context.Context, repoDID string, not *med
 	return nil
 }
 
-func getThumbnailCID(pv *bsky.FeedDefs_PostView) (*lexutil.LexBlob, error) {
-	if pv == nil {
-		return nil, fmt.Errorf("post view is nil")
-	}
-	rec, ok := pv.Record.Val.(*bsky.FeedPost)
-	if !ok {
-		return nil, fmt.Errorf("post view record is not a feed post")
-	}
-	if rec.Embed == nil {
-		return nil, fmt.Errorf("post view embed is nil")
-	}
-	if rec.Embed.EmbedExternal == nil {
-		return nil, fmt.Errorf("post view embed external view is nil")
-	}
-	if rec.Embed.EmbedExternal.External == nil {
-		return nil, fmt.Errorf("post view embed external is nil")
-	}
-	if rec.Embed.EmbedExternal.External.Thumb == nil {
-		return nil, fmt.Errorf("post view embed external thumb is nil")
-	}
-	return rec.Embed.EmbedExternal.External.Thumb, nil
-}
-
 func (ss *StreamSession) UpdateStatus(ctx context.Context, repoDID string) error {
 	ctx = log.WithLogValues(ctx, "func", "UpdateStatus")
 	ss.lastStatusLock.Lock()
@@ -293,21 +334,11 @@ func (ss *StreamSession) UpdateStatus(ctx context.Context, repoDID string) error
 		return fmt.Errorf("could not convert livestream to streamplace livestream: %w", err)
 	}
 
-	post, err := ss.mod.GetFeedPost(ls.PostURI)
-	if err != nil {
-		return fmt.Errorf("could not get feed post: %w", err)
+	lsvr, ok := lsv.Record.Val.(*streamplace.Livestream)
+	if !ok {
+		return fmt.Errorf("livestream is not a streamplace livestream")
 	}
-	if post == nil {
-		return fmt.Errorf("feed post not found for livestream: %w", err)
-	}
-	postView, err := post.ToBskyPostView()
-	if err != nil {
-		return fmt.Errorf("could not convert feed post to bsky post view: %w", err)
-	}
-	thumb, err := getThumbnailCID(postView)
-	if err != nil {
-		return fmt.Errorf("could not get thumbnail cid: %w", err)
-	}
+	thumb := lsvr.Thumb
 
 	repo, err := ss.mod.GetRepoByHandleOrDID(repoDID)
 	if err != nil {

--- a/pkg/gen/gen.go
+++ b/pkg/gen/gen.go
@@ -14,6 +14,7 @@ func main() {
 	if err := genCfg.WriteMapEncodersToFile("pkg/streamplace/cbor_gen.go", "streamplace",
 		streamplace.Key{},
 		streamplace.Livestream{},
+		streamplace.Livestream_NotificationSettings{},
 		streamplace.Segment{},
 		streamplace.Segment_Audio{},
 		streamplace.Segment_Video{},

--- a/pkg/integrations/discord/send-livestream.go
+++ b/pkg/integrations/discord/send-livestream.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/bluesky-social/indigo/api/bsky"
 	"golang.org/x/net/context/ctxhttp"
 	"stream.place/streamplace/pkg/aqhttp"
 	"stream.place/streamplace/pkg/integrations/discord/discordtypes"
@@ -20,7 +19,7 @@ import (
 	"stream.place/streamplace/pkg/streamplace"
 )
 
-func SendLivestream(ctx context.Context, w *discordtypes.Webhook, pdsURL string, lsv *streamplace.Livestream_LivestreamView, postView *bsky.FeedDefs_PostView, spcp *streamplace.ChatProfile) error {
+func SendLivestream(ctx context.Context, w *discordtypes.Webhook, pdsURL string, lsv *streamplace.Livestream_LivestreamView, spcp *streamplace.ChatProfile) error {
 	ctx = log.WithLogValues(ctx, "func", "SendLivestream")
 	ls, ok := lsv.Record.Val.(*streamplace.Livestream)
 	if !ok {

--- a/pkg/integrations/webhook/manager.go
+++ b/pkg/integrations/webhook/manager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bluesky-social/indigo/api/bsky"
 	"stream.place/streamplace/pkg/integrations/discord"
 	"stream.place/streamplace/pkg/integrations/discord/discordtypes"
 	"stream.place/streamplace/pkg/streamplace"
@@ -35,13 +34,13 @@ func SendChatWebhook(ctx context.Context, webhook *streamplace.ServerDefs_Webhoo
 }
 
 // SendLivestreamWebhook sends livestream notification to a specific webhook
-func SendLivestreamWebhook(ctx context.Context, webhook *streamplace.ServerDefs_Webhook, pdsURL string, lsv *streamplace.Livestream_LivestreamView, postView *bsky.FeedDefs_PostView, spcp *streamplace.ChatProfile) error {
+func SendLivestreamWebhook(ctx context.Context, webhook *streamplace.ServerDefs_Webhook, pdsURL string, lsv *streamplace.Livestream_LivestreamView, spcp *streamplace.ChatProfile) error {
 	discordWebhook, err := webhookToDiscordWebhook(webhook)
 	if err != nil {
 		return fmt.Errorf("failed to convert webhook: %w", err)
 	}
 
-	return discord.SendLivestream(ctx, discordWebhook, pdsURL, lsv, postView, spcp)
+	return discord.SendLivestream(ctx, discordWebhook, pdsURL, lsv, spcp)
 }
 
 // webhookToDiscordWebhook converts streamplace.ServerDefs_Webhook to discordtypes.Webhook

--- a/pkg/media/media.go
+++ b/pkg/media/media.go
@@ -251,6 +251,7 @@ func ParseSegmentAssertions(ctx context.Context, mani *c2patypes.Manifest) (*Seg
 	contentRights := extractContentRights(mani)
 	distributionPolicy := extractDistributionPolicy(mani, start)
 	metadataConfiguration := extractMetadataConfiguration(mani)
+	livestream := extractLivestream(mani)
 
 	out := SegmentMetadata{
 		StartTime:             start,
@@ -260,6 +261,7 @@ func ParseSegmentAssertions(ctx context.Context, mani *c2patypes.Manifest) (*Seg
 		ContentRights:         contentRights,
 		DistributionPolicy:    distributionPolicy,
 		MetadataConfiguration: metadataConfiguration,
+		Livestream:            livestream,
 	}
 	return &out, nil
 }
@@ -429,4 +431,22 @@ func extractMetadataConfiguration(mani *c2patypes.Manifest) *streamplace.Metadat
 		return nil
 	}
 	return &metadataConfiguration
+}
+
+func extractLivestream(mani *c2patypes.Manifest) *streamplace.Livestream {
+	ass := findAssertion(mani, "place.stream.livestream")
+	if ass == nil {
+		return nil
+	}
+	bs, err := json.Marshal(ass.Data)
+	if err != nil {
+		return nil
+	}
+
+	var livestream streamplace.Livestream
+	err = json.Unmarshal(bs, &livestream)
+	if err != nil {
+		return nil
+	}
+	return &livestream
 }

--- a/pkg/replication/iroh_replicator/kv.go
+++ b/pkg/replication/iroh_replicator/kv.go
@@ -192,7 +192,7 @@ func (swarm *IrohSwarm) startKV(ctx context.Context) error {
 func (swarm *IrohSwarm) handleIrohMessage(ctx context.Context, item iroh_streamplace.SubscribeItemEntry) error {
 	keyStr := string(item.Key)
 	valueStr := string(item.Value)
-	log.Warn(ctx, "SubscribeItemEntry", "key", keyStr, "value", valueStr)
+	log.Debug(ctx, "SubscribeItemEntry", "key", keyStr, "value", valueStr)
 	if len(valueStr) > 0 && valueStr[0] != '{' {
 		// not JSON, it's one of the rust messages
 		log.Debug(ctx, "not JSON", "key", keyStr, "value", valueStr)

--- a/pkg/statedb/queue_processor.go
+++ b/pkg/statedb/queue_processor.go
@@ -125,7 +125,7 @@ func (state *StatefulDB) processNotificationTask(ctx context.Context, task *AppT
 				continue
 			}
 			go func(lexiconWebhook *streamplace.ServerDefs_Webhook, wid string) {
-				err := webhook.SendLivestreamWebhook(ctx, lexiconWebhook, notificationTask.PDSURL, lsv, notificationTask.FeedPost, notificationTask.ChatProfile)
+				err := webhook.SendLivestreamWebhook(ctx, lexiconWebhook, notificationTask.PDSURL, lsv, notificationTask.ChatProfile)
 				if err != nil {
 					log.Error(ctx, "failed to send livestream to webhook", "err", err, "webhook_id", wid)
 					err := state.IncrementWebhookError(wid)

--- a/pkg/streamplace/cbor_gen.go
+++ b/pkg/streamplace/cbor_gen.go
@@ -250,13 +250,17 @@ func (t *Livestream) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
-	fieldCount := 8
+	fieldCount := 9
 
 	if t.Agent == nil {
 		fieldCount--
 	}
 
 	if t.CanonicalUrl == nil {
+		fieldCount--
+	}
+
+	if t.NotificationSettings == nil {
 		fieldCount--
 	}
 
@@ -474,6 +478,25 @@ func (t *Livestream) MarshalCBOR(w io.Writer) error {
 			}
 		}
 	}
+
+	// t.NotificationSettings (streamplace.Livestream_NotificationSettings) (struct)
+	if t.NotificationSettings != nil {
+
+		if len("notificationSettings") > 1000000 {
+			return xerrors.Errorf("Value in field \"notificationSettings\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("notificationSettings"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("notificationSettings")); err != nil {
+			return err
+		}
+
+		if err := t.NotificationSettings.MarshalCBOR(cw); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -502,7 +525,7 @@ func (t *Livestream) UnmarshalCBOR(r io.Reader) (err error) {
 
 	n := extra
 
-	nameBuf := make([]byte, 12)
+	nameBuf := make([]byte, 20)
 	for i := uint64(0); i < n; i++ {
 		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 1000000)
 		if err != nil {
@@ -652,6 +675,155 @@ func (t *Livestream) UnmarshalCBOR(r io.Reader) (err error) {
 					}
 
 					t.CanonicalUrl = (*string)(&sval)
+				}
+			}
+			// t.NotificationSettings (streamplace.Livestream_NotificationSettings) (struct)
+		case "notificationSettings":
+
+			{
+
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+					t.NotificationSettings = new(Livestream_NotificationSettings)
+					if err := t.NotificationSettings.UnmarshalCBOR(cr); err != nil {
+						return xerrors.Errorf("unmarshaling t.NotificationSettings pointer: %w", err)
+					}
+				}
+
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			if err := cbg.ScanForLinks(r, func(cid.Cid) {}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+func (t *Livestream_NotificationSettings) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+	fieldCount := 1
+
+	if t.PushNotification == nil {
+		fieldCount--
+	}
+
+	if _, err := cw.Write(cbg.CborEncodeMajorType(cbg.MajMap, uint64(fieldCount))); err != nil {
+		return err
+	}
+
+	// t.PushNotification (bool) (bool)
+	if t.PushNotification != nil {
+
+		if len("pushNotification") > 1000000 {
+			return xerrors.Errorf("Value in field \"pushNotification\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("pushNotification"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("pushNotification")); err != nil {
+			return err
+		}
+
+		if t.PushNotification == nil {
+			if _, err := cw.Write(cbg.CborNull); err != nil {
+				return err
+			}
+		} else {
+			if err := cbg.WriteBool(w, *t.PushNotification); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (t *Livestream_NotificationSettings) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = Livestream_NotificationSettings{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("Livestream_NotificationSettings: map struct too large (%d)", extra)
+	}
+
+	n := extra
+
+	nameBuf := make([]byte, 16)
+	for i := uint64(0); i < n; i++ {
+		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 1000000)
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			// Field doesn't exist on this type, so ignore it
+			if err := cbg.ScanForLinks(cr, func(cid.Cid) {}); err != nil {
+				return err
+			}
+			continue
+		}
+
+		switch string(nameBuf[:nameLen]) {
+		// t.PushNotification (bool) (bool)
+		case "pushNotification":
+
+			{
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+
+					maj, extra, err = cr.ReadHeader()
+					if err != nil {
+						return err
+					}
+					if maj != cbg.MajOther {
+						return fmt.Errorf("booleans must be major type 7")
+					}
+
+					var val bool
+					switch extra {
+					case 20:
+						val = false
+					case 21:
+						val = true
+					default:
+						return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+					}
+					t.PushNotification = &val
 				}
 			}
 

--- a/pkg/streamplace/streamlivestream.go
+++ b/pkg/streamplace/streamlivestream.go
@@ -24,7 +24,8 @@ type Livestream struct {
 	// canonicalUrl: The primary URL where this livestream can be viewed, if available.
 	CanonicalUrl *string `json:"canonicalUrl,omitempty" cborgen:"canonicalUrl,omitempty"`
 	// createdAt: Client-declared timestamp when this livestream started.
-	CreatedAt string `json:"createdAt" cborgen:"createdAt"`
+	CreatedAt            string                           `json:"createdAt" cborgen:"createdAt"`
+	NotificationSettings *Livestream_NotificationSettings `json:"notificationSettings,omitempty" cborgen:"notificationSettings,omitempty"`
 	// post: The post that announced this livestream.
 	Post  *comatprototypes.RepoStrongRef `json:"post,omitempty" cborgen:"post,omitempty"`
 	Thumb *util.LexBlob                  `json:"thumb,omitempty" cborgen:"thumb,omitempty"`
@@ -46,6 +47,12 @@ type Livestream_LivestreamView struct {
 	Uri           string                                   `json:"uri" cborgen:"uri"`
 	// viewerCount: The number of viewers watching this livestream. Use when you can't reasonably use #viewerCount directly.
 	ViewerCount *Livestream_ViewerCount `json:"viewerCount,omitempty" cborgen:"viewerCount,omitempty"`
+}
+
+// Livestream_NotificationSettings is a "notificationSettings" in the place.stream.livestream schema.
+type Livestream_NotificationSettings struct {
+	// pushNotification: Whether this livestream should trigger a push notification to followers.
+	PushNotification *bool `json:"pushNotification,omitempty" cborgen:"pushNotification,omitempty"`
 }
 
 // Livestream_StreamplaceAnything is a "streamplaceAnything" in the place.stream.livestream schema.


### PR DESCRIPTION
@espeon Please review. Last thought: maybe `url` and `canonicalUrl` should be swapped... it seems like url is the one people would show by default if they weren't thinking. Uncertain though.

<img width="814" height="1532" alt="image" src="https://github.com/user-attachments/assets/909e1c76-1ced-4681-980c-f596b11a83c0" />
