### PR TITLE
fix: misc. navigation bar tweaks

### DIFF
--- a/js/app/components/sidebar/sidebar.tsx
+++ b/js/app/components/sidebar/sidebar.tsx
@@ -7,8 +7,9 @@ import {
   useNavigation,
 } from "@react-navigation/native";
 import { Text, zero } from "@streamplace/components";
+import { useAQLinkHref } from "components/aqlink";
 import React from "react";
-import { Image, Platform, View } from "react-native";
+import { Image, Platform, Pressable, View } from "react-native";
 import Animated, {
   SharedValue,
   useAnimatedStyle,
@@ -52,6 +53,13 @@ export default function Sidebar({
     };
   });
 
+  // home route
+  const route = state.routes.find((r) => r.name === "Home");
+  const { href } = useAQLinkHref({
+    screen: route ? route.name : "Home",
+    params: route?.params as any,
+  });
+
   if (hidden) {
     return <View />;
   }
@@ -65,7 +73,9 @@ export default function Sidebar({
         zero.layout.flex.column,
       ]}
     >
-      <View
+      <Pressable
+        // @ts-ignore This makes it render as <a> on web!
+        href={route ? href : undefined}
         style={[
           zero.layout.flex.row,
           zero.layout.flex.alignCenter,
@@ -84,7 +94,7 @@ export default function Sidebar({
           style={{ width: 28, height: 30, resizeMode: "contain" }}
         />
         {!collapsed && <Text size="2xl">Streamplace</Text>}
-      </View>
+      </Pressable>
 
       {state.routes.map((route) => {
         const descriptor = descriptors[route.key];
@@ -124,6 +134,7 @@ export default function Sidebar({
             route={route}
             onPress={(ev) => {
               ev.preventDefault();
+              // bleh
               if (route.name === "Home") {
                 // reset the stack (b/c streamlist is in the same stack as home)
                 navigation.dispatch(
@@ -135,6 +146,17 @@ export default function Sidebar({
                         state: {
                           routes: [{ name: "StreamList" }],
                         },
+                      },
+                    ],
+                  }),
+                );
+              } else if (route.name === "Settings") {
+                navigation.dispatch(
+                  CommonActions.reset({
+                    index: 0,
+                    routes: [
+                      {
+                        name: "Settings",
                       },
                     ],
                   }),

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -514,7 +514,7 @@ export function StreamplaceDrawer() {
           options={{
             drawerIcon: () => <Home color={foregroundColor} size={24} />,
             drawerLabel: () => <Text variant="h5">Home</Text>,
-            headerTitle: "Streamplace",
+            headerTitle: isWeb ? "Home" : "Streamplace",
             headerShown: isWeb,
             title: "Streamplace",
           }}
@@ -566,6 +566,21 @@ export function StreamplaceDrawer() {
             ),
             drawerLabel: () => <Text variant="h5">Settings</Text>,
             headerShown: false,
+          }}
+          listeners={{
+            drawerItemPress: (e) => {
+              e.preventDefault();
+              navigation.dispatch(
+                CommonActions.reset({
+                  index: 0,
+                  routes: [
+                    {
+                      name: "Settings",
+                    },
+                  ],
+                }),
+              );
+            },
           }}
         />
 


### PR DESCRIPTION
1. Logo in the top left redirects home, and we change the "Streamplace" on the navbar to "Home".
2. Adds a reset stack button to the 'settings' menu like we do already with 'home'
3. Adds a back button to non-base navigators (e.g. settings, home stacks)