### PR TITLE
feat: move log in/sign up to top right

### DIFF
--- a/js/app/components/login/login-form.tsx
+++ b/js/app/components/login/login-form.tsx
@@ -74,7 +74,8 @@ export default function LoginForm({ onSuccess }: LoginFormProps) {
   };
 
   const onSignup = () => {
-    loginAction("https://bsky.social", openLoginLink);
+    // TODO: remove requirement for oauth-protected-resource in oatproxy
+    loginAction("https://blewit.us-west.host.bsky.network", openLoginLink);
   };
 
   const isMobile = Platform.OS === "ios" || Platform.OS === "android";

--- a/js/app/components/login/login-form.tsx
+++ b/js/app/components/login/login-form.tsx
@@ -75,7 +75,7 @@ export default function LoginForm({ onSuccess }: LoginFormProps) {
 
   const onSignup = () => {
     // TODO: remove requirement for oauth-protected-resource in oatproxy
-    loginAction("https://blewit.us-west.host.bsky.network", openLoginLink);
+    loginAction("https://bsky.social", openLoginLink);
   };
 
   const isMobile = Platform.OS === "ios" || Platform.OS === "android";

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -63,6 +63,7 @@ import {
   Platform,
   Pressable,
   StatusBar,
+  useWindowDimensions,
   View,
 } from "react-native";
 import AboutScreen from "./screens/about";
@@ -332,22 +333,7 @@ const AvatarButton = () => {
     loginAction("https://blewit.us-west.host.bsky.network", openLoginLink);
   };
 
-  const [windowWidth, setWindowWidth] = React.useState(
-    Platform.OS === "web" && typeof window !== "undefined"
-      ? window.innerWidth
-      : 1000,
-  );
-
-  React.useEffect(() => {
-    if (Platform.OS !== "web") return;
-
-    const handleResize = () => {
-      setWindowWidth(window.innerWidth);
-    };
-
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
+  const windowWidth = useWindowDimensions().width;
 
   const isCompact = windowWidth <= 800;
 

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -16,15 +16,16 @@ import {
 } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import {
+  Button,
   Text,
   useDefaultStreamer,
   useSiteTitle,
   useTheme,
   useToast,
+  zero,
 } from "@streamplace/components";
 import { Provider, Settings } from "components";
 import AQLink from "components/aqlink";
-import Login from "components/login/login";
 import LoginModal from "components/login/login-modal";
 import { AboutCategorySettings } from "components/settings/about-category-settings";
 import { AccountCategorySettings } from "components/settings/account-category-settings";
@@ -143,7 +144,6 @@ type RootStackParamList = {
   KeyManagement: undefined;
   GoLive: undefined;
   LiveDashboard: undefined;
-  Login: undefined;
   AVSync: undefined;
   AppReturn: { scheme: string };
   About: undefined;
@@ -197,7 +197,6 @@ const linking: LinkingOptions<ReactNavigation.RootParamList> = {
       KeyManagement: "key-management",
       GoLive: "golive",
       LiveDashboard: "live",
-      Login: "login",
       AVSync: "sync-test",
       AppReturn: "app-return/:scheme",
       About: "about",
@@ -293,36 +292,111 @@ const NavigationButton = ({ canGoBack }: { canGoBack?: boolean }) => {
 
 const AvatarButton = () => {
   const userProfile = useUserProfile();
+  const openLoginModal = useStore((state) => state.openLoginModal);
+  const loginAction = useStore((state) => state.login);
+  const openLoginLink = useStore((state) => state.openLoginLink);
+  const { theme } = useTheme();
   let source: ImageSourcePropType | undefined = undefined;
-  let opacity = 1;
-  const targetScreen: any = userProfile
-    ? { screen: "Settings", params: { screen: "AccountCategory" } }
-    : { screen: "Login", params: {} };
 
   if (userProfile) {
     source = { uri: userProfile.avatar };
-    opacity = 0;
-  }
-  return (
-    <AQLink to={targetScreen}>
-      <ImageBackground
-        // defeat cursed-ass caching on ios; image sticks around when source is undefined
-        key={source?.uri ?? "default"}
-        source={source}
-        style={{
-          width: 40,
-          height: 40,
-          borderRadius: 24,
-          overflow: "hidden",
-          marginRight: 10,
-          backgroundColor: "black",
-          justifyContent: "center",
-          alignItems: "center",
-        }}
+    return (
+      <AQLink
+        to={{ screen: "Settings", params: { screen: "AccountCategory" } }}
       >
-        <User size={24} color="white" style={{ zIndex: -2 }} />
-      </ImageBackground>
-    </AQLink>
+        <ImageBackground
+          key={source?.uri ?? "default"}
+          source={source}
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 24,
+            overflow: "hidden",
+            marginRight: 10,
+            backgroundColor: "black",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          <User size={24} color="white" style={{ zIndex: -2 }} />
+        </ImageBackground>
+      </AQLink>
+    );
+  }
+
+  const handleSignup = () => {
+    // TODO: remove requirement for oauth-protected-resource in oatproxy
+    loginAction("https://blewit.us-west.host.bsky.network", openLoginLink);
+  };
+
+  const [windowWidth, setWindowWidth] = React.useState(
+    Platform.OS === "web" && typeof window !== "undefined"
+      ? window.innerWidth
+      : 1000,
+  );
+
+  React.useEffect(() => {
+    if (Platform.OS !== "web") return;
+
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const isCompact = windowWidth <= 800;
+
+  if (isCompact) {
+    return (
+      <Button
+        onPress={() => openLoginModal()}
+        variant="ghost"
+        size="icon"
+        width="min"
+        style={{ marginRight: 10, marginLeft: "auto" }}
+      >
+        <LogIn size={20} color={theme.colors.text} />
+      </Button>
+    );
+  }
+
+  return (
+    <View
+      style={{
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 8,
+        marginRight: 10,
+      }}
+    >
+      <Button
+        onPress={() => openLoginModal()}
+        variant="secondary"
+        width="min"
+        style={[zero.r.full]}
+      >
+        <Text style={{ color: theme.colors.text }}>Log In</Text>
+      </Button>
+      <Button
+        onPress={handleSignup}
+        variant="primary"
+        width="min"
+        style={[zero.r.full]}
+      >
+        <Text style={{ color: theme.colors.text }}>Sign Up</Text>
+      </Button>
+      <Button
+        width="min"
+        size="icon"
+        variant="secondary"
+        style={[zero.r.full]}
+        onPress={() => openLoginModal()}
+      >
+        <User size={24} color="white" />
+      </Button>
+    </View>
   );
 };
 
@@ -659,15 +733,7 @@ export function StreamplaceDrawer() {
             drawerItemStyle: { display: "none" },
           }}
         />
-        <Drawer.Screen
-          name="Login"
-          component={Login}
-          options={{
-            drawerIcon: () => <LogIn color={foregroundColor} size={24} />,
-            drawerLabel: () => <Text variant="h5">Login</Text>,
-            drawerItemStyle: { display: userProfile ? "none" : undefined },
-          }}
-        />
+
         <Drawer.Screen
           name="PopoutChat"
           component={PopoutChat}

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -26,6 +26,7 @@ import {
 } from "@streamplace/components";
 import { Provider, Settings } from "components";
 import AQLink from "components/aqlink";
+import Login from "components/login/login";
 import LoginModal from "components/login/login-modal";
 import { AboutCategorySettings } from "components/settings/about-category-settings";
 import { AccountCategorySettings } from "components/settings/account-category-settings";
@@ -144,6 +145,7 @@ type RootStackParamList = {
   KeyManagement: undefined;
   GoLive: undefined;
   LiveDashboard: undefined;
+  Login: undefined;
   AVSync: undefined;
   AppReturn: { scheme: string };
   About: undefined;
@@ -197,6 +199,7 @@ const linking: LinkingOptions<ReactNavigation.RootParamList> = {
       KeyManagement: "key-management",
       GoLive: "golive",
       LiveDashboard: "live",
+      Login: "login",
       AVSync: "sync-test",
       AppReturn: "app-return/:scheme",
       About: "about",
@@ -733,7 +736,15 @@ export function StreamplaceDrawer() {
             drawerItemStyle: { display: "none" },
           }}
         />
-
+        <Drawer.Screen
+          name="Login"
+          component={Login}
+          options={{
+            drawerLabel: () => null,
+            drawerItemStyle: { display: "none" },
+            headerShown: false,
+          }}
+        />
         <Drawer.Screen
           name="PopoutChat"
           component={PopoutChat}

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -330,7 +330,7 @@ const AvatarButton = () => {
 
   const handleSignup = () => {
     // TODO: remove requirement for oauth-protected-resource in oatproxy
-    loginAction("https://blewit.us-west.host.bsky.network", openLoginLink);
+    loginAction("https://bsky.social", openLoginLink);
   };
 
   const windowWidth = useWindowDimensions().width;

--- a/js/components/src/components/ui/button.tsx
+++ b/js/components/src/components/ui/button.tsx
@@ -23,6 +23,7 @@ const buttonVariants = cva("", {
       lg: "lg",
       xl: "xl",
       pill: "pill",
+      icon: "icon",
     },
   },
   defaultVariants: {
@@ -142,6 +143,12 @@ export const Button = forwardRef<any, ButtonProps>(
             ],
             inner: { gap: 4 },
             text: zero.typography.universal.xs,
+          };
+        case "icon":
+          return {
+            button: [zero.p[2], { borderRadius: zero.borderRadius.md }],
+            inner: { gap: 0 },
+            text: zero.typography.universal.sm,
           };
         case "md":
         default:


### PR DESCRIPTION
Suggestion from @uncenter, but I personally like it as well. Most people expect the buttons to be near the avatar wherever it may be, so it's probably best ux-wise to add links around to log in/sign up.

<img width="329" height="65" alt="image" src="https://github.com/user-attachments/assets/1df79b7d-555d-4dee-9800-de89e4f77328" />
