### PR TITLE
config: allow RTMPS addon and regular at the same time

### DIFF
--- a/pkg/cmd/streamplace.go
+++ b/pkg/cmd/streamplace.go
@@ -413,11 +413,10 @@ func start(build *config.BuildFlags, platformJobs []jobFunc) error {
 			group.Go(func() error {
 				return rtmps.ServeRTMPSAddon(ctx, &cli)
 			})
-		} else {
-			group.Go(func() error {
-				return a.ServeRTMPS(ctx, &cli)
-			})
 		}
+		group.Go(func() error {
+			return a.ServeRTMPS(ctx, &cli)
+		})
 	} else {
 		group.Go(func() error {
 			return a.ServeHTTP(ctx)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,6 +67,7 @@ type CLI struct {
 	HTTPSAddr                   string
 	RTMPAddr                    string
 	RTMPSAddr                   string
+	RTMPSAddonAddr              string
 	Secure                      bool
 	NoMist                      bool
 	MistAdminPort               int
@@ -212,6 +213,7 @@ func (cli *CLI) NewFlagSet(name string) *flag.FlagSet {
 	fs.IntVar(&cli.RateLimitBurst, "rate-limit-burst", 0, "rate limit burst for requests per ip")
 	fs.IntVar(&cli.RateLimitWebsocket, "rate-limit-websocket", 10, "number of concurrent websocket connections allowed per ip")
 	fs.StringVar(&cli.RTMPServerAddon, "rtmp-server-addon", "", "address of external RTMP server to forward streams to")
+	fs.StringVar(&cli.RTMPSAddonAddr, "rtmps-addon-addr", ":1936", "address to listen for RTMPS on the addon server")
 	fs.StringVar(&cli.RTMPSAddr, "rtmps-addr", ":1935", "address to listen for RTMPS connections (when --secure=true)")
 	fs.StringVar(&cli.RTMPAddr, "rtmp-addr", ":1935", "address to listen for RTMP connections (when --secure=false)")
 	cli.JSONFlag(fs, &cli.DiscordWebhooks, "discord-webhooks", "[]", "JSON array of Discord webhooks to send notifications to")

--- a/pkg/rtmps/rtmps.go
+++ b/pkg/rtmps/rtmps.go
@@ -29,13 +29,13 @@ func ServeRTMPSAddon(ctx context.Context, cli *config.CLI) error {
 		MinVersion:   tls.VersionTLS12,
 	}
 
-	listener, err := tls.Listen("tcp", cli.RTMPAddr, tlsConfig)
+	listener, err := tls.Listen("tcp", cli.RTMPSAddonAddr, tlsConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create RTMPS listener: %w", err)
 	}
 
 	log.Log(ctx, "rtmps server starting",
-		"addr", cli.RTMPAddr,
+		"addr", cli.RTMPSAddonAddr,
 		"forwarding_to", cli.RTMPServerAddon)
 
 	go func() {


### PR DESCRIPTION
Workaround for people having trouble with the new RTMP server.