### PR TITLE
fix: don't show chat when ingest is "new"

### DIFF
--- a/js/app/components/mobile/ui.tsx
+++ b/js/app/components/mobile/ui.tsx
@@ -271,7 +271,7 @@ export function MobileUi({
           <PlayerUI.AutoplayButton />
         </View>
       </GestureDetector>
-      {showChat === undefined && (
+      {showChat === undefined && ingest !== "new" && (
         <MobileChatPanel isPlayerRatioGreater={isPlayerRatioGreater} />
       )}
     </>


### PR DESCRIPTION
We had an issue when starting a stream from the go live screen, the chat would pop up, blocking the user from entering in a title and starting a livestream. This fixes it by not showing chat when ingest is "new" (when we're planning to send a stream to the broadcaster)