### PR TITLE
fix: set explicit color bg on mobile

### DIFF
--- a/js/app/components/provider/provider.shared.tsx
+++ b/js/app/components/provider/provider.shared.tsx
@@ -36,11 +36,16 @@ Sentry.setTag("executionEnvironment", Constants.executionEnvironment);
 Sentry.setTag("expoGoVersion", Constants.expoVersion);
 Sentry.setTag("expoRuntimeVersion", Constants.expoRuntimeVersion);
 
+const isWeb = Platform.OS === "web";
+
+// set transparent dark theme on web for easier OBS browser sourcing
+const darkTheme = isWeb ? { background: "transparent" } : {};
+
 const SPDarkTheme = {
   ...DarkTheme,
   colors: {
     ...DarkTheme.colors,
-    background: "transparent",
+    ...darkTheme,
   },
 };
 


### PR DESCRIPTION
It looks like the color we set in css in the index.html is not respected on native platforms, so the best option in this case is to leave the background as-is instead of making it transparent in react-navigation

<img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/e8aa64a4-77f6-426e-9fb8-905cf28be46c" />
