### PR TITLE
Mute player in live stream on dashboard

### DIFF
--- a/js/app/components/live-dashboard/stream-monitor.tsx
+++ b/js/app/components/live-dashboard/stream-monitor.tsx
@@ -104,7 +104,7 @@ export default function StreamMonitor({
       <View style={[flex.values[1], layout.flex.center, bg.neutral[900]]}>
         {isLive && userProfile ? (
           isStreamVisible ? (
-            <Player src={userProfile.did} name={userProfile.handle}>
+            <Player src={userProfile.did} name={userProfile.handle} muted={true}>
               <DesktopUi />
               <PlayerUI.ViewerLoadingOverlay />
               <OfflineCounter isMobile={true} />


### PR DESCRIPTION
I noticed today that whilst setting up my stream I had a horrible feedback loop, this was caused by the player on the live dashboard being unmuted. This change *should*, if I'm right, mute that player by default.