### PR TITLE
director: set app.bsky.actor.status duration to 10

### DIFF
--- a/pkg/director/stream_session.go
+++ b/pkg/director/stream_session.go
@@ -368,7 +368,7 @@ func (ss *StreamSession) UpdateStatus(ctx context.Context, repoDID string) error
 		},
 	}
 
-	duration := int64(120)
+	duration := int64(10)
 	status := bsky.ActorStatus{
 		Status:          "app.bsky.actor.status#live",
 		DurationMinutes: &duration,


### PR DESCRIPTION
This is a little arbitrary, as we're supposed to automatically delete the record when you're done, but in the event that doesn't happen for whatever reason we want it to be small.

It looks like Bluesky refreshes the record every 5 minutes, so this gives us some breathing room while not persisting your status too long if the delete failed for whatever reason.

https://github.com/bluesky-social/social-app/commit/1d4263078d937dd447dbfe638effb48dccc3faf3