### PR TITLE
feat(frontend): Implement delegated moderation UI

### DIFF
--- a/js/app/components/live-dashboard/livestream-panel.tsx
+++ b/js/app/components/live-dashboard/livestream-panel.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Checkbox,
   ContentMetadataForm,
+  Dashboard,
   formatHandle,
   formatHandleWithAt,
   Input,
@@ -178,7 +179,9 @@ function LivestreamPanel({ scrollable = true }: { scrollable?: boolean }) {
   const [selectedImage, setSelectedImage] = useState<
     string | File | Blob | undefined
   >();
-  const [mode, setMode] = useState<"create" | "metadata">("create");
+  const [mode, setMode] = useState<"create" | "metadata" | "moderation">(
+    "create",
+  );
 
   const [createPost, setCreatePost] = useState(true);
   const [sendPushNotification, setSendPushNotification] = useState(true);
@@ -210,9 +213,12 @@ function LivestreamPanel({ scrollable = true }: { scrollable?: boolean }) {
     setCreatePost(typeof livestream.record.post !== "undefined");
   }, [livestream, defaultCanonicalUrl]);
 
-  const handleModeChange = useCallback((newMode: "create" | "metadata") => {
-    setMode(newMode);
-  }, []);
+  const handleModeChange = useCallback(
+    (newMode: "create" | "metadata" | "moderation") => {
+      setMode(newMode);
+    },
+    [],
+  );
 
   const handleSubmit = useCallback(async () => {
     if (!title.trim()) return;
@@ -370,6 +376,7 @@ function LivestreamPanel({ scrollable = true }: { scrollable?: boolean }) {
               values={[
                 { label: "Create", value: "create" },
                 { label: "Metadata", value: "metadata" },
+                { label: "Moderation", value: "moderation" },
               ]}
               style={[{ marginVertical: -2 }]}
               selectedValue={mode}
@@ -385,6 +392,11 @@ function LivestreamPanel({ scrollable = true }: { scrollable?: boolean }) {
                 showUpdateButton={!userIsLive}
                 style={{ flex: 1, height: "100%" }}
               />
+            </View>
+          ) : mode === "moderation" ? (
+            // Moderation view
+            <View style={[flex.values[1], { minHeight: 400 }]}>
+              <Dashboard.ModeratorPanel isLive={userIsLive} embedded={true} />
             </View>
           ) : (
             // Create/Edit view

--- a/js/components/src/components/chat/mod-view.tsx
+++ b/js/components/src/components/chat/mod-view.tsx
@@ -1,16 +1,20 @@
 import { TriggerRef, useRootContext } from "@rn-primitives/dropdown-menu";
 import { forwardRef, useEffect, useRef, useState } from "react";
 import { gap, mr, w } from "../../lib/theme/atoms";
-import { useIsMyStream, usePlayerStore } from "../../player-store";
+import { usePlayerStore } from "../../player-store";
 import {
   useCreateBlockRecord,
   useCreateHideChatRecord,
 } from "../../streamplace-store/block";
+import { useCanModerate } from "../../streamplace-store/moderation";
 import { usePDSAgent } from "../../streamplace-store/xrpc";
 
 import { Linking } from "react-native";
 import { ChatMessageViewHydrated } from "streamplace";
-import { useDeleteChatMessage } from "../../livestream-store";
+import {
+  useDeleteChatMessage,
+  useLivestreamStore,
+} from "../../livestream-store";
 import { useStreamplaceStore } from "../../streamplace-store";
 import { formatHandle, formatHandleWithAt } from "../../utils/format-handle";
 import {
@@ -52,7 +56,11 @@ export const ModView = forwardRef<ModViewRef, ModViewProps>(() => {
   const setReportSubject = usePlayerStore((x) => x.setReportSubject);
   const setModMessage = usePlayerStore((x) => x.setModMessage);
   const deleteChatMessage = useDeleteChatMessage();
-  const isMyStream = useIsMyStream();
+
+  // Get the streamer's DID from the livestream profile
+  const streamerDID = useLivestreamStore((x) => x.profile?.did);
+  // Check moderation permissions for the current user on this streamer's channel
+  const modPermissions = useCanModerate(streamerDID);
 
   // get the channel did
   const channelId = usePlayerStore((state) => state.src);
@@ -77,6 +85,9 @@ export const ModView = forwardRef<ModViewRef, ModViewProps>(() => {
       triggerRef.current?.close();
     }
   }, [message]);
+
+  // Can show moderation actions if user can hide or ban
+  const canModerate = modPermissions.canHide || modPermissions.canBan;
 
   return (
     <DropdownMenu
@@ -120,50 +131,57 @@ export const ModView = forwardRef<ModViewRef, ModViewProps>(() => {
               </DropdownMenuItem>
             </DropdownMenuGroup>
 
-            {/* TODO: Checking for non-owner moderators */}
-            {isMyStream() && (
+            {canModerate && (
               <DropdownMenuGroup title={`Moderation actions`}>
-                <DropdownMenuItem
-                  disabled={isHideLoading || messageRemoved}
-                  onPress={() => {
-                    if (isHideLoading || messageRemoved) return;
-                    createHideChat(message.uri)
-                      .then((r) => setMessageRemoved(true))
-                      .catch((e) => console.error(e));
-                  }}
-                >
-                  <Text
-                    color={
-                      isHideLoading || messageRemoved ? "muted" : "destructive"
-                    }
+                {modPermissions.canHide && (
+                  <DropdownMenuItem
+                    disabled={isHideLoading || messageRemoved}
+                    onPress={() => {
+                      if (isHideLoading || messageRemoved) return;
+                      createHideChat(message.uri, streamerDID ?? undefined)
+                        .then((r) => setMessageRemoved(true))
+                        .catch((e) => console.error(e));
+                    }}
                   >
-                    {isHideLoading
-                      ? "Removing..."
-                      : messageRemoved
-                        ? "Message removed"
-                        : "Remove this message"}
-                  </Text>
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  disabled={message.author.did === agent?.did || isBlockLoading}
-                  onPress={() => {
-                    createBlock(message.author.did)
-                      .then((r) => console.log(r))
-                      .catch((e) => console.error(e));
-                  }}
-                >
-                  {message.author.did === agent?.did ? (
-                    <Text color="muted">
-                      Block yourself (you can't block yourself)
+                    <Text
+                      color={
+                        isHideLoading || messageRemoved
+                          ? "muted"
+                          : "destructive"
+                      }
+                    >
+                      {isHideLoading
+                        ? "Removing..."
+                        : messageRemoved
+                          ? "Message removed"
+                          : "Remove this message"}
                     </Text>
-                  ) : (
-                    <Text color="destructive">
-                      {isBlockLoading
-                        ? "Blocking..."
-                        : `Block user ${formatHandleWithAt(message.author)} from this channel`}
-                    </Text>
-                  )}
-                </DropdownMenuItem>
+                  </DropdownMenuItem>
+                )}
+                {modPermissions.canBan && (
+                  <DropdownMenuItem
+                    disabled={
+                      message.author.did === agent?.did || isBlockLoading
+                    }
+                    onPress={() => {
+                      createBlock(message.author.did, streamerDID ?? undefined)
+                        .then((r) => console.log(r))
+                        .catch((e) => console.error(e));
+                    }}
+                  >
+                    {message.author.did === agent?.did ? (
+                      <Text color="muted">
+                        Block yourself (you can't block yourself)
+                      </Text>
+                    ) : (
+                      <Text color="destructive">
+                        {isBlockLoading
+                          ? "Blocking..."
+                          : `Block user ${formatHandleWithAt(message.author)} from this channel`}
+                      </Text>
+                    )}
+                  </DropdownMenuItem>
+                )}
               </DropdownMenuGroup>
             )}
 

--- a/js/components/src/components/chat/mod-view.tsx
+++ b/js/components/src/components/chat/mod-view.tsx
@@ -5,27 +5,36 @@ import { usePlayerStore } from "../../player-store";
 import {
   useCreateBlockRecord,
   useCreateHideChatRecord,
+  useUpdateLivestreamRecord,
 } from "../../streamplace-store/block";
-import { useCanModerate } from "../../streamplace-store/moderation";
+import {
+  ModerationPermissions,
+  useCanModerate,
+} from "../../streamplace-store/moderation";
 import { usePDSAgent } from "../../streamplace-store/xrpc";
 
 import { Linking } from "react-native";
 import { ChatMessageViewHydrated } from "streamplace";
 import {
   useDeleteChatMessage,
+  useLivestream,
   useLivestreamStore,
 } from "../../livestream-store";
 import { useStreamplaceStore } from "../../streamplace-store";
 import { formatHandle, formatHandleWithAt } from "../../utils/format-handle";
 import {
   atoms,
+  Button,
+  DialogFooter,
   DropdownMenu,
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuTrigger,
   layout,
+  ResponsiveDialog,
   ResponsiveDropdownMenuContent,
   Text,
+  Textarea,
   useToast,
   View,
 } from "../ui";
@@ -46,11 +55,16 @@ export type ModViewRef = {
 export const ModView = forwardRef<ModViewRef, ModViewProps>(() => {
   const triggerRef = useRef<TriggerRef>(null);
   const message = usePlayerStore((state) => state.modMessage);
+  const toast = useToast();
 
   let agent = usePDSAgent();
   let [messageRemoved, setMessageRemoved] = useState(false);
   let { createBlock, isLoading: isBlockLoading } = useCreateBlockRecord();
   let { createHideChat, isLoading: isHideLoading } = useCreateHideChatRecord();
+  let { updateLivestream, isLoading: isUpdateTitleLoading } =
+    useUpdateLivestreamRecord();
+  const livestream = useLivestream();
+  const [showUpdateTitleDialog, setShowUpdateTitleDialog] = useState(false);
 
   const setReportModalOpen = usePlayerStore((x) => x.setReportModalOpen);
   const setReportSubject = usePlayerStore((x) => x.setReportSubject);
@@ -67,16 +81,11 @@ export const ModView = forwardRef<ModViewRef, ModViewProps>(() => {
   // get the logged in user's identity
   const handle = useStreamplaceStore((state) => state.handle);
 
-  if (!agent?.did) {
-    <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
-      <Text>Log in to submit mod actions</Text>
-    </View>;
-  }
-
   const cleanup = () => {
     setModMessage(null);
   };
 
+  // Effect must be called unconditionally (before any early returns)
   useEffect(() => {
     if (message) {
       setMessageRemoved(false);
@@ -86,135 +95,262 @@ export const ModView = forwardRef<ModViewRef, ModViewProps>(() => {
     }
   }, [message]);
 
-  // Can show moderation actions if user can hide or ban
-  const canModerate = modPermissions.canHide || modPermissions.canBan;
+  // Early return AFTER all hooks have been called
+  if (!agent?.did) {
+    return (
+      <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
+        <Text>Log in to submit mod actions</Text>
+      </View>
+    );
+  }
+
+  // Can show moderation actions if user can hide, ban, or manage livestream
+  const canModerate =
+    modPermissions.canHide ||
+    modPermissions.canBan ||
+    modPermissions.canManageLivestream;
+
+  // Check if any moderation actions are actually available for this message
+  // This must match the individual action checks inside the DropdownMenuGroup
+  const hasAvailableActions = !!(
+    message &&
+    agent?.did &&
+    ((modPermissions.canHide && message.author.did !== streamerDID) ||
+      (modPermissions.canBan &&
+        message.author.did !== agent.did &&
+        message.author.did !== streamerDID))
+  );
 
   return (
-    <DropdownMenu
-      style={[layout.flex.row, layout.flex.alignCenter, gap.all[2], w[80]]}
-      onOpenChange={(isOpen) => {
-        if (!isOpen) {
-          cleanup();
-        }
-      }}
-    >
-      <DropdownMenuTrigger ref={triggerRef}>
-        {/* Hidden trigger */}
-        <View />
-      </DropdownMenuTrigger>
-      <ResponsiveDropdownMenuContent>
-        {message && (
-          <>
-            <DropdownMenuGroup>
-              <DropdownMenuItem>
-                <View
-                  style={[
-                    layout.flex.column,
-                    mr[5],
-                    { gap: 6, maxWidth: "100%" },
-                  ]}
-                >
-                  <Text
-                    style={{
-                      fontVariant: ["tabular-nums"],
-                      color: atoms.colors.gray[300],
-                    }}
-                  >
-                    {new Date(message.record.createdAt).toLocaleTimeString([], {
-                      hour: "2-digit",
-                      minute: "2-digit",
-                      hour12: false,
-                    })}{" "}
-                    {formatHandleWithAt(message.author)}: {message.record.text}
-                  </Text>
-                </View>
-              </DropdownMenuItem>
-            </DropdownMenuGroup>
+    <>
+      <DropdownMenu
+        style={[layout.flex.row, layout.flex.alignCenter, gap.all[2], w[80]]}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            cleanup();
+          }
+        }}
+      >
+        <DropdownMenuTrigger ref={triggerRef}>
+          {/* Hidden trigger */}
+          <View />
+        </DropdownMenuTrigger>
+        <ResponsiveDropdownMenuContent>
+          {message && (
+            <ModViewContent
+              message={message}
+              modPermissions={modPermissions}
+              agent={agent}
+              streamerDID={streamerDID}
+              hasAvailableActions={hasAvailableActions}
+              isHideLoading={isHideLoading}
+              isBlockLoading={isBlockLoading}
+              messageRemoved={messageRemoved}
+              setMessageRemoved={setMessageRemoved}
+              createHideChat={createHideChat}
+              createBlock={createBlock}
+              toast={toast}
+              setShowUpdateTitleDialog={setShowUpdateTitleDialog}
+              isUpdateTitleLoading={isUpdateTitleLoading}
+              livestream={livestream}
+              setReportModalOpen={setReportModalOpen}
+              setReportSubject={setReportSubject}
+              deleteChatMessage={deleteChatMessage}
+            />
+          )}
+        </ResponsiveDropdownMenuContent>
+      </DropdownMenu>
 
-            {canModerate && (
-              <DropdownMenuGroup title={`Moderation actions`}>
-                {modPermissions.canHide && (
-                  <DropdownMenuItem
-                    disabled={isHideLoading || messageRemoved}
-                    onPress={() => {
-                      if (isHideLoading || messageRemoved) return;
-                      createHideChat(message.uri, streamerDID ?? undefined)
-                        .then((r) => setMessageRemoved(true))
-                        .catch((e) => console.error(e));
-                    }}
-                  >
-                    <Text
-                      color={
-                        isHideLoading || messageRemoved
-                          ? "muted"
-                          : "destructive"
-                      }
-                    >
-                      {isHideLoading
-                        ? "Removing..."
-                        : messageRemoved
-                          ? "Message removed"
-                          : "Remove this message"}
-                    </Text>
-                  </DropdownMenuItem>
-                )}
-                {modPermissions.canBan && (
-                  <DropdownMenuItem
-                    disabled={
-                      message.author.did === agent?.did || isBlockLoading
-                    }
-                    onPress={() => {
-                      createBlock(message.author.did, streamerDID ?? undefined)
-                        .then((r) => console.log(r))
-                        .catch((e) => console.error(e));
-                    }}
-                  >
-                    {message.author.did === agent?.did ? (
-                      <Text color="muted">
-                        Block yourself (you can't block yourself)
-                      </Text>
-                    ) : (
-                      <Text color="destructive">
-                        {isBlockLoading
-                          ? "Blocking..."
-                          : `Block user ${formatHandleWithAt(message.author)} from this channel`}
-                      </Text>
-                    )}
-                  </DropdownMenuItem>
-                )}
-              </DropdownMenuGroup>
-            )}
-
-            <DropdownMenuGroup title={`User actions`}>
-              <DropdownMenuItem
-                onPress={() => {
-                  Linking.openURL(
-                    `https://${BSKY_FRONTEND_DOMAIN}/profile/${formatHandle(message.author)}`,
-                  );
-                }}
-              >
-                <Text color="primary">View user on {BSKY_FRONTEND_DOMAIN}</Text>
-              </DropdownMenuItem>
-              {message.author.did === agent?.did && (
-                <DeleteButton
-                  message={message}
-                  deleteChatMessage={deleteChatMessage}
-                />
-              )}
-              {message.author.did !== agent?.did && (
-                <ReportButton
-                  message={message}
-                  setReportModalOpen={setReportModalOpen}
-                  setReportSubject={setReportSubject}
-                />
-              )}
-            </DropdownMenuGroup>
-          </>
-        )}
-      </ResponsiveDropdownMenuContent>
-    </DropdownMenu>
+      {/* Update Stream Title Dialog - rendered outside dropdown */}
+      {showUpdateTitleDialog && (
+        <UpdateStreamTitleDialog
+          livestream={livestream}
+          streamerDID={streamerDID}
+          updateLivestream={updateLivestream}
+          isLoading={isUpdateTitleLoading}
+          onClose={() => setShowUpdateTitleDialog(false)}
+        />
+      )}
+    </>
   );
 });
+
+interface ModViewContentProps {
+  message: ChatMessageViewHydrated;
+  modPermissions: ModerationPermissions;
+  agent: ReturnType<typeof usePDSAgent>;
+  streamerDID?: string;
+  hasAvailableActions: boolean;
+  isHideLoading: boolean;
+  isBlockLoading: boolean;
+  messageRemoved: boolean;
+  setMessageRemoved: (removed: boolean) => void;
+  createHideChat: (uri: string, streamerDID?: string) => Promise<any>;
+  createBlock: (did: string, streamerDID?: string) => Promise<any>;
+  toast: ReturnType<typeof useToast>;
+  setShowUpdateTitleDialog: (show: boolean) => void;
+  isUpdateTitleLoading: boolean;
+  livestream: any;
+  setReportModalOpen: (open: boolean) => void;
+  setReportSubject: (subject: any) => void;
+  deleteChatMessage: (uri: string) => Promise<any>;
+}
+
+function ModViewContent({
+  message,
+  modPermissions,
+  agent,
+  streamerDID,
+  hasAvailableActions,
+  isHideLoading,
+  isBlockLoading,
+  messageRemoved,
+  setMessageRemoved,
+  createHideChat,
+  createBlock,
+  toast,
+  setShowUpdateTitleDialog,
+  isUpdateTitleLoading,
+  livestream,
+  setReportModalOpen,
+  setReportSubject,
+  deleteChatMessage,
+}: ModViewContentProps) {
+  const { onOpenChange } = useRootContext();
+
+  return (
+    <>
+      <DropdownMenuGroup key="message-display">
+        <DropdownMenuItem>
+          <View
+            style={[layout.flex.column, mr[5], { gap: 6, maxWidth: "100%" }]}
+          >
+            <Text
+              style={{
+                fontVariant: ["tabular-nums"],
+                color: atoms.colors.gray[300],
+              }}
+            >
+              {new Date(message.record.createdAt).toLocaleTimeString([], {
+                hour: "2-digit",
+                minute: "2-digit",
+                hour12: false,
+              })}{" "}
+              {formatHandleWithAt(message.author)}: {message.record.text}
+            </Text>
+          </View>
+        </DropdownMenuItem>
+      </DropdownMenuGroup>
+
+      {hasAvailableActions && (
+        <DropdownMenuGroup
+          key="moderation-actions"
+          title={`Moderation actions`}
+        >
+          {modPermissions.canHide && message.author.did !== streamerDID && (
+            <DropdownMenuItem
+              disabled={isHideLoading || messageRemoved}
+              onPress={() => {
+                if (isHideLoading || messageRemoved) return;
+                createHideChat(message.uri, streamerDID ?? undefined)
+                  .then((r) => setMessageRemoved(true))
+                  .catch((e) => console.error(e));
+              }}
+            >
+              <Text
+                color={isHideLoading || messageRemoved ? "muted" : "warning"}
+              >
+                {isHideLoading
+                  ? "Hiding..."
+                  : messageRemoved
+                    ? "Message hidden"
+                    : "Hide this message"}
+              </Text>
+            </DropdownMenuItem>
+          )}
+          {modPermissions.canBan &&
+            agent?.did &&
+            message.author.did !== agent.did &&
+            message.author.did !== streamerDID && (
+              <DropdownMenuItem
+                disabled={isBlockLoading}
+                onPress={() => {
+                  if (isBlockLoading) return;
+                  createBlock(message.author.did, streamerDID ?? undefined)
+                    .then((r) => {
+                      toast.show(
+                        "User blocked",
+                        `${formatHandleWithAt(message.author)} has been blocked from this channel.`,
+                        { duration: 3 },
+                      );
+                      onOpenChange?.(false);
+                    })
+                    .catch((e) => {
+                      console.error(e);
+                      toast.show(
+                        "Error blocking user",
+                        e instanceof Error ? e.message : "Failed to block user",
+                        { duration: 5 },
+                      );
+                    });
+                }}
+              >
+                <Text color="destructive">
+                  {isBlockLoading
+                    ? "Blocking..."
+                    : `Block user ${formatHandleWithAt(message.author)} from this channel`}
+                </Text>
+              </DropdownMenuItem>
+            )}
+        </DropdownMenuGroup>
+      )}
+
+      {modPermissions.canManageLivestream && (
+        <DropdownMenuGroup key="stream-actions" title={`Stream actions`}>
+          <DropdownMenuItem
+            onPress={() => {
+              setShowUpdateTitleDialog(true);
+            }}
+            disabled={isUpdateTitleLoading || !livestream}
+          >
+            <Text
+              color={isUpdateTitleLoading || !livestream ? "muted" : "primary"}
+            >
+              {isUpdateTitleLoading ? "Updating..." : "Update stream title"}
+            </Text>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      )}
+
+      <DropdownMenuGroup key="user-actions" title={`User actions`}>
+        <DropdownMenuItem
+          onPress={() => {
+            Linking.openURL(
+              `https://${BSKY_FRONTEND_DOMAIN}/profile/${formatHandle(message.author)}`,
+            );
+          }}
+        >
+          <Text color="primary">View user on {BSKY_FRONTEND_DOMAIN}</Text>
+        </DropdownMenuItem>
+        {message.author.did === agent?.did && (
+          <DeleteButton
+            message={message}
+            deleteChatMessage={deleteChatMessage}
+            onOpenChange={onOpenChange}
+          />
+        )}
+        {message.author.did !== agent?.did && (
+          <ReportButton
+            message={message}
+            setReportModalOpen={setReportModalOpen}
+            setReportSubject={setReportSubject}
+            onOpenChange={onOpenChange}
+          />
+        )}
+      </DropdownMenuGroup>
+    </>
+  );
+}
 
 enum DeleteState {
   None,
@@ -225,12 +361,13 @@ enum DeleteState {
 export function DeleteButton({
   message,
   deleteChatMessage,
+  onOpenChange,
 }: {
   message: ChatMessageViewHydrated;
   deleteChatMessage: (uri: string) => Promise<any>;
+  onOpenChange?: (open: boolean) => void;
 }) {
   const [confirming, setConfirming] = useState<DeleteState>(DeleteState.None);
-  const { onOpenChange } = useRootContext();
   const toast = useToast();
   return (
     <DropdownMenuItem
@@ -271,12 +408,13 @@ export function ReportButton({
   message,
   setReportModalOpen,
   setReportSubject,
+  onOpenChange,
 }: {
   message: ChatMessageViewHydrated;
   setReportModalOpen: (open: boolean) => void;
   setReportSubject: (subject: any) => void;
+  onOpenChange?: (open: boolean) => void;
 }) {
-  const { onOpenChange } = useRootContext();
   return (
     <DropdownMenuItem
       onPress={() => {
@@ -293,5 +431,161 @@ export function ReportButton({
     >
       <Text color="warning">Report chat...</Text>
     </DropdownMenuItem>
+  );
+}
+
+interface UpdateStreamTitleDialogProps {
+  livestream: any;
+  streamerDID?: string;
+  updateLivestream: (
+    livestreamUri: string,
+    title: string,
+    streamerDID?: string,
+  ) => Promise<any>;
+  isLoading: boolean;
+  onClose: () => void;
+}
+
+function UpdateStreamTitleDialog({
+  livestream,
+  streamerDID,
+  updateLivestream,
+  isLoading,
+  onClose,
+}: UpdateStreamTitleDialogProps) {
+  const [title, setTitle] = useState(livestream?.record?.title || "");
+  const [error, setError] = useState<string | null>(null);
+  const toast = useToast();
+
+  useEffect(() => {
+    if (livestream?.record?.title) {
+      setTitle(livestream.record.title);
+    }
+  }, [livestream?.record?.title]);
+
+  const handleUpdate = async () => {
+    setError(null);
+
+    if (!title.trim()) {
+      setError("Please enter a stream title");
+      return;
+    }
+
+    if (!livestream?.uri) {
+      setError("No livestream found");
+      return;
+    }
+
+    try {
+      await updateLivestream(livestream.uri, title.trim(), streamerDID);
+      toast.show(
+        "Stream title updated",
+        "The stream title has been successfully updated.",
+        { duration: 3 },
+      );
+      onClose();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to update stream title",
+      );
+    }
+  };
+
+  return (
+    <ResponsiveDialog
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+          setError(null);
+          setTitle(livestream?.record?.title || "");
+        }
+      }}
+      title="Update Stream Title"
+      description="Update the title of the livestream."
+      size="md"
+      dismissible={false}
+    >
+      <View style={[{ padding: 16, paddingBottom: 0 }]}>
+        <View style={[{ marginBottom: 16 }]}>
+          <Text
+            style={[
+              { color: atoms.colors.gray[300], fontSize: 13, marginBottom: 8 },
+            ]}
+          >
+            Stream Title
+          </Text>
+          <Textarea
+            value={title}
+            onChangeText={(text) => {
+              setTitle(text);
+              setError(null);
+            }}
+            placeholder="Enter stream title..."
+            maxLength={140}
+            multiline
+            style={[
+              {
+                padding: 12,
+                borderRadius: 8,
+                backgroundColor: atoms.colors.neutral[800],
+                color: atoms.colors.white,
+                borderWidth: 1,
+                borderColor: atoms.colors.neutral[600],
+                minHeight: 100,
+                fontSize: 16,
+              },
+            ]}
+          />
+          <Text
+            style={[
+              { color: atoms.colors.gray[400], fontSize: 12, marginTop: 4 },
+            ]}
+          >
+            {title.length}/140 characters
+          </Text>
+        </View>
+
+        {error && (
+          <View
+            style={[
+              {
+                backgroundColor: atoms.colors.red[900],
+                padding: 12,
+                borderRadius: 8,
+                borderWidth: 1,
+                borderColor: atoms.colors.red[700],
+                marginBottom: 16,
+              },
+            ]}
+          >
+            <Text style={[{ color: atoms.colors.red[400], fontSize: 13 }]}>
+              {error}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      <DialogFooter>
+        <Button
+          variant="secondary"
+          onPress={() => {
+            onClose();
+            setError(null);
+            setTitle(livestream?.record?.title || "");
+          }}
+          disabled={isLoading}
+        >
+          <Text>Cancel</Text>
+        </Button>
+        <Button
+          variant="primary"
+          onPress={handleUpdate}
+          disabled={isLoading || !title.trim()}
+        >
+          <Text>{isLoading ? "Updating..." : "Update Title"}</Text>
+        </Button>
+      </DialogFooter>
+    </ResponsiveDialog>
   );
 }

--- a/js/components/src/components/chat/mod-view.tsx
+++ b/js/components/src/components/chat/mod-view.tsx
@@ -568,6 +568,7 @@ function UpdateStreamTitleDialog({
 
       <DialogFooter>
         <Button
+          width="min"
           variant="secondary"
           onPress={() => {
             onClose();
@@ -580,6 +581,7 @@ function UpdateStreamTitleDialog({
         </Button>
         <Button
           variant="primary"
+          width="min"
           onPress={handleUpdate}
           disabled={isLoading || !title.trim()}
         >

--- a/js/components/src/components/dashboard/index.tsx
+++ b/js/components/src/components/dashboard/index.tsx
@@ -2,4 +2,5 @@ export { default as ChatPanel } from "./chat-panel";
 export { default as Header } from "./header";
 export { default as InformationWidget } from "./information-widget";
 export { default as ModActions } from "./mod-actions";
+export { default as ModeratorPanel } from "./moderator-panel";
 export { default as Problems, ProblemsWrapperRef } from "./problems";

--- a/js/components/src/components/dashboard/moderator-panel.tsx
+++ b/js/components/src/components/dashboard/moderator-panel.tsx
@@ -1,0 +1,625 @@
+import { Shield, Trash2, UserPlus } from "lucide-react-native";
+import { useEffect, useMemo, useState } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
+import {
+  Button,
+  Dialog,
+  DialogFooter,
+  Input,
+  ResponsiveDialog,
+  useToast,
+} from "../../components/ui";
+import { useAvatars } from "../../hooks/useAvatars";
+import { atoms } from "../../lib/theme";
+import {
+  useAddModerator,
+  useListModerators,
+  useRemoveModerator,
+} from "../../streamplace-store/moderator-management";
+import { formatHandleWithAt } from "../../utils/format-handle";
+
+const {
+  flex,
+  bg,
+  r,
+  borders,
+  p,
+  text: textStyle,
+  layout,
+  gap,
+  mb,
+  px,
+  py,
+} = atoms;
+
+interface ModeratorPanelProps {
+  isLive?: boolean;
+  embedded?: boolean; // If true, removes outer container styling (for use inside other panels)
+}
+
+export default function ModeratorPanel({
+  isLive,
+  embedded = false,
+}: ModeratorPanelProps) {
+  const { moderators, isLoading, error, refresh } = useListModerators();
+  const [showAddDialog, setShowAddDialog] = useState(false);
+
+  // Collect all moderator DIDs for batch fetching profiles
+  const moderatorDIDs = useMemo(
+    () => moderators.map((mod) => mod.value.moderator),
+    [moderators],
+  );
+
+  const containerStyle = embedded
+    ? [flex.values[1], layout.flex.column]
+    : [
+        flex.values[1],
+        bg.neutral[900],
+        r.lg,
+        borders.width.thin,
+        borders.color.neutral[700],
+        layout.flex.column,
+      ];
+
+  return (
+    <View style={containerStyle}>
+      {/* Header */}
+      <View
+        style={[
+          layout.flex.row,
+          layout.flex.spaceBetween,
+          layout.flex.alignCenter,
+          borders.bottom.width.thin,
+          borders.bottom.color.neutral[700],
+          p[4],
+        ]}
+      >
+        <View style={[layout.flex.row, layout.flex.alignCenter, gap.all[2]]}>
+          <Shield size={18} color="#ffffff" />
+          <Text style={[textStyle.white, { fontSize: 18, fontWeight: "600" }]}>
+            Moderators
+          </Text>
+        </View>
+        <Pressable
+          onPress={() => setShowAddDialog(true)}
+          style={[
+            layout.flex.row,
+            layout.flex.alignCenter,
+            gap.all[2],
+            bg.blue[600],
+            px[3],
+            py[2],
+            r.md,
+          ]}
+        >
+          <UserPlus size={16} color="#ffffff" />
+          <Text style={[textStyle.white, { fontSize: 13, fontWeight: "500" }]}>
+            Add
+          </Text>
+        </Pressable>
+      </View>
+
+      {/* Content */}
+      <ScrollView style={[flex.values[1], p[4]]}>
+        {isLoading && moderators.length === 0 && (
+          <Text
+            style={[textStyle.gray[400], { fontSize: 14, textAlign: "center" }]}
+          >
+            Loading moderators...
+          </Text>
+        )}
+
+        {error && (
+          <View
+            style={[
+              bg.red[900],
+              p[3],
+              r.md,
+              borders.width.thin,
+              borders.color.red[700],
+            ]}
+          >
+            <Text style={[textStyle.red[400], { fontSize: 13 }]}>{error}</Text>
+          </View>
+        )}
+
+        {!isLoading && moderators.length === 0 && !error && (
+          <View style={[layout.flex.center, p[6]]}>
+            <Shield size={48} color="#6b7280" style={[mb[4]]} />
+            <Text
+              style={[
+                textStyle.gray[400],
+                { fontSize: 14, textAlign: "center", marginBottom: 8 },
+              ]}
+            >
+              No moderators yet
+            </Text>
+            <Text
+              style={[
+                textStyle.gray[500],
+                { fontSize: 12, textAlign: "center" },
+              ]}
+            >
+              Add moderators to help manage your chat
+            </Text>
+          </View>
+        )}
+
+        {moderators.map((mod, index) => (
+          <ModeratorCard
+            key={mod.rkey}
+            moderator={mod}
+            onRemove={refresh}
+            isLast={index === moderators.length - 1}
+            moderatorDIDs={moderatorDIDs}
+          />
+        ))}
+      </ScrollView>
+
+      {/* Add Moderator Dialog */}
+      <AddModeratorDialog
+        visible={showAddDialog}
+        onClose={() => setShowAddDialog(false)}
+        onSuccess={() => {
+          setShowAddDialog(false);
+          refresh();
+        }}
+      />
+    </View>
+  );
+}
+
+interface ModeratorCardProps {
+  moderator: {
+    uri: string;
+    cid: string;
+    value: {
+      moderator: string;
+      permissions: string[];
+      createdAt: string;
+      expirationTime?: string;
+    };
+    rkey: string;
+  };
+  onRemove: () => void;
+  isLast: boolean;
+  moderatorDIDs: string[]; // All moderator DIDs for batch fetching
+}
+
+function ModeratorCard({
+  moderator,
+  onRemove,
+  isLast,
+  moderatorDIDs,
+}: ModeratorCardProps) {
+  const { removeModerator, isLoading } = useRemoveModerator();
+  const [showConfirm, setShowConfirm] = useState(false);
+  const toast = useToast();
+
+  // Use useAvatars hook to batch-fetch profiles for all moderators
+  const profiles = useAvatars(moderatorDIDs);
+  const profile = profiles[moderator.value.moderator];
+
+  // Format display name using existing utility
+  const displayName = useMemo(() => {
+    if (profile) {
+      return formatHandleWithAt(profile);
+    }
+    return moderator.value.moderator; // Fall back to DID
+  }, [profile, moderator.value.moderator]);
+
+  const handleRemove = async () => {
+    try {
+      await removeModerator(moderator.rkey);
+      setShowConfirm(false);
+      toast.show(
+        "Moderator removed",
+        "The moderator has been successfully removed.",
+        { duration: 3 },
+      );
+      onRemove();
+    } catch (err) {
+      console.error("Failed to remove moderator:", err);
+      toast.show(
+        "Error removing moderator",
+        err instanceof Error ? err.message : "Failed to remove moderator",
+        { duration: 5 },
+      );
+    }
+  };
+
+  const isExpired =
+    moderator.value.expirationTime &&
+    new Date(moderator.value.expirationTime) < new Date();
+
+  return (
+    <View
+      style={[
+        layout.flex.row,
+        layout.flex.spaceBetween,
+        layout.flex.alignCenter,
+        p[3],
+        bg.neutral[800],
+        r.md,
+        !isLast && mb[2],
+        borders.width.thin,
+        borders.color.neutral[700],
+      ]}
+    >
+      <View style={[flex.values[1]]}>
+        <Text
+          style={[
+            textStyle.white,
+            { fontSize: 14, fontWeight: "500", marginBottom: 4 },
+          ]}
+          numberOfLines={1}
+        >
+          {displayName}
+        </Text>
+        <View style={[layout.flex.row, { flexWrap: "wrap" }, gap.all[1]]}>
+          {moderator.value.permissions.map((perm) => (
+            <View
+              key={perm}
+              style={[
+                bg.blue[900],
+                px[2],
+                py[1],
+                r.sm,
+                borders.width.thin,
+                borders.color.blue[700],
+              ]}
+            >
+              <Text
+                style={[
+                  textStyle.blue[300],
+                  { fontSize: 11, fontWeight: "500" },
+                ]}
+              >
+                {perm}
+              </Text>
+            </View>
+          ))}
+          {isExpired && (
+            <View
+              style={[
+                bg.red[900],
+                px[2],
+                py[1],
+                r.sm,
+                borders.width.thin,
+                borders.color.red[700],
+              ]}
+            >
+              <Text
+                style={[
+                  textStyle.red[300],
+                  { fontSize: 11, fontWeight: "500" },
+                ]}
+              >
+                Expired
+              </Text>
+            </View>
+          )}
+        </View>
+        {moderator.value.expirationTime && !isExpired && (
+          <Text style={[textStyle.gray[400], { fontSize: 11, marginTop: 4 }]}>
+            Expires:{" "}
+            {new Date(moderator.value.expirationTime).toLocaleDateString()}
+          </Text>
+        )}
+      </View>
+      <Pressable
+        onPress={() => setShowConfirm(true)}
+        disabled={isLoading}
+        style={[
+          p[2],
+          r.md,
+          bg.red[900],
+          borders.width.thin,
+          borders.color.red[700],
+          isLoading && { opacity: 0.5 },
+        ]}
+      >
+        <Trash2 size={16} color="#f87171" />
+      </Pressable>
+
+      {/* Confirm Delete Dialog */}
+      <Dialog
+        open={showConfirm}
+        onOpenChange={setShowConfirm}
+        title="Remove Moderator?"
+        description="This will revoke all moderation permissions for this user."
+        dismissible={false}
+      >
+        <DialogFooter>
+          <Button
+            variant="secondary"
+            onPress={() => setShowConfirm(false)}
+            disabled={isLoading}
+          >
+            <Text>Cancel</Text>
+          </Button>
+          <Button
+            variant="destructive"
+            onPress={handleRemove}
+            disabled={isLoading}
+          >
+            <Text>{isLoading ? "Removing..." : "Remove"}</Text>
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </View>
+  );
+}
+
+interface AddModeratorDialogProps {
+  visible: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+function AddModeratorDialog({
+  visible,
+  onClose,
+  onSuccess,
+}: AddModeratorDialogProps) {
+  const { addModerator, isLoading } = useAddModerator();
+  const [moderatorDID, setModeratorDID] = useState("");
+  const [permissions, setPermissions] = useState({
+    ban: false,
+    hide: false,
+    "livestream.manage": false,
+  });
+  const [error, setError] = useState<string | null>(null);
+  const toast = useToast();
+
+  // Reset form when dialog closes
+  useEffect(() => {
+    if (!visible) {
+      setModeratorDID("");
+      setPermissions({ ban: false, hide: false, "livestream.manage": false });
+      setError(null);
+    }
+  }, [visible]);
+
+  // Clear error when user starts typing
+  const handleDIDChange = (text: string) => {
+    setModeratorDID(text);
+    if (error) setError(null);
+  };
+
+  const handleAdd = async () => {
+    setError(null);
+
+    if (!moderatorDID.trim()) {
+      setError("Please enter a DID or handle");
+      return;
+    }
+
+    const selectedPermissions = Object.entries(permissions)
+      .filter(([_, enabled]) => enabled)
+      .map(([perm]) => perm) as ("ban" | "hide" | "livestream.manage")[];
+
+    if (selectedPermissions.length === 0) {
+      setError("Please select at least one permission");
+      return;
+    }
+
+    try {
+      await addModerator({
+        moderatorDID: moderatorDID.trim(),
+        permissions: selectedPermissions,
+      });
+      toast.show(
+        "Moderator added",
+        "The new moderator has been added successfully.",
+        { duration: 3 },
+      );
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add moderator");
+    }
+  };
+
+  return (
+    <ResponsiveDialog
+      open={visible}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      title="Add Moderator"
+      description="Enter the DID or handle of the user you want to add as a moderator and select their permissions."
+      size="md"
+      dismissible={false}
+    >
+      {/* DID Input */}
+      <View style={[mb[4]]}>
+        <Text style={[textStyle.gray[300], { fontSize: 13, marginBottom: 8 }]}>
+          Moderator DID or Handle
+        </Text>
+        <Input
+          value={moderatorDID}
+          onChangeText={handleDIDChange}
+          placeholder="did:plc:... or @handle.bsky.social"
+          onSubmitEditing={handleAdd}
+          returnKeyType="done"
+        />
+      </View>
+
+      {/* Permissions */}
+      <View style={[mb[4]]}>
+        <Text style={[textStyle.gray[300], { fontSize: 13, marginBottom: 8 }]}>
+          Permissions
+        </Text>
+        <View style={[gap.all[2]]}>
+          <Pressable
+            onPress={() => setPermissions((p) => ({ ...p, ban: !p.ban }))}
+            style={[
+              layout.flex.row,
+              layout.flex.alignCenter,
+              p[3],
+              r.md,
+              bg.neutral[800],
+              borders.width.thin,
+              borders.color.neutral[700],
+            ]}
+          >
+            <View
+              style={[
+                {
+                  width: 20,
+                  height: 20,
+                  borderRadius: 4,
+                },
+                borders.width.thin,
+                borders.color.neutral[600],
+                permissions.ban ? bg.blue[600] : bg.neutral[900],
+                layout.flex.center,
+                { marginRight: 12 },
+              ]}
+            >
+              {permissions.ban && (
+                <Text style={[textStyle.white, { fontSize: 12 }]}>✓</Text>
+              )}
+            </View>
+            <View>
+              <Text
+                style={[textStyle.white, { fontSize: 14, fontWeight: "500" }]}
+              >
+                Ban Users
+              </Text>
+              <Text style={[textStyle.gray[400], { fontSize: 12 }]}>
+                Block users from chat
+              </Text>
+            </View>
+          </Pressable>
+
+          <Pressable
+            onPress={() => setPermissions((p) => ({ ...p, hide: !p.hide }))}
+            style={[
+              layout.flex.row,
+              layout.flex.alignCenter,
+              p[3],
+              r.md,
+              bg.neutral[800],
+              borders.width.thin,
+              borders.color.neutral[700],
+            ]}
+          >
+            <View
+              style={[
+                {
+                  width: 20,
+                  height: 20,
+                  borderRadius: 4,
+                },
+                borders.width.thin,
+                borders.color.neutral[600],
+                permissions.hide ? bg.blue[600] : bg.neutral[900],
+                layout.flex.center,
+                { marginRight: 12 },
+              ]}
+            >
+              {permissions.hide && (
+                <Text style={[textStyle.white, { fontSize: 12 }]}>✓</Text>
+              )}
+            </View>
+            <View>
+              <Text
+                style={[textStyle.white, { fontSize: 14, fontWeight: "500" }]}
+              >
+                Hide Messages
+              </Text>
+              <Text style={[textStyle.gray[400], { fontSize: 12 }]}>
+                Hide individual chat messages
+              </Text>
+            </View>
+          </Pressable>
+
+          <Pressable
+            onPress={() =>
+              setPermissions((p) => ({
+                ...p,
+                "livestream.manage": !p["livestream.manage"],
+              }))
+            }
+            style={[
+              layout.flex.row,
+              layout.flex.alignCenter,
+              p[3],
+              r.md,
+              bg.neutral[800],
+              borders.width.thin,
+              borders.color.neutral[700],
+            ]}
+          >
+            <View
+              style={[
+                {
+                  width: 20,
+                  height: 20,
+                  borderRadius: 4,
+                },
+                borders.width.thin,
+                borders.color.neutral[600],
+                permissions["livestream.manage"]
+                  ? bg.blue[600]
+                  : bg.neutral[900],
+                layout.flex.center,
+                { marginRight: 12 },
+              ]}
+            >
+              {permissions["livestream.manage"] && (
+                <Text style={[textStyle.white, { fontSize: 12 }]}>✓</Text>
+              )}
+            </View>
+            <View>
+              <Text
+                style={[textStyle.white, { fontSize: 14, fontWeight: "500" }]}
+              >
+                Manage Livestream
+              </Text>
+              <Text style={[textStyle.gray[400], { fontSize: 12 }]}>
+                Update stream title
+              </Text>
+            </View>
+          </Pressable>
+        </View>
+      </View>
+
+      {/* Error */}
+      {error && (
+        <View
+          style={[
+            bg.red[900],
+            p[3],
+            r.md,
+            borders.width.thin,
+            borders.color.red[700],
+            mb[4],
+          ]}
+        >
+          <Text style={[textStyle.red[400], { fontSize: 13 }]}>{error}</Text>
+        </View>
+      )}
+
+      {/* Actions */}
+      <DialogFooter>
+        <Button variant="secondary" onPress={onClose} disabled={isLoading}>
+          <Text>Cancel</Text>
+        </Button>
+        <Button
+          variant="primary"
+          onPress={handleAdd}
+          disabled={
+            isLoading ||
+            !moderatorDID.trim() ||
+            Object.values(permissions).every((p) => !p)
+          }
+        >
+          <Text>{isLoading ? "Adding..." : "Add Moderator"}</Text>
+        </Button>
+      </DialogFooter>
+    </ResponsiveDialog>
+  );
+}

--- a/js/components/src/components/dashboard/moderator-panel.tsx
+++ b/js/components/src/components/dashboard/moderator-panel.tsx
@@ -1,4 +1,4 @@
-import { Shield, Trash2, UserPlus } from "lucide-react-native";
+import { Check, Shield, Trash2, UserPlus } from "lucide-react-native";
 import { useEffect, useMemo, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import {
@@ -28,6 +28,7 @@ const {
   layout,
   gap,
   mb,
+  my,
   px,
   py,
 } = atoms;
@@ -433,7 +434,7 @@ function AddModeratorDialog({
       dismissible={false}
     >
       {/* DID Input */}
-      <View style={[mb[4]]}>
+      <View style={[my[4]]}>
         <Text style={[textStyle.gray[300], { fontSize: 13, marginBottom: 8 }]}>
           Moderator DID or Handle
         </Text>
@@ -478,9 +479,7 @@ function AddModeratorDialog({
                 { marginRight: 12 },
               ]}
             >
-              {permissions.ban && (
-                <Text style={[textStyle.white, { fontSize: 12 }]}>✓</Text>
-              )}
+              {permissions.ban && <Check size={12} color="white" />}
             </View>
             <View>
               <Text
@@ -605,10 +604,16 @@ function AddModeratorDialog({
 
       {/* Actions */}
       <DialogFooter>
-        <Button variant="secondary" onPress={onClose} disabled={isLoading}>
-          <Text>Cancel</Text>
+        <Button
+          width="min"
+          variant="secondary"
+          onPress={onClose}
+          disabled={isLoading}
+        >
+          Cancel
         </Button>
         <Button
+          width="min"
           variant="primary"
           onPress={handleAdd}
           disabled={
@@ -617,7 +622,7 @@ function AddModeratorDialog({
             Object.values(permissions).every((p) => !p)
           }
         >
-          <Text>{isLoading ? "Adding..." : "Add Moderator"}</Text>
+          {isLoading ? "Adding..." : "Add Moderator"}
         </Button>
       </DialogFooter>
     </ResponsiveDialog>

--- a/js/components/src/livestream-store/chat.tsx
+++ b/js/components/src/livestream-store/chat.tsx
@@ -374,8 +374,6 @@ export const useSubmitReport = () => {
       subject: ComAtprotoModerationCreateReport.InputSchema["subject"],
       reasonType: string,
       reason?: string,
-      // no clue about this
-      moderationSvcDid: string = "did:web:stream.place",
     ) => {
       if (!pdsAgent || !userDID) {
         throw new Error("No PDS agent or user DID found");

--- a/js/components/src/livestream-store/livestream-state.tsx
+++ b/js/components/src/livestream-store/livestream-state.tsx
@@ -3,6 +3,7 @@ import {
   ChatMessageViewHydrated,
   LivestreamViewHydrated,
   PlaceStreamDefs,
+  PlaceStreamModerationPermission,
   PlaceStreamSegment,
 } from "streamplace";
 
@@ -23,6 +24,10 @@ export interface LivestreamState {
   setStreamKey: (key: string | null) => void;
   websocketConnected: boolean;
   hasReceivedSegment: boolean;
+  moderationPermissions: PlaceStreamModerationPermission.Record[];
+  setModerationPermissions: (
+    permissions: PlaceStreamModerationPermission.Record[],
+  ) => void;
 }
 
 export interface LivestreamProblem {

--- a/js/components/src/livestream-store/livestream-store.tsx
+++ b/js/components/src/livestream-store/livestream-store.tsx
@@ -24,6 +24,8 @@ export const makeLivestreamStore = (): StoreApi<LivestreamState> => {
     problems: [],
     websocketConnected: false,
     hasReceivedSegment: false,
+    moderationPermissions: [],
+    setModerationPermissions: (perms) => set({ moderationPermissions: perms }),
   }));
 };
 

--- a/js/components/src/livestream-store/websocket-consumer.tsx
+++ b/js/components/src/livestream-store/websocket-consumer.tsx
@@ -7,6 +7,7 @@ import {
   PlaceStreamChatMessage,
   PlaceStreamDefs,
   PlaceStreamLivestream,
+  PlaceStreamModerationPermission,
   PlaceStreamSegment,
 } from "streamplace";
 import { SystemMessages } from "../lib/system-messages";
@@ -120,6 +121,49 @@ export const handleWebSocketMessages = (
           pendingHides: newPendingHides,
         };
         state = reduceChat(state, [], [], [hiddenMessageUri]);
+      } else if (
+        PlaceStreamModerationPermission.isRecord(message) ||
+        (message &&
+          typeof message === "object" &&
+          "$type" in message &&
+          (message as { $type?: string }).$type ===
+          "place.stream.moderation.permission")
+      ) {
+        // Handle moderation permission record updates
+        // This can be a new permission or a deletion marker
+        const permRecord = message as
+          | PlaceStreamModerationPermission.Record
+          | { deleted?: boolean; rkey?: string; streamer?: string };
+
+        if ((permRecord as any).deleted) {
+          // Handle deletion: clear permissions to trigger refetch
+          // The useCanModerate hook will refetch and repopulate
+          state = {
+            ...state,
+            moderationPermissions: [],
+          };
+        } else {
+          // Handle new/updated permission: add or update in the list
+          const newPerm = permRecord as PlaceStreamModerationPermission.Record;
+          const existingIndex = state.moderationPermissions.findIndex(
+            (p) => p.moderator === newPerm.moderator,
+          );
+
+          let newPermissions: PlaceStreamModerationPermission.Record[];
+          if (existingIndex >= 0) {
+            // Update existing
+            newPermissions = [...state.moderationPermissions];
+            newPermissions[existingIndex] = newPerm;
+          } else {
+            // Add new
+            newPermissions = [...state.moderationPermissions, newPerm];
+          }
+
+          state = {
+            ...state,
+            moderationPermissions: newPermissions,
+          };
+        }
       }
     }
   }

--- a/js/components/src/livestream-store/websocket-consumer.tsx
+++ b/js/components/src/livestream-store/websocket-consumer.tsx
@@ -144,18 +144,33 @@ export const handleWebSocketMessages = (
           };
         } else {
           // Handle new/updated permission: add or update in the list
-          const newPerm = permRecord as PlaceStreamModerationPermission.Record;
-          const existingIndex = state.moderationPermissions.findIndex(
-            (p) => p.moderator === newPerm.moderator,
-          );
+          // Use createdAt as a unique identifier since multiple records can exist for the same moderator
+          // (e.g., one record with "ban" permission, another with "hide" permission)
+          // Note: rkey would be ideal but isn't always present in the WebSocket message
+          const newPerm = permRecord as PlaceStreamModerationPermission.Record & {
+            rkey?: string;
+          };
+          const existingIndex = state.moderationPermissions.findIndex((p) => {
+            const pWithRkey = p as PlaceStreamModerationPermission.Record & {
+              rkey?: string;
+            };
+            // Prefer matching by rkey if available, fall back to createdAt
+            if (newPerm.rkey && pWithRkey.rkey) {
+              return pWithRkey.rkey === newPerm.rkey;
+            }
+            return (
+              p.moderator === newPerm.moderator &&
+              p.createdAt === newPerm.createdAt
+            );
+          });
 
           let newPermissions: PlaceStreamModerationPermission.Record[];
           if (existingIndex >= 0) {
-            // Update existing
+            // Update existing record with same moderator AND createdAt
             newPermissions = [...state.moderationPermissions];
             newPermissions[existingIndex] = newPerm;
           } else {
-            // Add new
+            // Add new record (could be a new record for an existing moderator with different permissions)
             newPermissions = [...state.moderationPermissions, newPerm];
           }
 

--- a/js/components/src/livestream-store/websocket-consumer.tsx
+++ b/js/components/src/livestream-store/websocket-consumer.tsx
@@ -127,7 +127,7 @@ export const handleWebSocketMessages = (
           typeof message === "object" &&
           "$type" in message &&
           (message as { $type?: string }).$type ===
-          "place.stream.moderation.permission")
+            "place.stream.moderation.permission")
       ) {
         // Handle moderation permission record updates
         // This can be a new permission or a deletion marker
@@ -147,9 +147,10 @@ export const handleWebSocketMessages = (
           // Use createdAt as a unique identifier since multiple records can exist for the same moderator
           // (e.g., one record with "ban" permission, another with "hide" permission)
           // Note: rkey would be ideal but isn't always present in the WebSocket message
-          const newPerm = permRecord as PlaceStreamModerationPermission.Record & {
-            rkey?: string;
-          };
+          const newPerm =
+            permRecord as PlaceStreamModerationPermission.Record & {
+              rkey?: string;
+            };
           const existingIndex = state.moderationPermissions.findIndex((p) => {
             const pWithRkey = p as PlaceStreamModerationPermission.Record & {
               rkey?: string;

--- a/js/components/src/streamplace-store/block.tsx
+++ b/js/components/src/streamplace-store/block.tsx
@@ -150,7 +150,7 @@ export function useUpdateLivestreamRecord() {
           throw new Error("Invalid livestream URI");
         }
 
-        // Get existing record first
+        // Get existing record to copy fields
         const getResult = await agent.com.atproto.repo.getRecord({
           repo: agent.did,
           collection: "place.stream.livestream",
@@ -159,22 +159,18 @@ export function useUpdateLivestreamRecord() {
 
         const oldRecord = getResult.data.value as any;
 
-        // Update the record
+        // Create new record (don't edit - old records are "chapter markers")
+        // Spread entire record to preserve all fields (agent, canonicalUrl, notificationSettings, etc.)
         const record = {
-          $type: "place.stream.livestream",
-          title: title,
-          url: oldRecord.url,
-          createdAt: oldRecord.createdAt,
-          post: oldRecord.post,
-          thumb: oldRecord.thumb,
+          ...oldRecord,
+          title: title, // Override title
+          createdAt: new Date().toISOString(), // Override timestamp for new chapter marker
         };
 
-        const result = await agent.com.atproto.repo.putRecord({
+        const result = await agent.com.atproto.repo.createRecord({
           repo: agent.did,
           collection: "place.stream.livestream",
-          rkey,
           record,
-          swapRecord: getResult.data.cid,
         });
         return result;
       }

--- a/js/components/src/streamplace-store/block.tsx
+++ b/js/components/src/streamplace-store/block.tsx
@@ -2,11 +2,21 @@ import { AppBskyGraphBlock } from "@atproto/api";
 import { useState } from "react";
 import { usePDSAgent } from "./xrpc";
 
+/**
+ * Hook to create a block record (ban user from chat).
+ *
+ * When the caller is the stream owner (agent.did === streamerDID), creates the
+ * block record directly via ATProto writes to their repo.
+ *
+ * When the caller is a delegated moderator, uses the place.stream.moderation.createBlock
+ * XRPC endpoint which validates permissions and creates the record using the
+ * streamer's OAuth session.
+ */
 export function useCreateBlockRecord() {
   let agent = usePDSAgent();
   const [isLoading, setIsLoading] = useState(false);
 
-  const createBlock = async (subjectDID: string) => {
+  const createBlock = async (subjectDID: string, streamerDID?: string) => {
     if (!agent) {
       throw new Error("No PDS agent found");
     }
@@ -17,15 +27,25 @@ export function useCreateBlockRecord() {
 
     setIsLoading(true);
     try {
-      const record: AppBskyGraphBlock.Record = {
-        $type: "app.bsky.graph.block",
+      // If no streamerDID provided or caller is the streamer, use direct ATProto write
+      if (!streamerDID || agent.did === streamerDID) {
+        const record: AppBskyGraphBlock.Record = {
+          $type: "app.bsky.graph.block",
+          subject: subjectDID,
+          createdAt: new Date().toISOString(),
+        };
+        const result = await agent.com.atproto.repo.createRecord({
+          repo: agent.did,
+          collection: "app.bsky.graph.block",
+          record,
+        });
+        return result;
+      }
+
+      // Otherwise, use delegated moderation endpoint
+      const result = await agent.place.stream.moderation.createBlock({
+        streamer: streamerDID,
         subject: subjectDID,
-        createdAt: new Date().toISOString(),
-      };
-      const result = await agent.com.atproto.repo.createRecord({
-        repo: agent.did,
-        collection: "app.bsky.graph.block",
-        record,
       });
       return result;
     } finally {
@@ -36,11 +56,24 @@ export function useCreateBlockRecord() {
   return { createBlock, isLoading };
 }
 
+/**
+ * Hook to create a gate record (hide a chat message).
+ *
+ * When the caller is the stream owner (agent.did === streamerDID), creates the
+ * gate record directly via ATProto writes to their repo.
+ *
+ * When the caller is a delegated moderator, uses the place.stream.moderation.createGate
+ * XRPC endpoint which validates permissions and creates the record using the
+ * streamer's OAuth session.
+ */
 export function useCreateHideChatRecord() {
   let agent = usePDSAgent();
   const [isLoading, setIsLoading] = useState(false);
 
-  const createHideChat = async (chatMessageUri: string) => {
+  const createHideChat = async (
+    chatMessageUri: string,
+    streamerDID?: string,
+  ) => {
     if (!agent) {
       throw new Error("No PDS agent found");
     }
@@ -51,15 +84,25 @@ export function useCreateHideChatRecord() {
 
     setIsLoading(true);
     try {
-      const record = {
-        $type: "place.stream.chat.gate",
-        hiddenMessage: chatMessageUri,
-      };
+      // If no streamerDID provided or caller is the streamer, use direct ATProto write
+      if (!streamerDID || agent.did === streamerDID) {
+        const record = {
+          $type: "place.stream.chat.gate",
+          hiddenMessage: chatMessageUri,
+        };
 
-      const result = await agent.com.atproto.repo.createRecord({
-        repo: agent.did,
-        collection: "place.stream.chat.gate",
-        record,
+        const result = await agent.com.atproto.repo.createRecord({
+          repo: agent.did,
+          collection: "place.stream.chat.gate",
+          record,
+        });
+        return result;
+      }
+
+      // Otherwise, use delegated moderation endpoint
+      const result = await agent.place.stream.moderation.createGate({
+        streamer: streamerDID,
+        messageUri: chatMessageUri,
       });
       return result;
     } finally {

--- a/js/components/src/streamplace-store/block.tsx
+++ b/js/components/src/streamplace-store/block.tsx
@@ -112,3 +112,84 @@ export function useCreateHideChatRecord() {
 
   return { createHideChat, isLoading };
 }
+
+/**
+ * Hook to update a livestream record (update stream title).
+ *
+ * When the caller is the stream owner (agent.did === streamerDID), updates the
+ * livestream record directly via ATProto writes to their repo.
+ *
+ * When the caller is a delegated moderator, uses the place.stream.moderation.updateLivestream
+ * XRPC endpoint which validates permissions and updates the record using the
+ * streamer's OAuth session.
+ */
+export function useUpdateLivestreamRecord() {
+  let agent = usePDSAgent();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const updateLivestream = async (
+    livestreamUri: string,
+    title: string,
+    streamerDID?: string,
+  ) => {
+    if (!agent) {
+      throw new Error("No PDS agent found");
+    }
+
+    if (!agent.did) {
+      throw new Error("No user DID found, assuming not logged in");
+    }
+
+    setIsLoading(true);
+    try {
+      // If no streamerDID provided or caller is the streamer, use direct ATProto write
+      if (!streamerDID || agent.did === streamerDID) {
+        // Extract rkey from URI
+        const rkey = livestreamUri.split("/").pop();
+        if (!rkey) {
+          throw new Error("Invalid livestream URI");
+        }
+
+        // Get existing record first
+        const getResult = await agent.com.atproto.repo.getRecord({
+          repo: agent.did,
+          collection: "place.stream.livestream",
+          rkey,
+        });
+
+        const oldRecord = getResult.data.value as any;
+
+        // Update the record
+        const record = {
+          $type: "place.stream.livestream",
+          title: title,
+          url: oldRecord.url,
+          createdAt: oldRecord.createdAt,
+          post: oldRecord.post,
+          thumb: oldRecord.thumb,
+        };
+
+        const result = await agent.com.atproto.repo.putRecord({
+          repo: agent.did,
+          collection: "place.stream.livestream",
+          rkey,
+          record,
+          swapRecord: getResult.data.cid,
+        });
+        return result;
+      }
+
+      // Otherwise, use delegated moderation endpoint
+      const result = await agent.place.stream.moderation.updateLivestream({
+        streamer: streamerDID,
+        livestreamUri: livestreamUri,
+        title: title,
+      });
+      return result;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { updateLivestream, isLoading };
+}

--- a/js/components/src/streamplace-store/index.tsx
+++ b/js/components/src/streamplace-store/index.tsx
@@ -1,3 +1,4 @@
+export * from "./block";
 export * from "./moderation";
 export * from "./moderator-management";
 export * from "./stream";

--- a/js/components/src/streamplace-store/index.tsx
+++ b/js/components/src/streamplace-store/index.tsx
@@ -1,3 +1,5 @@
+export * from "./moderation";
+export * from "./moderator-management";
 export * from "./stream";
 export * from "./streamplace-store";
 export * from "./user";

--- a/js/components/src/streamplace-store/moderation.tsx
+++ b/js/components/src/streamplace-store/moderation.tsx
@@ -146,23 +146,33 @@ export function useCanModerate(
     setModerationPermissions,
   ]);
 
-  const delegation = moderationPermissions.find(
+  // Find ALL delegation records for this moderator and merge their permissions
+  const delegations = moderationPermissions.filter(
     (perm) => perm.moderator === userDID,
   );
 
-  // Extract permissions from the delegation record
-  const permissions: string[] = delegation
-    ? (() => {
-        // Check if delegation has expired
-        if (delegation.expirationTime) {
-          const expiration = new Date(delegation.expirationTime);
-          if (new Date() > expiration) {
-            return [];
-          }
+  // Merge permissions from all delegation records for this moderator
+  const permissions: string[] = delegations.reduce(
+    (acc: string[], delegation) => {
+      // Check if delegation has expired
+      if (delegation.expirationTime) {
+        const expiration = new Date(delegation.expirationTime);
+        if (new Date() > expiration) {
+          return acc; // Skip expired delegations
         }
-        return delegation.permissions || [];
-      })()
-    : [];
+      }
+
+      // Add all permissions from this delegation, avoiding duplicates
+      const delegationPerms = delegation.permissions || [];
+      for (const perm of delegationPerms) {
+        if (!acc.includes(perm)) {
+          acc.push(perm);
+        }
+      }
+      return acc;
+    },
+    [],
+  );
 
   return {
     canBan: isOwner || permissions.includes("ban"),

--- a/js/components/src/streamplace-store/moderation.tsx
+++ b/js/components/src/streamplace-store/moderation.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from "react";
+import { PlaceStreamModerationPermission } from "streamplace";
+import { useLivestreamStore } from "../livestream-store/livestream-store";
+import { usePDSAgent } from "./xrpc";
+
+export interface ModerationPermissions {
+  canBan: boolean;
+  canHide: boolean;
+  canManageLivestream: boolean;
+  isOwner: boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Hook to check if the current user can moderate for a given streamer.
+ * Returns permission flags based on:
+ * - Owner: full permissions if userDID === streamerDID
+ * - Delegated: permissions from place.stream.moderation.permission records
+ */
+export function useCanModerate(
+  streamerDID: string | null | undefined,
+): ModerationPermissions {
+  const agent = usePDSAgent();
+  const userDID = agent?.did;
+
+  // Get moderation permissions from livestream store (updated via WebSocket)
+  const moderationPermissions = useLivestreamStore(
+    (state) => state.moderationPermissions,
+  );
+  const setModerationPermissions = useLivestreamStore(
+    (state) => state.setModerationPermissions,
+  );
+
+  const [isOwner, setIsOwner] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!userDID || !streamerDID) {
+      setModerationPermissions([]);
+      setIsOwner(false);
+      setError(null);
+      return;
+    }
+
+    // If user is the streamer, they have full permissions
+    if (userDID === streamerDID) {
+      setIsOwner(true);
+      setModerationPermissions([]); // Not needed for owner
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    // Otherwise, fetch delegation records from the streamer's repo
+    // This initial fetch populates the store, then WebSocket updates will keep it in sync
+    const fetchDelegation = async () => {
+      if (!agent) {
+        setModerationPermissions([]);
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+      setIsOwner(false);
+
+      try {
+        // Use authenticated agent to list permission records from the streamer's repo
+        const result = await agent.com.atproto.repo.listRecords({
+          repo: streamerDID,
+          collection: "place.stream.moderation.permission",
+          limit: 100,
+        });
+
+        const records = result.data.records || [];
+        const permissionRecords: PlaceStreamModerationPermission.Record[] =
+          records
+            .map((r: { value: any }) => r.value)
+            .filter(
+              (v: any) => v && v.$type === "place.stream.moderation.permission",
+            );
+
+        // Store all permissions in the livestream store
+        // WebSocket updates will keep this in sync
+        setModerationPermissions(permissionRecords);
+      } catch (err) {
+        console.error("[useCanModerate] Error fetching permissions:", err);
+        setError(
+          `Could not fetch moderation permissions: ${err instanceof Error ? err.message : `Unknown error: ${err}`}`,
+        );
+        setModerationPermissions([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    // Fetch immediately on mount or when dependencies change
+    fetchDelegation();
+  }, [userDID, streamerDID, agent, setModerationPermissions]);
+
+  // If permissions were cleared (e.g., due to deletion), trigger a refetch
+  useEffect(() => {
+    // If permissions were cleared and we're not the owner, refetch
+    if (
+      moderationPermissions.length === 0 &&
+      !isOwner &&
+      userDID &&
+      streamerDID &&
+      agent
+    ) {
+      const fetchDelegation = async () => {
+        try {
+          const result = await agent.com.atproto.repo.listRecords({
+            repo: streamerDID,
+            collection: "place.stream.moderation.permission",
+            limit: 100,
+          });
+
+          const records = result.data.records || [];
+          const permissionRecords: PlaceStreamModerationPermission.Record[] =
+            records
+              .map((r: { value: any }) => r.value)
+              .filter(
+                (v: any) =>
+                  v && v.$type === "place.stream.moderation.permission",
+              );
+
+          setModerationPermissions(permissionRecords);
+        } catch (err) {
+          console.error("[useCanModerate] Error refetching permissions:", err);
+        }
+      };
+
+      // Small delay to avoid rapid refetches
+      const timeout = setTimeout(fetchDelegation, 100);
+      return () => clearTimeout(timeout);
+    }
+  }, [
+    moderationPermissions.length,
+    isOwner,
+    userDID,
+    streamerDID,
+    agent,
+    setModerationPermissions,
+  ]);
+
+  const delegation = moderationPermissions.find(
+    (perm) => perm.moderator === userDID,
+  );
+
+  // Extract permissions from the delegation record
+  const permissions: string[] = delegation
+    ? (() => {
+        // Check if delegation has expired
+        if (delegation.expirationTime) {
+          const expiration = new Date(delegation.expirationTime);
+          if (new Date() > expiration) {
+            return [];
+          }
+        }
+        return delegation.permissions || [];
+      })()
+    : [];
+
+  return {
+    canBan: isOwner || permissions.includes("ban"),
+    canHide: isOwner || permissions.includes("hide"),
+    canManageLivestream: isOwner || permissions.includes("livestream.manage"),
+    isOwner,
+    isLoading,
+    error,
+  };
+}

--- a/js/components/src/streamplace-store/moderator-management.tsx
+++ b/js/components/src/streamplace-store/moderator-management.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useState } from "react";
+import { PlaceStreamModerationPermission } from "streamplace";
+import { usePDSAgent } from "./xrpc";
+
+interface ModeratorRecord {
+  uri: string;
+  cid: string;
+  value: PlaceStreamModerationPermission.Record;
+  rkey: string;
+}
+
+interface ListModeratorsResult {
+  moderators: ModeratorRecord[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Hook to list all moderators for the current user's stream.
+ * Fetches place.stream.moderation.permission records from the user's repo.
+ */
+export function useListModerators(): ListModeratorsResult {
+  const agent = usePDSAgent();
+  const [moderators, setModerators] = useState<ModeratorRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRefreshTrigger((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!agent?.did) {
+      setModerators([]);
+      setError(null);
+      return;
+    }
+
+    const fetchModerators = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const result = await agent.place.stream.moderation.permission.list({
+          repo: agent.did!,
+        });
+
+        const records = result.records.map((record: any) => {
+          const rkey = record.uri.split("/").pop();
+          return {
+            uri: record.uri,
+            cid: record.cid || "",
+            value: record.value,
+            rkey: rkey || "",
+          };
+        });
+
+        setModerators(records);
+      } catch (err) {
+        setError(
+          `Failed to fetch moderators: ${err instanceof Error ? err.message : "Unknown error"}`,
+        );
+        setModerators([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchModerators();
+  }, [agent?.did, refreshTrigger]);
+
+  return {
+    moderators,
+    isLoading,
+    error,
+    refresh,
+  };
+}
+
+interface AddModeratorParams {
+  moderatorDID: string;
+  permissions: ("ban" | "hide" | "livestream.manage")[];
+  expirationTime?: string; // ISO 8601 datetime string
+}
+
+/**
+ * Hook to add a new moderator.
+ * Creates a place.stream.moderation.permission record in the current user's repo.
+ */
+export function useAddModerator() {
+  const agent = usePDSAgent();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const addModerator = async (params: AddModeratorParams) => {
+    if (!agent?.did) {
+      throw new Error("Not logged in");
+    }
+
+    if (params.permissions.length === 0) {
+      throw new Error("At least one permission must be selected");
+    }
+
+    setIsLoading(true);
+    try {
+      // Resolve handle to DID if needed
+      let moderatorDID = params.moderatorDID.trim();
+      if (moderatorDID.startsWith("@")) {
+        // It's a handle, resolve to DID
+        const resolved = await agent.com.atproto.identity.resolveHandle({
+          handle: moderatorDID.substring(1), // Remove @
+        });
+        moderatorDID = resolved.data.did;
+      } else if (!moderatorDID.startsWith("did:")) {
+        // Try to resolve as handle without @
+        try {
+          const resolved = await agent.com.atproto.identity.resolveHandle({
+            handle: moderatorDID,
+          });
+          moderatorDID = resolved.data.did;
+        } catch (e) {
+          // If resolution fails, assume it's already a DID
+          throw new Error(
+            `Invalid DID or handle: ${moderatorDID}. Please use a valid DID (did:plc:...) or handle (@handle.bsky.social)`,
+          );
+        }
+      }
+
+      const record: PlaceStreamModerationPermission.Record = {
+        $type: "place.stream.moderation.permission",
+        moderator: moderatorDID,
+        permissions: params.permissions,
+        createdAt: new Date().toISOString(),
+      };
+
+      if (params.expirationTime) {
+        (record as any).expirationTime = params.expirationTime;
+      }
+
+      const result = await agent.place.stream.moderation.permission.create(
+        { repo: agent.did },
+        record,
+      );
+
+      return result;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { addModerator, isLoading };
+}
+
+/**
+ * Hook to remove a moderator.
+ * Deletes a place.stream.moderation.permission record by its rkey.
+ */
+export function useRemoveModerator() {
+  const agent = usePDSAgent();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const removeModerator = async (rkey: string) => {
+    if (!agent?.did) {
+      throw new Error("Not logged in");
+    }
+
+    setIsLoading(true);
+    try {
+      await agent.place.stream.moderation.permission.delete({
+        repo: agent.did,
+        rkey,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { removeModerator, isLoading };
+}

--- a/js/components/src/streamplace-store/moderator-management.tsx
+++ b/js/components/src/streamplace-store/moderator-management.tsx
@@ -106,21 +106,16 @@ export function useAddModerator() {
     try {
       // Resolve handle to DID if needed
       let moderatorDID = params.moderatorDID.trim();
-      if (moderatorDID.startsWith("@")) {
-        // It's a handle, resolve to DID
-        const resolved = await agent.com.atproto.identity.resolveHandle({
-          handle: moderatorDID.substring(1), // Remove @
-        });
-        moderatorDID = resolved.data.did;
-      } else if (!moderatorDID.startsWith("did:")) {
-        // Try to resolve as handle without @
+      if (!moderatorDID.startsWith("did:")) {
+        if (moderatorDID.startsWith("@")) {
+          moderatorDID = moderatorDID.substring(1); // Remove @
+        }
         try {
           const resolved = await agent.com.atproto.identity.resolveHandle({
             handle: moderatorDID,
           });
           moderatorDID = resolved.data.did;
         } catch (e) {
-          // If resolution fails, assume it's already a DID
           throw new Error(
             `Invalid DID or handle: ${moderatorDID}. Please use a valid DID (did:plc:...) or handle (@handle.bsky.social)`,
           );


### PR DESCRIPTION
UI for delegated moderation: 
- allows streamers to grant moderation permissions and delegated moderators to perform moderation actions.

Changes:                                                 
- **ModeratorPanel** component for permission management       
- **Moderation hooks**: `useCanModerate`, `useModeratorManagement`, `useCreateBlockRecord`, etc.         
- **Actions**: block users, hide messages, update livestream metadata                                     
- **Real-time updates**: WebSocket integration for permission sync                                                
                                                          
Tested in browser with moderation permissions, delegated actions, and WebSocket updates.  


Built on top of #788 
                                 
Part 4 of 4 for #718

Closes #718