### PR TITLE
fix: add danmu back to router

### DIFF
--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -85,6 +85,7 @@ import {
   useNotificationToken,
   useUserProfile,
 } from "store/hooks";
+import DanmuOBSScreen from "./screens/danmu-obs";
 import MobileGoLive from "./screens/mobile-go-live";
 import MobileStream from "./screens/mobile-stream";
 
@@ -135,6 +136,7 @@ type RootStackParamList = {
   Embed: { user: string };
   InfoWidgetEmbed: undefined;
   LegacyStream: { user: string };
+  DanmuOBS: { user: string };
   MobileGoLive: undefined;
 };
 
@@ -182,6 +184,7 @@ const linking: LinkingOptions<ReactNavigation.RootParamList> = {
       Embed: "embed/:user",
       InfoWidgetEmbed: "info-widget",
       LegacyStream: "legacy/:user",
+      DanmuOBS: "widgets/:user/danmu",
       MobileGoLive: "mobile-golive",
     },
   },
@@ -619,6 +622,15 @@ export function StreamplaceDrawer() {
         <Drawer.Screen
           name="InfoWidgetEmbed"
           component={InfoWidgetEmbed}
+          options={{
+            drawerLabel: () => null,
+            drawerItemStyle: { display: "none" },
+            headerShown: false,
+          }}
+        />
+        <Drawer.Screen
+          name="DanmuOBS"
+          component={DanmuOBSScreen}
           options={{
             drawerLabel: () => null,
             drawerItemStyle: { display: "none" },

--- a/js/docs/src/content/docs/features/danmu.md
+++ b/js/docs/src/content/docs/features/danmu.md
@@ -3,6 +3,8 @@ title: Danmu Overlay
 description: Add flying bullet-style chat comments to the player, or your stream
 ---
 
+:::note This feature is experimental and may change in future releases. :::
+
 [Danmu (or Danmaku)](https://en.wikipedia.org/wiki/Danmaku_subtitling) (弹幕,
 "bullet curtain") is a comment style where messages fly across the video
 horizontally. Originating from Niconico and Bilibili, it's a fun way to display
@@ -20,9 +22,10 @@ overlay is transparent so you can layer it over your video in OBS.
 In-player danmu is currently an experimental feature. To unlock it:
 
 1. Open Settings in Streamplace
-2. Tap the version number 5 times
-3. You'll see "You are now a developer". congrats!
-4. Scroll down to see the Danmu settings
+2. Enter the "About" section
+3. Tap the version number 5 times
+4. You'll see "You are now a developer". congrats!
+5. Go back to Settings, you should now see a "Danmu" section!
 
 From there you can:
 


### PR DESCRIPTION
No clue how, but it was missing in the router on last release