### PR TITLE
fix: use macos-15-intel instead of macos-13 for x86/64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
             cmd: make ios
             xcode-version: "16.4"
           - name: darwin-amd64
-            runs-on: macos-13
+            runs-on: macos-15-intel
             cmd: make
             xcode-version: "15.2.0"
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -105,7 +105,7 @@ jobs:
           - name: darwin-amd64
             runs-on: macos-15-intel
             cmd: make
-            xcode-version: "15.2.0"
+            xcode-version: "16.4"
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
apparently they're doing brownouts for macos 13: https://github.com/actions/runner-images/issues/13046