### PR TITLE
feat: add scroll to bottom button in chat

### DIFF
--- a/js/components/src/components/chat/chat.tsx
+++ b/js/components/src/components/chat/chat.tsx
@@ -354,7 +354,7 @@ export function Chat({
           }}
         >
           <ChevronDown size={16} color="white" />
-          <Text style={{ color: "white", fontWeight: "600", fontSize: 13 }}>
+          <Text style={{ color: "white", fontSize: 13 }}>
             Scroll to bottom
           </Text>
         </Pressable>

--- a/js/components/src/components/chat/chat.tsx
+++ b/js/components/src/components/chat/chat.tsx
@@ -1,4 +1,4 @@
-import { Ellipsis, Reply } from "lucide-react-native";
+import { ChevronDown, Ellipsis, Reply } from "lucide-react-native";
 import { ComponentProps, memo, useEffect, useRef, useState } from "react";
 import { Keyboard, Platform, Pressable } from "react-native";
 import { FlatList } from "react-native-gesture-handler";
@@ -8,6 +8,8 @@ import Swipeable, {
 import Reanimated, {
   SharedValue,
   useAnimatedStyle,
+  useSharedValue,
+  withTiming,
 } from "react-native-reanimated";
 import { ChatMessageViewHydrated } from "streamplace";
 import {
@@ -245,6 +247,27 @@ export function Chat({
 }) {
   const chat = useChat();
   const [isScrolledUp, setIsScrolledUp] = useState(false);
+  const flatListRef = useRef<FlatList>(null);
+
+  // Animation for scroll-to-bottom button
+  const buttonOpacity = useSharedValue(0);
+  const buttonTranslateY = useSharedValue(20);
+
+  useEffect(() => {
+    buttonOpacity.value = withTiming(isScrolledUp ? 1 : 0, { duration: 200 });
+    buttonTranslateY.value = withTiming(isScrolledUp ? 0 : 20, {
+      duration: 200,
+    });
+  }, [isScrolledUp]);
+
+  const buttonAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: buttonOpacity.value,
+    transform: [{ translateY: buttonTranslateY.value }],
+  }));
+
+  const scrollToBottom = () => {
+    flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
+  };
 
   const handleScroll = (event: any) => {
     const { contentOffset } = event.nativeEvent;
@@ -270,11 +293,18 @@ export function Chat({
 
   return (
     <View
-      style={[flex.shrink[1], { minWidth: 0, maxWidth: "100%" }].concat(
-        propsStyle || [],
-      )}
+      style={[
+        flex.shrink[1],
+        {
+          minWidth: 0,
+          maxWidth: "100%",
+          position: "relative",
+          overflow: "visible",
+        },
+      ].concat(propsStyle || [])}
     >
       <FlatList
+        ref={flatListRef}
         style={[
           flex.grow[1],
           flex.shrink[1],
@@ -292,6 +322,43 @@ export function Chat({
         scrollEventThrottle={16}
         nestedScrollEnabled={true}
       />
+      <Reanimated.View
+        style={[
+          {
+            position: "absolute",
+            bottom: 16,
+            left: 0,
+            right: 0,
+            alignItems: "center",
+            pointerEvents: isScrolledUp ? "box-none" : "none",
+          },
+          buttonAnimatedStyle,
+        ]}
+      >
+        <Pressable
+          onPress={scrollToBottom}
+          style={{
+            pointerEvents: "auto",
+            flexDirection: "row",
+            alignItems: "center",
+            backgroundColor: "rgba(59, 130, 246, 0.9)",
+            paddingHorizontal: 16,
+            paddingVertical: 8,
+            borderRadius: 20,
+            gap: 6,
+            shadowColor: "#000",
+            shadowOffset: { width: 0, height: 2 },
+            shadowOpacity: 0.25,
+            shadowRadius: 4,
+            elevation: 5,
+          }}
+        >
+          <ChevronDown size={16} color="white" />
+          <Text style={{ color: "white", fontWeight: "600", fontSize: 13 }}>
+            Scroll to bottom
+          </Text>
+        </Pressable>
+      </Reanimated.View>
       <ModView />
     </View>
   );

--- a/js/components/src/components/chat/chat.tsx
+++ b/js/components/src/components/chat/chat.tsx
@@ -354,9 +354,7 @@ export function Chat({
           }}
         >
           <ChevronDown size={16} color="white" />
-          <Text style={{ color: "white", fontSize: 13 }}>
-            Scroll to bottom
-          </Text>
+          <Text style={{ color: "white", fontSize: 13 }}>Scroll to bottom</Text>
         </Pressable>
       </Reanimated.View>
       <ModView />


### PR DESCRIPTION
I added a "scroll to bottom" button that appears when you scroll up in the chat. Closes #812

## What I Did:

When you scroll up in the chat, a blue button appears at the bottom. The button says "Scroll to bottom" with an arrow icon. It slides up  when it appears. When you click it, the chat scrolls back to the newest messages. If there is any issue, please, let me know

## Video


https://github.com/user-attachments/assets/33f16d6a-3827-4785-97af-da4a795b5e34






