### PR TITLE
golive: tag golive posts as english

### DIFF
--- a/js/app/store/slices/blueskySlice.ts
+++ b/js/app/store/slices/blueskySlice.ts
@@ -522,6 +522,7 @@ export const createBlueskySlice: StateCreator<
       },
       facets: rt.facets,
       createdAt: now.toISOString(),
+      langs: ["en"],
     };
     record.embed = {
       $type: "app.bsky.embed.external",
@@ -532,7 +533,6 @@ export const createBlueskySlice: StateCreator<
         uri: linkUrl,
       },
     };
-    console.log("golivePost record", record);
     return await state.pdsAgent.post(record);
   },
 

--- a/js/components/src/streamplace-store/stream.tsx
+++ b/js/components/src/streamplace-store/stream.tsx
@@ -108,6 +108,7 @@ async function buildGoLivePost(
     },
     facets: rt.facets,
     createdAt: now.toISOString(),
+    langs: ["en"],
   };
   record.embed = {
     $type: "app.bsky.embed.external",


### PR DESCRIPTION
Works around https://github.com/streamplace/streamplace/issues/791. To do this properly we should do https://github.com/streamplace/streamplace/issues/792 but just setting everything to english at the moment unbreaks the feed.