### PR TITLE
fix local ref in lexicon files

### DIFF
--- a/js/docs/src/content/docs/lex-reference/chat/place-stream-chat-defs.md
+++ b/js/docs/src/content/docs/lex-reference/chat/place-stream-chat-defs.md
@@ -23,7 +23,7 @@ description: Reference for the place.stream.chat.defs lexicon
 | `record`      | `unknown`                                                                                                                                        | ✅    |                                                                                        |                    |
 | `indexedAt`   | `string`                                                                                                                                         | ✅    |                                                                                        | Format: `datetime` |
 | `chatProfile` | [`place.stream.chat.profile`](/lex-reference/place-stream-chat-profile)                                                                          | ❌    |                                                                                        |                    |
-| `replyTo`     | Union of:<br/>&nbsp;&nbsp;[`place.stream.chat.defs#messageView`](/lex-reference/place-stream-chat-defs#messageview)                              | ❌    |                                                                                        |                    |
+| `replyTo`     | Union of:<br/>&nbsp;&nbsp;[`#messageView`](#messageview)                                                                                         | ❌    |                                                                                        |                    |
 | `deleted`     | `boolean`                                                                                                                                        | ❌    | If true, this message has been deleted or labeled and should be cleared from the cache |                    |
 
 ---
@@ -64,7 +64,7 @@ description: Reference for the place.stream.chat.defs lexicon
         },
         "replyTo": {
           "type": "union",
-          "refs": ["place.stream.chat.defs#messageView"]
+          "refs": ["#messageView"]
         },
         "deleted": {
           "type": "boolean",

--- a/js/docs/src/content/docs/lex-reference/chat/place-stream-chat-profile.md
+++ b/js/docs/src/content/docs/lex-reference/chat/place-stream-chat-profile.md
@@ -19,9 +19,9 @@ Record containing customizations for a user's chat profile.
 
 **Record Properties:**
 
-| Name    | Type                                                                                | Req'd | Description | Constraints |
-| ------- | ----------------------------------------------------------------------------------- | ----- | ----------- | ----------- |
-| `color` | [`place.stream.chat.profile#color`](/lex-reference/place-stream-chat-profile#color) | ❌    |             |             |
+| Name    | Type               | Req'd | Description | Constraints |
+| ------- | ------------------ | ----- | ----------- | ----------- |
+| `color` | [`#color`](#color) | ❌    |             |             |
 
 ---
 
@@ -60,7 +60,7 @@ Customizations for the color of a user's name in chat
         "properties": {
           "color": {
             "type": "ref",
-            "ref": "place.stream.chat.profile#color"
+            "ref": "#color"
           }
         }
       }

--- a/js/docs/src/content/docs/lex-reference/place-stream-livestream.md
+++ b/js/docs/src/content/docs/lex-reference/place-stream-livestream.md
@@ -46,7 +46,7 @@ Record announcing a livestream is happening
 | `author`      | [`app.bsky.actor.defs#profileViewBasic`](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky/actor/defs.json#profileViewBasic) | ✅    |                                                                                                          |                    |
 | `record`      | `unknown`                                                                                                                                        | ✅    |                                                                                                          |                    |
 | `indexedAt`   | `string`                                                                                                                                         | ✅    |                                                                                                          | Format: `datetime` |
-| `viewerCount` | [`place.stream.livestream#viewerCount`](/lex-reference/place-stream-livestream#viewercount)                                                      | ❌    | The number of viewers watching this livestream. Use when you can't reasonably use #viewerCount directly. |                    |
+| `viewerCount` | [`#viewerCount`](#viewercount)                                                                                                                   | ❌    | The number of viewers watching this livestream. Use when you can't reasonably use #viewerCount directly. |                    |
 
 ---
 
@@ -157,7 +157,7 @@ Record announcing a livestream is happening
         "viewerCount": {
           "type": "ref",
           "description": "The number of viewers watching this livestream. Use when you can't reasonably use #viewerCount directly.",
-          "ref": "place.stream.livestream#viewerCount"
+          "ref": "#viewerCount"
         }
       }
     },

--- a/lexicons/place/stream/chat/defs.json
+++ b/lexicons/place/stream/chat/defs.json
@@ -20,7 +20,7 @@
         },
         "replyTo": {
           "type": "union",
-          "refs": ["place.stream.chat.defs#messageView"]
+          "refs": ["#messageView"]
         },
         "deleted": {
           "type": "boolean",

--- a/lexicons/place/stream/chat/profile.json
+++ b/lexicons/place/stream/chat/profile.json
@@ -12,7 +12,7 @@
         "properties": {
           "color": {
             "type": "ref",
-            "ref": "place.stream.chat.profile#color"
+            "ref": "#color"
           }
         }
       }

--- a/lexicons/place/stream/livestream.json
+++ b/lexicons/place/stream/livestream.json
@@ -63,7 +63,7 @@
         "viewerCount": {
           "type": "ref",
           "description": "The number of viewers watching this livestream. Use when you can't reasonably use #viewerCount directly.",
-          "ref": "place.stream.livestream#viewerCount"
+          "ref": "#viewerCount"
         }
       }
     },


### PR DESCRIPTION
As specified in the specs, local ref values should be referenced starting with the hash part: https://atproto.com/specs/lexicon#ref
> The ref string can be a global reference to a Lexicon type definition (an NSID, optionally with a #-delimited name indicating a definition other than main), or can indicate a local definition within the same Lexicon file (a # followed by a name).