### PR TITLE
feat(backend): Implement delegated moderation system

### DIFF
--- a/pkg/atproto/firehose.go
+++ b/pkg/atproto/firehose.go
@@ -310,6 +310,15 @@ func (atsync *ATProtoSynchronizer) handleCommitEventOps(ctx context.Context, evt
 				if err != nil {
 					log.Error(ctx, "failed to delete moderation delegation", "err", err)
 				}
+				// Publish deletion to WebSocket bus for real-time updates
+				// Create a deleted record marker to notify frontend
+				deletedRecord := map[string]any{
+					"$type":     "place.stream.moderation.permission",
+					"deleted":   true,
+					"rkey":      rkey.String(),
+					"streamer":  evt.Repo,
+				}
+				go atsync.Bus.Publish(evt.Repo, deletedRecord)
 			}
 
 			if collection.String() == constants.PLACE_STREAM_CHAT_GATE {

--- a/pkg/atproto/firehose.go
+++ b/pkg/atproto/firehose.go
@@ -313,10 +313,10 @@ func (atsync *ATProtoSynchronizer) handleCommitEventOps(ctx context.Context, evt
 				// Publish deletion to WebSocket bus for real-time updates
 				// Create a deleted record marker to notify frontend
 				deletedRecord := map[string]any{
-					"$type":     "place.stream.moderation.permission",
-					"deleted":   true,
-					"rkey":      rkey.String(),
-					"streamer":  evt.Repo,
+					"$type":    "place.stream.moderation.permission",
+					"deleted":  true,
+					"rkey":     rkey.String(),
+					"streamer": evt.Repo,
 				}
 				go atsync.Bus.Publish(evt.Repo, deletedRecord)
 			}

--- a/pkg/atproto/firehose.go
+++ b/pkg/atproto/firehose.go
@@ -304,6 +304,22 @@ func (atsync *ATProtoSynchronizer) handleCommitEventOps(ctx context.Context, evt
 				atsync.Bus.Publish(msg.StreamerRepoDID, mv)
 			}
 
+			if collection.String() == constants.PLACE_STREAM_MODERATION_PERMISSION {
+				log.Debug(ctx, "deleting moderation delegation", "userDID", evt.Repo, "rkey", rkey.String())
+				err := atsync.Model.DeleteModerationDelegation(ctx, rkey.String())
+				if err != nil {
+					log.Error(ctx, "failed to delete moderation delegation", "err", err)
+				}
+			}
+
+			if collection.String() == constants.PLACE_STREAM_CHAT_GATE {
+				log.Debug(ctx, "deleting gate", "userDID", evt.Repo, "rkey", rkey.String())
+				err := atsync.Model.DeleteGate(ctx, rkey.String())
+				if err != nil {
+					log.Error(ctx, "failed to delete gate", "err", err)
+				}
+			}
+
 		default:
 			log.Error(ctx, "unexpected record op kind")
 		}

--- a/pkg/atproto/sync.go
+++ b/pkg/atproto/sync.go
@@ -2,6 +2,7 @@ package atproto
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -421,6 +422,51 @@ func (atsync *ATProtoSynchronizer) handleCreateUpdate(ctx context.Context, userD
 		err = atsync.Model.CreateMetadataConfiguration(ctx, metadata)
 		if err != nil {
 			log.Error(ctx, "failed to create metadata configuration", "err", err)
+		}
+
+	case *streamplace.ModerationPermission:
+		repo, err := atsync.SyncBlueskyRepoCached(ctx, userDID, atsync.Model)
+		if err != nil {
+			return fmt.Errorf("failed to sync bluesky repo: %w", err)
+		}
+		if repo == nil {
+			// someone we don't know about
+			return nil
+		}
+		log.Debug(ctx, "creating moderation delegation", "streamerDID", userDID, "moderatorDID", rec.Moderator)
+
+		permissionsJSON, err := json.Marshal(rec.Permissions)
+		if err != nil {
+			return fmt.Errorf("failed to marshal permissions: %w", err)
+		}
+
+		// Parse optional expiration time
+		var expirationTime *time.Time
+		if rec.ExpirationTime != nil {
+			t, err := time.Parse(time.RFC3339, *rec.ExpirationTime)
+			if err != nil {
+				log.Warn(ctx, "failed to parse expiration time", "value", *rec.ExpirationTime, "err", err)
+			} else {
+				expirationTime = &t
+			}
+		}
+
+		delegation := &model.ModerationDelegation{
+			RKey:           rkey.String(),
+			CID:            cid,
+			RepoDID:        userDID,
+			Repo:           repo,
+			ModeratorDID:   rec.Moderator,
+			Permissions:    permissionsJSON,
+			ExpirationTime: expirationTime,
+			Record:         *recCBOR,
+			CreatedAt:      now,
+			IndexedAt:      now,
+		}
+
+		err = atsync.Model.CreateModerationDelegation(ctx, delegation)
+		if err != nil {
+			return fmt.Errorf("failed to create moderation delegation: %w", err)
 		}
 
 	default:

--- a/pkg/atproto/sync.go
+++ b/pkg/atproto/sync.go
@@ -469,6 +469,10 @@ func (atsync *ATProtoSynchronizer) handleCreateUpdate(ctx context.Context, userD
 			return fmt.Errorf("failed to create moderation delegation: %w", err)
 		}
 
+		// Publish moderation permission record to WebSocket bus for real-time updates
+		// This allows moderators to see their permissions instantly without page refresh
+		go atsync.Bus.Publish(userDID, rec)
+
 	default:
 		log.Debug(ctx, "unhandled record type", "type", reflect.TypeOf(rec))
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,16 +1,17 @@
 package constants
 
-var PLACE_STREAM_KEY = "place.stream.key"                                 //nolint:all
-var PLACE_STREAM_LIVESTREAM = "place.stream.livestream"                   //nolint:all
-var PLACE_STREAM_CHAT_MESSAGE = "place.stream.chat.message"               //nolint:all
-var PLACE_STREAM_CHAT_PROFILE = "place.stream.chat.profile"               //nolint:all
-var PLACE_STREAM_SERVER_SETTINGS = "place.stream.server.settings"         //nolint:all
-var STREAMPLACE_SIGNING_KEY = "signingKey"                                //nolint:all
-var APP_BSKY_GRAPH_FOLLOW = "app.bsky.graph.follow"                       //nolint:all
-var APP_BSKY_FEED_POST = "app.bsky.feed.post"                             //nolint:all
-var APP_BSKY_GRAPH_BLOCK = "app.bsky.graph.block"                         //nolint:all
-var PLACE_STREAM_CHAT_GATE = "place.stream.chat.gate"                     //nolint:all
-var PLACE_STREAM_DEFAULT_METADATA = "place.stream.metadata.configuration" //nolint:all
+var PLACE_STREAM_KEY = "place.stream.key"                                     //nolint:all
+var PLACE_STREAM_LIVESTREAM = "place.stream.livestream"                       //nolint:all
+var PLACE_STREAM_CHAT_MESSAGE = "place.stream.chat.message"                   //nolint:all
+var PLACE_STREAM_CHAT_PROFILE = "place.stream.chat.profile"                   //nolint:all
+var PLACE_STREAM_SERVER_SETTINGS = "place.stream.server.settings"             //nolint:all
+var PLACE_STREAM_MODERATION_PERMISSION = "place.stream.moderation.permission" //nolint:all
+var STREAMPLACE_SIGNING_KEY = "signingKey"                                    //nolint:all
+var APP_BSKY_GRAPH_FOLLOW = "app.bsky.graph.follow"                           //nolint:all
+var APP_BSKY_FEED_POST = "app.bsky.feed.post"                                 //nolint:all
+var APP_BSKY_GRAPH_BLOCK = "app.bsky.graph.block"                             //nolint:all
+var PLACE_STREAM_CHAT_GATE = "place.stream.chat.gate"                         //nolint:all
+var PLACE_STREAM_DEFAULT_METADATA = "place.stream.metadata.configuration"     //nolint:all
 
 const DID_KEY_PREFIX = "did:key" //nolint:all
 const ADDRESS_KEY_PREFIX = "0x"  //nolint:all

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -107,6 +107,16 @@ type Model interface {
 	CreateMetadataConfiguration(ctx context.Context, metadata *MetadataConfiguration) error
 	GetMetadataConfiguration(ctx context.Context, repoDID string) (*MetadataConfiguration, error)
 	DeleteMetadataConfiguration(ctx context.Context, repoDID string) error
+
+	CreateModerationDelegation(ctx context.Context, delegation *ModerationDelegation) error
+	DeleteModerationDelegation(ctx context.Context, rkey string) error
+	GetModerationDelegation(ctx context.Context, streamerDID, moderatorDID string) (*ModerationDelegation, error)
+	GetModeratorDelegations(ctx context.Context, moderatorDID string) ([]*ModerationDelegation, error)
+	GetStreamerModerators(ctx context.Context, streamerDID string) ([]*ModerationDelegation, error)
+
+	CreateAuditLog(ctx context.Context, log *ModerationAuditLog) error
+	GetAuditLogs(ctx context.Context, streamerDID string, limit int, before *time.Time) ([]*ModerationAuditLog, error)
+	GetModeratorAuditLogs(ctx context.Context, moderatorDID string, limit int, before *time.Time) ([]*ModerationAuditLog, error)
 }
 
 var DBRevision = 2
@@ -175,6 +185,8 @@ func MakeDB(dbURL string) (Model, error) {
 		Label{},
 		BroadcastOrigin{},
 		MetadataConfiguration{},
+		ModerationDelegation{},
+		ModerationAuditLog{},
 	} {
 		err = db.AutoMigrate(model)
 		if err != nil {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -111,6 +111,7 @@ type Model interface {
 	CreateModerationDelegation(ctx context.Context, delegation *ModerationDelegation) error
 	DeleteModerationDelegation(ctx context.Context, rkey string) error
 	GetModerationDelegation(ctx context.Context, streamerDID, moderatorDID string) (*ModerationDelegation, error)
+	GetModerationDelegations(ctx context.Context, streamerDID, moderatorDID string) ([]*ModerationDelegation, error)
 	GetModeratorDelegations(ctx context.Context, moderatorDID string) ([]*ModerationDelegation, error)
 	GetStreamerModerators(ctx context.Context, streamerDID string) ([]*ModerationDelegation, error)
 

--- a/pkg/model/moderation_audit_log.go
+++ b/pkg/model/moderation_audit_log.go
@@ -1,0 +1,57 @@
+package model
+
+import (
+	"context"
+	"time"
+)
+
+type ModerationAuditLog struct {
+	ID           uint      `gorm:"primaryKey;autoIncrement"`
+	StreamerDID  string    `gorm:"column:streamer_did;index:idx_streamer_time,priority:1"`
+	ModeratorDID string    `gorm:"column:moderator_did;index:idx_audit_moderator"`
+	Action       string    `gorm:"column:action"`     // "createBlock", "deleteBlock", "createGate", "deleteGate", "updateLivestream"
+	TargetURI    string    `gorm:"column:target_uri"` // URI of affected resource
+	TargetDID    string    `gorm:"column:target_did"` // DID of affected user (for blocks)
+	ResultURI    string    `gorm:"column:result_uri"` // URI of created/deleted record
+	Success      bool      `gorm:"column:success"`
+	ErrorMsg     string    `gorm:"column:error_msg"`
+	CreatedAt    time.Time `gorm:"column:created_at;index:idx_streamer_time,priority:2"`
+}
+
+func (m *DBModel) CreateAuditLog(ctx context.Context, log *ModerationAuditLog) error {
+	return m.DB.WithContext(ctx).Create(log).Error
+}
+
+func (m *DBModel) GetAuditLogs(ctx context.Context, streamerDID string, limit int, before *time.Time) ([]*ModerationAuditLog, error) {
+	var logs []*ModerationAuditLog
+	query := m.DB.WithContext(ctx).Where("streamer_did = ?", streamerDID).
+		Order("created_at DESC").
+		Limit(limit)
+
+	if before != nil {
+		query = query.Where("created_at < ?", *before)
+	}
+
+	err := query.Find(&logs).Error
+	if err != nil {
+		return nil, err
+	}
+	return logs, nil
+}
+
+func (m *DBModel) GetModeratorAuditLogs(ctx context.Context, moderatorDID string, limit int, before *time.Time) ([]*ModerationAuditLog, error) {
+	var logs []*ModerationAuditLog
+	query := m.DB.WithContext(ctx).Where("moderator_did = ?", moderatorDID).
+		Order("created_at DESC").
+		Limit(limit)
+
+	if before != nil {
+		query = query.Where("created_at < ?", *before)
+	}
+
+	err := query.Find(&logs).Error
+	if err != nil {
+		return nil, err
+	}
+	return logs, nil
+}

--- a/pkg/model/moderation_delegation.go
+++ b/pkg/model/moderation_delegation.go
@@ -44,6 +44,19 @@ func (m *DBModel) GetModerationDelegation(ctx context.Context, streamerDID, mode
 	return &delegation, nil
 }
 
+// GetModerationDelegations returns ALL delegation records for a moderator from a specific streamer.
+// This allows multiple separate permission records (e.g., one for "ban", one for "hide") to be merged.
+func (m *DBModel) GetModerationDelegations(ctx context.Context, streamerDID, moderatorDID string) ([]*ModerationDelegation, error) {
+	var delegations []*ModerationDelegation
+	err := m.DB.WithContext(ctx).Preload("Repo").
+		Where("repo_did = ? AND moderator_did = ?", streamerDID, moderatorDID).
+		Find(&delegations).Error
+	if err != nil {
+		return nil, err
+	}
+	return delegations, nil
+}
+
 func (m *DBModel) GetModeratorDelegations(ctx context.Context, moderatorDID string) ([]*ModerationDelegation, error) {
 	var delegations []*ModerationDelegation
 	err := m.DB.WithContext(ctx).Preload("Repo").

--- a/pkg/model/moderation_delegation.go
+++ b/pkg/model/moderation_delegation.go
@@ -1,0 +1,67 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+type ModerationDelegation struct {
+	RKey           string     `gorm:"primaryKey;column:rkey"`
+	CID            string     `gorm:"column:cid"`
+	RepoDID        string     `json:"repoDID" gorm:"column:repo_did;index:idx_repo_moderator,priority:1"`
+	Repo           *Repo      `json:"repo,omitempty" gorm:"foreignKey:DID;references:RepoDID"`
+	ModeratorDID   string     `gorm:"column:moderator_did;index:idx_repo_moderator,priority:2;index:idx_moderator"`
+	Permissions    []byte     `gorm:"column:permissions"`     // JSON array stored as bytes
+	ExpirationTime *time.Time `gorm:"column:expiration_time"` // Optional expiration timestamp
+	Record         []byte     `gorm:"column:record"`          // Full CBOR record
+	CreatedAt      time.Time  `gorm:"column:created_at"`
+	IndexedAt      time.Time  `gorm:"column:indexed_at"`
+}
+
+func (m *DBModel) CreateModerationDelegation(ctx context.Context, delegation *ModerationDelegation) error {
+	return m.DB.WithContext(ctx).Create(delegation).Error
+}
+
+func (m *DBModel) DeleteModerationDelegation(ctx context.Context, rkey string) error {
+	return m.DB.WithContext(ctx).Where("rkey = ?", rkey).Delete(&ModerationDelegation{}).Error
+}
+
+func (m *DBModel) GetModerationDelegation(ctx context.Context, streamerDID, moderatorDID string) (*ModerationDelegation, error) {
+	var delegation ModerationDelegation
+	err := m.DB.WithContext(ctx).Preload("Repo").
+		Where("repo_did = ? AND moderator_did = ?", streamerDID, moderatorDID).
+		Order("created_at DESC").
+		First(&delegation).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &delegation, nil
+}
+
+func (m *DBModel) GetModeratorDelegations(ctx context.Context, moderatorDID string) ([]*ModerationDelegation, error) {
+	var delegations []*ModerationDelegation
+	err := m.DB.WithContext(ctx).Preload("Repo").
+		Where("moderator_did = ?", moderatorDID).
+		Find(&delegations).Error
+	if err != nil {
+		return nil, err
+	}
+	return delegations, nil
+}
+
+func (m *DBModel) GetStreamerModerators(ctx context.Context, streamerDID string) ([]*ModerationDelegation, error) {
+	var delegations []*ModerationDelegation
+	err := m.DB.WithContext(ctx).Preload("Repo").
+		Where("repo_did = ?", streamerDID).
+		Find(&delegations).Error
+	if err != nil {
+		return nil, err
+	}
+	return delegations, nil
+}

--- a/pkg/moderation/permissions.go
+++ b/pkg/moderation/permissions.go
@@ -62,38 +62,42 @@ func (pc *PermissionChecker) CheckPermission(ctx context.Context, moderatorDID, 
 	return nil
 }
 
-// HasPermission checks if a moderator has a specific permission for a streamer
+// HasPermission checks if a moderator has a specific permission for a streamer.
+// It merges permissions from ALL delegation records for the moderator.
 func (pc *PermissionChecker) HasPermission(ctx context.Context, moderatorDID, streamerDID, permission string) (bool, error) {
 	// Streamers always have all permissions for their own content
 	if moderatorDID == streamerDID {
 		return true, nil
 	}
 
-	// Look up delegation record
-	delegation, err := pc.model.GetModerationDelegation(ctx, streamerDID, moderatorDID)
+	// Look up ALL delegation records for this moderator
+	delegations, err := pc.model.GetModerationDelegations(ctx, streamerDID, moderatorDID)
 	if err != nil {
-		return false, fmt.Errorf("failed to get moderation delegation: %w", err)
+		return false, fmt.Errorf("failed to get moderation delegations: %w", err)
 	}
 
-	if delegation == nil {
+	if len(delegations) == 0 {
 		return false, nil
 	}
 
-	// Check if delegation has expired
-	if delegation.ExpirationTime != nil && time.Now().After(*delegation.ExpirationTime) {
-		return false, nil
-	}
+	// Check all delegation records and merge their permissions
+	for _, delegation := range delegations {
+		// Skip expired delegations
+		if delegation.ExpirationTime != nil && time.Now().After(*delegation.ExpirationTime) {
+			continue
+		}
 
-	// Parse permissions JSON array
-	var permissions []string
-	if err := json.Unmarshal(delegation.Permissions, &permissions); err != nil {
-		return false, fmt.Errorf("failed to unmarshal permissions: %w", err)
-	}
+		// Parse permissions JSON array
+		var permissions []string
+		if err := json.Unmarshal(delegation.Permissions, &permissions); err != nil {
+			return false, fmt.Errorf("failed to unmarshal permissions: %w", err)
+		}
 
-	// Check if moderator has the required permission
-	for _, p := range permissions {
-		if p == permission {
-			return true, nil
+		// Check if this delegation has the required permission
+		for _, p := range permissions {
+			if p == permission {
+				return true, nil
+			}
 		}
 	}
 

--- a/pkg/moderation/permissions.go
+++ b/pkg/moderation/permissions.go
@@ -1,0 +1,101 @@
+package moderation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"stream.place/streamplace/pkg/model"
+)
+
+// Permission scope constants
+const (
+	PermissionBan              = "ban"
+	PermissionHide             = "hide"
+	PermissionLivestreamManage = "livestream.manage"
+)
+
+// ActionPermissions maps moderation actions to required permissions
+var ActionPermissions = map[string]string{
+	"createBlock":      PermissionBan,
+	"deleteBlock":      PermissionBan,
+	"createGate":       PermissionHide,
+	"deleteGate":       PermissionHide,
+	"updateLivestream": PermissionLivestreamManage,
+}
+
+// PermissionChecker validates moderation permissions
+type PermissionChecker struct {
+	model model.Model
+}
+
+// NewPermissionChecker creates a new permission checker
+func NewPermissionChecker(m model.Model) *PermissionChecker {
+	return &PermissionChecker{model: m}
+}
+
+// CheckPermission validates that a moderator has permission to perform an action
+// Returns an error if the moderator lacks the required permission
+func (pc *PermissionChecker) CheckPermission(ctx context.Context, moderatorDID, streamerDID, action string) error {
+	// Get required permission for this action (validate action first)
+	requiredPermission, ok := ActionPermissions[action]
+	if !ok {
+		return fmt.Errorf("unknown action: %s", action)
+	}
+
+	// Streamers always have permission for their own content
+	if moderatorDID == streamerDID {
+		return nil
+	}
+
+	// Check if moderator has the required permission
+	hasPermission, err := pc.HasPermission(ctx, moderatorDID, streamerDID, requiredPermission)
+	if err != nil {
+		return fmt.Errorf("failed to check permissions: %w", err)
+	}
+
+	if !hasPermission {
+		return fmt.Errorf("moderator %s does not have permission '%s' for streamer %s", moderatorDID, requiredPermission, streamerDID)
+	}
+
+	return nil
+}
+
+// HasPermission checks if a moderator has a specific permission for a streamer
+func (pc *PermissionChecker) HasPermission(ctx context.Context, moderatorDID, streamerDID, permission string) (bool, error) {
+	// Streamers always have all permissions for their own content
+	if moderatorDID == streamerDID {
+		return true, nil
+	}
+
+	// Look up delegation record
+	delegation, err := pc.model.GetModerationDelegation(ctx, streamerDID, moderatorDID)
+	if err != nil {
+		return false, fmt.Errorf("failed to get moderation delegation: %w", err)
+	}
+
+	if delegation == nil {
+		return false, nil
+	}
+
+	// Check if delegation has expired
+	if delegation.ExpirationTime != nil && time.Now().After(*delegation.ExpirationTime) {
+		return false, nil
+	}
+
+	// Parse permissions JSON array
+	var permissions []string
+	if err := json.Unmarshal(delegation.Permissions, &permissions); err != nil {
+		return false, fmt.Errorf("failed to unmarshal permissions: %w", err)
+	}
+
+	// Check if moderator has the required permission
+	for _, p := range permissions {
+		if p == permission {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/spxrpc/moderation_helpers.go
+++ b/pkg/spxrpc/moderation_helpers.go
@@ -1,0 +1,78 @@
+package spxrpc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/streamplace/oatproxy/pkg/oatproxy"
+	"stream.place/streamplace/pkg/log"
+	"stream.place/streamplace/pkg/moderation"
+)
+
+// DelegatedModerationContext contains validated session and client for delegated moderation actions
+type DelegatedModerationContext struct {
+	ModeratorDID     string
+	ModeratorSession *oatproxy.OAuthSession
+	StreamerClient   *oatproxy.XrpcClient
+	StreamerSession  *oatproxy.OAuthSession
+}
+
+// GetDelegatedModerationContext validates moderator OAuth, checks permission, and returns streamer client
+// This consolidates the repeated pattern in all moderation handlers to eliminate duplication and fix security issues
+func (s *Server) GetDelegatedModerationContext(
+	ctx context.Context,
+	streamerDID string,
+	action string,
+) (*DelegatedModerationContext, error) {
+
+	// Step 1: Get and validate moderator OAuth session
+	// NOTE: GetOAuthSession returns (*OAuthSession, *XrpcClient), not (*OAuthSession, error)
+	moderatorSession, _ := oatproxy.GetOAuthSession(ctx)
+	if moderatorSession == nil {
+		return nil, echo.NewHTTPError(http.StatusUnauthorized, "oauth session not found")
+	}
+	moderatorDID := moderatorSession.DID
+
+	// Step 2: Check permission
+	permChecker := moderation.NewPermissionChecker(s.model)
+	if err := permChecker.CheckPermission(ctx, moderatorDID, streamerDID, action); err != nil {
+		log.Warn(ctx, "permission denied", "moderator", moderatorDID, "streamer", streamerDID, "action", action, "error", err)
+		return nil, echo.NewHTTPError(http.StatusForbidden, fmt.Sprintf("permission denied: %v", err))
+	}
+
+	// Step 3: Get streamer session
+	streamerSession, err := s.statefulDB.GetSessionByDID(streamerDID)
+	if err != nil {
+		log.Error(ctx, "failed to get streamer session", "streamer", streamerDID, "error", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to get streamer session: %v", err))
+	}
+	if streamerSession == nil {
+		return nil, echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("session not found for streamer %s", streamerDID))
+	}
+
+	// Step 4: Refresh session if needed
+	streamerSession, err = s.op.RefreshIfNeeded(streamerSession)
+	if err != nil {
+		log.Error(ctx, "failed to refresh streamer session", "streamer", streamerDID, "error", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to refresh session: %v", err))
+	}
+	if streamerSession == nil {
+		return nil, echo.NewHTTPError(http.StatusNotFound, "streamer session not found after refresh")
+	}
+
+	// Step 5: Get XRPC client for streamer
+	client, err := s.op.GetXrpcClient(streamerSession)
+	if err != nil {
+		log.Error(ctx, "failed to get xrpc client", "streamer", streamerDID, "error", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to get xrpc client: %v", err))
+	}
+
+	return &DelegatedModerationContext{
+		ModeratorDID:     moderatorDID,
+		ModeratorSession: moderatorSession,
+		StreamerClient:   client,
+		StreamerSession:  streamerSession,
+	}, nil
+}

--- a/pkg/spxrpc/place_stream_moderation.go
+++ b/pkg/spxrpc/place_stream_moderation.go
@@ -1,0 +1,353 @@
+package spxrpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/labstack/echo/v4"
+	"stream.place/streamplace/pkg/constants"
+	"stream.place/streamplace/pkg/log"
+	"stream.place/streamplace/pkg/model"
+	"stream.place/streamplace/pkg/streamplace"
+)
+
+// handlePlaceStreamModerationCreateBlock creates a block (ban) on behalf of a streamer
+func (s *Server) handlePlaceStreamModerationCreateBlock(ctx context.Context, input *streamplace.ModerationCreateBlock_Input) (*streamplace.ModerationCreateBlock_Output, error) {
+	// Validate input
+	if err := validateDID(input.Streamer); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid streamer DID: %v", err))
+	}
+	if err := validateDID(input.Subject); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid subject DID: %v", err))
+	}
+
+	// Get delegated moderation context (validates OAuth, permission, and returns client)
+	modCtx, err := s.GetDelegatedModerationContext(ctx, input.Streamer, "createBlock")
+	if err != nil {
+		return nil, err
+	}
+
+	// Create block record in streamer's repo
+	block := &bsky.GraphBlock{
+		Subject:   input.Subject,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	putInput := comatproto.RepoPutRecord_Input{
+		Collection: constants.APP_BSKY_GRAPH_BLOCK,
+		Record:     &lexutil.LexiconTypeDecoder{Val: block},
+		Repo:       input.Streamer,
+	}
+	putOutput := comatproto.RepoPutRecord_Output{}
+
+	err = modCtx.StreamerClient.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.putRecord", map[string]any{}, putInput, &putOutput)
+	if err != nil {
+		log.Error(ctx, "failed to create block record", "err", err)
+		if auditErr := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "createBlock", "", input.Subject, "", false, err.Error()); auditErr != nil {
+			log.Error(ctx, "failed to create audit log", "error", auditErr)
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to create block: %v", err))
+	}
+
+	// Log successful audit entry
+	if err := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "createBlock", "", input.Subject, putOutput.Uri, true, ""); err != nil {
+		log.Error(ctx, "failed to create audit log", "error", err)
+	}
+
+	return &streamplace.ModerationCreateBlock_Output{
+		Uri: putOutput.Uri,
+		Cid: putOutput.Cid,
+	}, nil
+}
+
+// handlePlaceStreamModerationDeleteBlock deletes a block (unban) on behalf of a streamer
+func (s *Server) handlePlaceStreamModerationDeleteBlock(ctx context.Context, input *streamplace.ModerationDeleteBlock_Input) (*streamplace.ModerationDeleteBlock_Output, error) {
+	// Validate input
+	if err := validateDID(input.Streamer); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid streamer DID: %v", err))
+	}
+	if err := validateATURI(input.BlockUri); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid block URI: %v", err))
+	}
+
+	// Get delegated moderation context (validates OAuth, permission, and returns client)
+	modCtx, err := s.GetDelegatedModerationContext(ctx, input.Streamer, "deleteBlock")
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse blockUri to extract rkey
+	// AT-URI format: at://did:plc:xxx/collection/rkey
+	rkey, err := extractRKey(input.BlockUri)
+	if err != nil {
+		log.Error(ctx, "failed to extract rkey from blockUri", "uri", input.BlockUri, "err", err)
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "invalid blockUri format")
+	}
+
+	// Delete block record from streamer's repo
+	deleteInput := comatproto.RepoDeleteRecord_Input{
+		Collection: constants.APP_BSKY_GRAPH_BLOCK,
+		Rkey:       rkey,
+		Repo:       input.Streamer,
+	}
+	deleteOutput := comatproto.RepoDeleteRecord_Output{}
+
+	err = modCtx.StreamerClient.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.deleteRecord", map[string]any{}, deleteInput, &deleteOutput)
+	if err != nil {
+		log.Error(ctx, "failed to delete block record", "err", err)
+		if auditErr := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "deleteBlock", input.BlockUri, "", "", false, err.Error()); auditErr != nil {
+			log.Error(ctx, "failed to create audit log", "error", auditErr)
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to delete block: %v", err))
+	}
+
+	// Log successful audit entry
+	if err := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "deleteBlock", input.BlockUri, "", "", true, ""); err != nil {
+		log.Error(ctx, "failed to create audit log", "error", err)
+	}
+
+	return &streamplace.ModerationDeleteBlock_Output{}, nil
+}
+
+// handlePlaceStreamModerationCreateGate creates a gate (hide message) on behalf of a streamer
+func (s *Server) handlePlaceStreamModerationCreateGate(ctx context.Context, input *streamplace.ModerationCreateGate_Input) (*streamplace.ModerationCreateGate_Output, error) {
+	// Validate input
+	if err := validateDID(input.Streamer); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid streamer DID: %v", err))
+	}
+	if err := validateATURI(input.MessageUri); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid message URI: %v", err))
+	}
+
+	// Get delegated moderation context (validates OAuth, permission, and returns client)
+	modCtx, err := s.GetDelegatedModerationContext(ctx, input.Streamer, "createGate")
+	if err != nil {
+		return nil, err
+	}
+
+	// Create gate record in streamer's repo
+	gate := &streamplace.ChatGate{
+		HiddenMessage: input.MessageUri,
+	}
+
+	putInput := comatproto.RepoPutRecord_Input{
+		Collection: constants.PLACE_STREAM_CHAT_GATE,
+		Record:     &lexutil.LexiconTypeDecoder{Val: gate},
+		Repo:       input.Streamer,
+	}
+	putOutput := comatproto.RepoPutRecord_Output{}
+
+	err = modCtx.StreamerClient.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.putRecord", map[string]any{}, putInput, &putOutput)
+	if err != nil {
+		log.Error(ctx, "failed to create gate record", "err", err)
+		if auditErr := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "createGate", input.MessageUri, "", "", false, err.Error()); auditErr != nil {
+			log.Error(ctx, "failed to create audit log", "error", auditErr)
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to create gate: %v", err))
+	}
+
+	// Log successful audit entry
+	if err := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "createGate", input.MessageUri, "", putOutput.Uri, true, ""); err != nil {
+		log.Error(ctx, "failed to create audit log", "error", err)
+	}
+
+	return &streamplace.ModerationCreateGate_Output{
+		Uri: putOutput.Uri,
+		Cid: putOutput.Cid,
+	}, nil
+}
+
+// handlePlaceStreamModerationDeleteGate deletes a gate (unhide message) on behalf of a streamer
+func (s *Server) handlePlaceStreamModerationDeleteGate(ctx context.Context, input *streamplace.ModerationDeleteGate_Input) (*streamplace.ModerationDeleteGate_Output, error) {
+	// Validate input
+	if err := validateDID(input.Streamer); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid streamer DID: %v", err))
+	}
+	if err := validateATURI(input.GateUri); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid gate URI: %v", err))
+	}
+
+	// Get delegated moderation context (validates OAuth, permission, and returns client)
+	modCtx, err := s.GetDelegatedModerationContext(ctx, input.Streamer, "deleteGate")
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse gateUri to extract rkey
+	rkey, err := extractRKey(input.GateUri)
+	if err != nil {
+		log.Error(ctx, "failed to extract rkey from gateUri", "uri", input.GateUri, "err", err)
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "invalid gateUri format")
+	}
+
+	// Delete gate record from streamer's repo
+	deleteInput := comatproto.RepoDeleteRecord_Input{
+		Collection: constants.PLACE_STREAM_CHAT_GATE,
+		Rkey:       rkey,
+		Repo:       input.Streamer,
+	}
+	deleteOutput := comatproto.RepoDeleteRecord_Output{}
+
+	err = modCtx.StreamerClient.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.deleteRecord", map[string]any{}, deleteInput, &deleteOutput)
+	if err != nil {
+		log.Error(ctx, "failed to delete gate record", "err", err)
+		if auditErr := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "deleteGate", input.GateUri, "", "", false, err.Error()); auditErr != nil {
+			log.Error(ctx, "failed to create audit log", "error", auditErr)
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to delete gate: %v", err))
+	}
+
+	// Log successful audit entry
+	if err := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "deleteGate", input.GateUri, "", "", true, ""); err != nil {
+		log.Error(ctx, "failed to create audit log", "error", err)
+	}
+
+	return &streamplace.ModerationDeleteGate_Output{}, nil
+}
+
+// handlePlaceStreamModerationUpdateLivestream updates livestream metadata on behalf of a streamer
+func (s *Server) handlePlaceStreamModerationUpdateLivestream(ctx context.Context, input *streamplace.ModerationUpdateLivestream_Input) (*streamplace.ModerationUpdateLivestream_Output, error) {
+	// Validate input
+	if err := validateDID(input.Streamer); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid streamer DID: %v", err))
+	}
+	if err := validateATURI(input.LivestreamUri); err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid livestream URI: %v", err))
+	}
+
+	// Get delegated moderation context (validates OAuth, permission, and returns client)
+	modCtx, err := s.GetDelegatedModerationContext(ctx, input.Streamer, "updateLivestream")
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse livestreamUri to extract rkey
+	rkey, err := extractRKey(input.LivestreamUri)
+	if err != nil {
+		log.Error(ctx, "failed to extract rkey from livestreamUri", "uri", input.LivestreamUri, "err", err)
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "invalid livestreamUri format")
+	}
+
+	// Get existing livestream record
+	getInput := map[string]any{
+		"repo":       input.Streamer,
+		"collection": constants.PLACE_STREAM_LIVESTREAM,
+		"rkey":       rkey,
+	}
+	getOutput := comatproto.RepoGetRecord_Output{}
+	err = modCtx.StreamerClient.Do(ctx, xrpc.Query, "application/json", "com.atproto.repo.getRecord", getInput, nil, &getOutput)
+	if err != nil {
+		log.Error(ctx, "failed to get livestream record", "err", err)
+		if auditErr := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "updateLivestream", input.LivestreamUri, "", "", false, fmt.Sprintf("failed to get record: %v", err)); auditErr != nil {
+			log.Error(ctx, "failed to create audit log", "error", auditErr)
+		}
+		return nil, echo.NewHTTPError(http.StatusNotFound, "livestream record not found")
+	}
+
+	// Decode existing record
+	if getOutput.Value == nil || getOutput.Value.Val == nil {
+		log.Error(ctx, "livestream record value is nil")
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "failed to decode livestream record")
+	}
+
+	// Convert the decoded value to our struct
+	livestream := &streamplace.Livestream{}
+	recordBytes, err := json.Marshal(getOutput.Value.Val)
+	if err != nil {
+		log.Error(ctx, "failed to marshal livestream record", "err", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "failed to decode livestream record")
+	}
+	err = json.Unmarshal(recordBytes, livestream)
+	if err != nil {
+		log.Error(ctx, "failed to unmarshal livestream record", "err", err)
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "failed to decode livestream record")
+	}
+
+	// Update only the provided fields
+	if input.Title != nil {
+		livestream.Title = *input.Title
+	}
+
+	// Update the record
+	putInput := comatproto.RepoPutRecord_Input{
+		Collection: constants.PLACE_STREAM_LIVESTREAM,
+		Record:     &lexutil.LexiconTypeDecoder{Val: livestream},
+		Rkey:       rkey,
+		Repo:       input.Streamer,
+		SwapRecord: getOutput.Cid,
+	}
+	putOutput := comatproto.RepoPutRecord_Output{}
+
+	err = modCtx.StreamerClient.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.putRecord", map[string]any{}, putInput, &putOutput)
+	if err != nil {
+		log.Error(ctx, "failed to update livestream record", "err", err)
+		if auditErr := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "updateLivestream", input.LivestreamUri, "", "", false, err.Error()); auditErr != nil {
+			log.Error(ctx, "failed to create audit log", "error", auditErr)
+		}
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to update livestream: %v", err))
+	}
+
+	// Log successful audit entry
+	if err := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "updateLivestream", input.LivestreamUri, "", putOutput.Uri, true, ""); err != nil {
+		log.Error(ctx, "failed to create audit log", "error", err)
+	}
+
+	return &streamplace.ModerationUpdateLivestream_Output{
+		Uri: putOutput.Uri,
+		Cid: putOutput.Cid,
+	}, nil
+}
+
+// Helper functions
+
+// extractRKey extracts the rkey from an AT-URI (at://did:plc:xxx/collection/rkey)
+func extractRKey(uri string) (string, error) {
+	aturi, err := syntax.ParseATURI(uri)
+	if err != nil {
+		return "", fmt.Errorf("invalid AT-URI: %w", err)
+	}
+	return aturi.RecordKey().String(), nil
+}
+
+// validateDID checks if string is a valid AT Protocol DID format
+func validateDID(did string) error {
+	_, err := syntax.ParseDID(did)
+	if err != nil {
+		return fmt.Errorf("invalid DID format: %w", err)
+	}
+	return nil
+}
+
+// validateATURI checks if string is a valid AT-URI format
+func validateATURI(uri string) error {
+	_, err := syntax.ParseATURI(uri)
+	if err != nil {
+		return fmt.Errorf("invalid AT-URI format: %w", err)
+	}
+	return nil
+}
+
+// logAudit logs a moderation action to the audit log
+func (s *Server) logAudit(ctx context.Context, streamerDID, moderatorDID, action, targetURI, targetDID, resultURI string, success bool, errorMsg string) error {
+	auditLog := &model.ModerationAuditLog{
+		StreamerDID:  streamerDID,
+		ModeratorDID: moderatorDID,
+		Action:       action,
+		TargetURI:    targetURI,
+		TargetDID:    targetDID,
+		ResultURI:    resultURI,
+		Success:      success,
+		ErrorMsg:     errorMsg,
+		CreatedAt:    time.Now(),
+	}
+
+	return s.model.CreateAuditLog(ctx, auditLog)
+}

--- a/pkg/spxrpc/place_stream_moderation.go
+++ b/pkg/spxrpc/place_stream_moderation.go
@@ -41,14 +41,14 @@ func (s *Server) handlePlaceStreamModerationCreateBlock(ctx context.Context, inp
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
 	}
 
-	putInput := comatproto.RepoPutRecord_Input{
+	createInput := comatproto.RepoCreateRecord_Input{
 		Collection: constants.APP_BSKY_GRAPH_BLOCK,
 		Record:     &lexutil.LexiconTypeDecoder{Val: block},
 		Repo:       input.Streamer,
 	}
-	putOutput := comatproto.RepoPutRecord_Output{}
+	createOutput := comatproto.RepoCreateRecord_Output{}
 
-	err = modCtx.StreamerClient.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.putRecord", map[string]any{}, putInput, &putOutput)
+	err = modCtx.StreamerClient.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.createRecord", map[string]any{}, createInput, &createOutput)
 	if err != nil {
 		log.Error(ctx, "failed to create block record", "err", err)
 		if auditErr := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "createBlock", "", input.Subject, "", false, err.Error()); auditErr != nil {
@@ -58,13 +58,13 @@ func (s *Server) handlePlaceStreamModerationCreateBlock(ctx context.Context, inp
 	}
 
 	// Log successful audit entry
-	if err := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "createBlock", "", input.Subject, putOutput.Uri, true, ""); err != nil {
+	if err := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "createBlock", "", input.Subject, createOutput.Uri, true, ""); err != nil {
 		log.Error(ctx, "failed to create audit log", "error", err)
 	}
 
 	return &streamplace.ModerationCreateBlock_Output{
-		Uri: putOutput.Uri,
-		Cid: putOutput.Cid,
+		Uri: createOutput.Uri,
+		Cid: createOutput.Cid,
 	}, nil
 }
 
@@ -138,14 +138,14 @@ func (s *Server) handlePlaceStreamModerationCreateGate(ctx context.Context, inpu
 		HiddenMessage: input.MessageUri,
 	}
 
-	putInput := comatproto.RepoPutRecord_Input{
+	createInput := comatproto.RepoCreateRecord_Input{
 		Collection: constants.PLACE_STREAM_CHAT_GATE,
 		Record:     &lexutil.LexiconTypeDecoder{Val: gate},
 		Repo:       input.Streamer,
 	}
-	putOutput := comatproto.RepoPutRecord_Output{}
+	createOutput := comatproto.RepoCreateRecord_Output{}
 
-	err = modCtx.StreamerClient.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.putRecord", map[string]any{}, putInput, &putOutput)
+	err = modCtx.StreamerClient.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.createRecord", map[string]any{}, createInput, &createOutput)
 	if err != nil {
 		log.Error(ctx, "failed to create gate record", "err", err)
 		if auditErr := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "createGate", input.MessageUri, "", "", false, err.Error()); auditErr != nil {
@@ -155,13 +155,13 @@ func (s *Server) handlePlaceStreamModerationCreateGate(ctx context.Context, inpu
 	}
 
 	// Log successful audit entry
-	if err := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "createGate", input.MessageUri, "", putOutput.Uri, true, ""); err != nil {
+	if err := s.logAudit(ctx, input.Streamer, modCtx.ModeratorDID, "createGate", input.MessageUri, "", createOutput.Uri, true, ""); err != nil {
 		log.Error(ctx, "failed to create audit log", "error", err)
 	}
 
 	return &streamplace.ModerationCreateGate_Output{
-		Uri: putOutput.Uri,
-		Cid: putOutput.Cid,
+		Uri: createOutput.Uri,
+		Cid: createOutput.Cid,
 	}, nil
 }
 

--- a/pkg/spxrpc/spxrpc.go
+++ b/pkg/spxrpc/spxrpc.go
@@ -31,6 +31,7 @@ type Server struct {
 	ATSync       *atproto.ATProtoSynchronizer
 	statefulDB   *statedb.StatefulDB
 	bus          *bus.Bus
+	op           *oatproxy.OATProxy
 }
 
 func NewServer(ctx context.Context, cli *config.CLI, model model.Model, statefulDB *statedb.StatefulDB, op *oatproxy.OATProxy, mdlw middleware.Middleware, atsync *atproto.ATProtoSynchronizer, bus *bus.Bus) (*Server, error) {
@@ -43,6 +44,7 @@ func NewServer(ctx context.Context, cli *config.CLI, model model.Model, stateful
 		ATSync:       atsync,
 		statefulDB:   statefulDB,
 		bus:          bus,
+		op:           op,
 	}
 	e.Use(s.ErrorHandlingMiddleware())
 	e.Use(s.ContextPreservingMiddleware())

--- a/pkg/spxrpc/stubs.go
+++ b/pkg/spxrpc/stubs.go
@@ -267,6 +267,11 @@ func (s *Server) RegisterHandlersPlaceStream(e *echo.Echo) error {
 	e.GET("/xrpc/place.stream.live.getLiveUsers", s.HandlePlaceStreamLiveGetLiveUsers)
 	e.GET("/xrpc/place.stream.live.getProfileCard", s.HandlePlaceStreamLiveGetProfileCard)
 	e.GET("/xrpc/place.stream.live.getSegments", s.HandlePlaceStreamLiveGetSegments)
+	e.POST("/xrpc/place.stream.moderation.createBlock", s.HandlePlaceStreamModerationCreateBlock)
+	e.POST("/xrpc/place.stream.moderation.createGate", s.HandlePlaceStreamModerationCreateGate)
+	e.POST("/xrpc/place.stream.moderation.deleteBlock", s.HandlePlaceStreamModerationDeleteBlock)
+	e.POST("/xrpc/place.stream.moderation.deleteGate", s.HandlePlaceStreamModerationDeleteGate)
+	e.POST("/xrpc/place.stream.moderation.updateLivestream", s.HandlePlaceStreamModerationUpdateLivestream)
 	e.POST("/xrpc/place.stream.server.createWebhook", s.HandlePlaceStreamServerCreateWebhook)
 	e.POST("/xrpc/place.stream.server.deleteWebhook", s.HandlePlaceStreamServerDeleteWebhook)
 	e.GET("/xrpc/place.stream.server.getServerTime", s.HandlePlaceStreamServerGetServerTime)
@@ -363,6 +368,96 @@ func (s *Server) HandlePlaceStreamLiveGetSegments(c echo.Context) error {
 	var handleErr error
 	// func (s *Server) handlePlaceStreamLiveGetSegments(ctx context.Context,before string,limit int,userDID string) (*placestream.LiveGetSegments_Output, error)
 	out, handleErr = s.handlePlaceStreamLiveGetSegments(ctx, before, limit, userDID)
+	if handleErr != nil {
+		return handleErr
+	}
+	return c.JSON(200, out)
+}
+
+func (s *Server) HandlePlaceStreamModerationCreateBlock(c echo.Context) error {
+	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandlePlaceStreamModerationCreateBlock")
+	defer span.End()
+
+	var body placestream.ModerationCreateBlock_Input
+	if err := c.Bind(&body); err != nil {
+		return err
+	}
+	var out *placestream.ModerationCreateBlock_Output
+	var handleErr error
+	// func (s *Server) handlePlaceStreamModerationCreateBlock(ctx context.Context,body *placestream.ModerationCreateBlock_Input) (*placestream.ModerationCreateBlock_Output, error)
+	out, handleErr = s.handlePlaceStreamModerationCreateBlock(ctx, &body)
+	if handleErr != nil {
+		return handleErr
+	}
+	return c.JSON(200, out)
+}
+
+func (s *Server) HandlePlaceStreamModerationCreateGate(c echo.Context) error {
+	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandlePlaceStreamModerationCreateGate")
+	defer span.End()
+
+	var body placestream.ModerationCreateGate_Input
+	if err := c.Bind(&body); err != nil {
+		return err
+	}
+	var out *placestream.ModerationCreateGate_Output
+	var handleErr error
+	// func (s *Server) handlePlaceStreamModerationCreateGate(ctx context.Context,body *placestream.ModerationCreateGate_Input) (*placestream.ModerationCreateGate_Output, error)
+	out, handleErr = s.handlePlaceStreamModerationCreateGate(ctx, &body)
+	if handleErr != nil {
+		return handleErr
+	}
+	return c.JSON(200, out)
+}
+
+func (s *Server) HandlePlaceStreamModerationDeleteBlock(c echo.Context) error {
+	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandlePlaceStreamModerationDeleteBlock")
+	defer span.End()
+
+	var body placestream.ModerationDeleteBlock_Input
+	if err := c.Bind(&body); err != nil {
+		return err
+	}
+	var out *placestream.ModerationDeleteBlock_Output
+	var handleErr error
+	// func (s *Server) handlePlaceStreamModerationDeleteBlock(ctx context.Context,body *placestream.ModerationDeleteBlock_Input) (*placestream.ModerationDeleteBlock_Output, error)
+	out, handleErr = s.handlePlaceStreamModerationDeleteBlock(ctx, &body)
+	if handleErr != nil {
+		return handleErr
+	}
+	return c.JSON(200, out)
+}
+
+func (s *Server) HandlePlaceStreamModerationDeleteGate(c echo.Context) error {
+	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandlePlaceStreamModerationDeleteGate")
+	defer span.End()
+
+	var body placestream.ModerationDeleteGate_Input
+	if err := c.Bind(&body); err != nil {
+		return err
+	}
+	var out *placestream.ModerationDeleteGate_Output
+	var handleErr error
+	// func (s *Server) handlePlaceStreamModerationDeleteGate(ctx context.Context,body *placestream.ModerationDeleteGate_Input) (*placestream.ModerationDeleteGate_Output, error)
+	out, handleErr = s.handlePlaceStreamModerationDeleteGate(ctx, &body)
+	if handleErr != nil {
+		return handleErr
+	}
+	return c.JSON(200, out)
+}
+
+func (s *Server) HandlePlaceStreamModerationUpdateLivestream(c echo.Context) error {
+	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandlePlaceStreamModerationUpdateLivestream")
+	defer span.End()
+
+	var body placestream.ModerationUpdateLivestream_Input
+	if err := c.Bind(&body); err != nil {
+		return err
+	}
+	var out *placestream.ModerationUpdateLivestream_Output
+	var handleErr error
+	// func (s *Server) handlePlaceStreamModerationUpdateLivestream(ctx context.Context,body *placestream.ModerationUpdateLivestream_Input) (*placestream.ModerationUpdateLivestream_Output, error)
+	out, handleErr = s.handlePlaceStreamModerationUpdateLivestream(ctx, &body)
 	if handleErr != nil {
 		return handleErr
 	}


### PR DESCRIPTION
Implements backend for delegated moderation. 

## Components

- Database models (ModerationDelegation, ModerationAuditLog)
- Permission system with expiration enforcement
- Firehose integration for delegation records

## XRPC handlers
- `createBlock` / `deleteBlock` - Ban/unban users
- `createGate` / `deleteGate` - Hide/unhide messages
- `updateLivestream` - Update stream metadata

## Out of Scope (follow-up work)
- Audit log read endpoint for streamers
- Rate limiting

---

Depends on #719.
Part 2 of 4 for #718