### PR TITLE
fix: add overflow hidden to stream monitor to fix square corners

### DIFF
--- a/js/app/components/live-dashboard/stream-monitor.tsx
+++ b/js/app/components/live-dashboard/stream-monitor.tsx
@@ -98,6 +98,7 @@ export default function StreamMonitor({
         borders.width.thin,
         borders.color.neutral[700],
         layout.flex.column,
+        { overflow: "hidden" },
       ]}
     >
       <View style={[flex.values[1], layout.flex.center, bg.neutral[900]]}>


### PR DESCRIPTION
## Fix
<img width="512" height="343" alt="fix" src="https://github.com/user-attachments/assets/ed879a22-227d-444e-b0c4-9081058abeff" />

I considered adding border-radius to each child component individually, but that would require modifying multiple children . Instead, I checked out the pattern already established in the codebase by checking `cards.tsx` and `avatar.tsx` where overflow: "hidden" is used on the parent . I think using overflow: "hidden"  keeps the fix simple . 
Fixes #818 

