### PR TITLE
feat: filter blocked users from home feed and chat

### DIFF
--- a/js/components/src/livestream-provider/websocket.tsx
+++ b/js/components/src/livestream-provider/websocket.tsx
@@ -1,10 +1,12 @@
 import { useRef } from "react";
 import useWebSocket from "react-use-websocket";
 import { useHandleWebsocketMessages } from "../livestream-store";
-import { useUrl } from "../streamplace-store";
+import { useDID, useStreamplaceStore, useUrl } from "../streamplace-store";
 
 export function useLivestreamWebsocket(src: string) {
   const url = useUrl();
+  const did = useDID();
+  const oauthSession = useStreamplaceStore((state) => state.oauthSession);
   const handleWebSocketMessages = useHandleWebsocketMessages();
 
   let wsUrl = url.replace(/^http\:/, "ws:");
@@ -15,7 +17,14 @@ export function useLivestreamWebsocket(src: string) {
   const hasReceivedMessage = useRef(false);
   const hasErrored = useRef(false);
 
-  const { readyState } = useWebSocket(`${wsUrl}/api/websocket/${src}`, {
+  // Don't connect until auth state is resolved (undefined = still loading)
+  const authResolved = oauthSession !== undefined;
+
+  const wsUrlWithViewer = did
+    ? `${wsUrl}/api/websocket/${src}?viewer=${encodeURIComponent(did)}`
+    : `${wsUrl}/api/websocket/${src}`;
+
+  const { readyState } = useWebSocket(authResolved ? wsUrlWithViewer : null, {
     reconnectInterval: 1000,
     shouldReconnect: () => !hasErrored.current,
 

--- a/js/components/src/streamplace-provider/poller.tsx
+++ b/js/components/src/streamplace-provider/poller.tsx
@@ -1,21 +1,23 @@
 import React, { useEffect } from "react";
-import { StreamplaceAgent } from "streamplace";
 import {
   useDID,
   useGetBskyProfile,
   useGetChatProfile,
   useStreamplaceStore,
 } from "../streamplace-store";
-import { usePDSAgent } from "../streamplace-store/xrpc";
+import {
+  usePDSAgent,
+  usePossiblyUnauthedPDSAgent,
+} from "../streamplace-store/xrpc";
 import { useTimeSync } from "../time-sync";
 
 export default function Poller({ children }: { children: React.ReactNode }) {
-  const url = useStreamplaceStore((state) => state.url);
   const setLiveUsers = useStreamplaceStore((state) => state.setLiveUsers);
   const did = useDID();
   const pdsAgent = usePDSAgent();
   const getChatProfile = useGetChatProfile();
   const getBskyProfile = useGetBskyProfile();
+  const liveUsersAgent = usePossiblyUnauthedPDSAgent();
   const liveUserRefresh = useStreamplaceStore(
     (state) => state.liveUsersRefresh,
   );
@@ -30,13 +32,13 @@ export default function Poller({ children }: { children: React.ReactNode }) {
   }, [pdsAgent, did]);
 
   useEffect(() => {
-    const agent = new StreamplaceAgent(url);
+    if (!liveUsersAgent) return;
     const go = async () => {
       setLiveUsers({
         liveUsersLoading: true,
       });
       try {
-        const res = await agent.place.stream.live.getLiveUsers();
+        const res = await liveUsersAgent.place.stream.live.getLiveUsers();
         setLiveUsers({
           liveUsers: res.data.streams || [],
           liveUsersLoading: false,
@@ -52,7 +54,7 @@ export default function Poller({ children }: { children: React.ReactNode }) {
     go();
     const handle = setInterval(go, 3000);
     return () => clearInterval(handle);
-  }, [url, liveUserRefresh]);
+  }, [liveUsersAgent, liveUserRefresh]);
 
   return <>{children}</>;
 }

--- a/js/components/src/streamplace-store/streamplace-store.tsx
+++ b/js/components/src/streamplace-store/streamplace-store.tsx
@@ -110,7 +110,7 @@ export const makeStreamplaceStore = ({
     liveUsersRefresh: 0,
     liveUsersLoading: true,
     liveUsersError: null,
-    oauthSession: null,
+    oauthSession: undefined,
     handle: null,
     chatProfile: null,
 

--- a/pkg/api/websocket.go
+++ b/pkg/api/websocket.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/julienschmidt/httprouter"
 
+	"stream.place/streamplace/pkg/bus"
 	apierrors "stream.place/streamplace/pkg/errors"
 	"stream.place/streamplace/pkg/log"
 	"stream.place/streamplace/pkg/renditions"
@@ -65,6 +66,12 @@ func (a *StreamplaceAPI) HandleWebsocket(ctx context.Context) httprouter.Handle 
 			apierrors.WriteHTTPNotFound(w, "user not found", err)
 			return
 		}
+		viewerDID := req.URL.Query().Get("viewer")
+		if viewerDID != "" {
+			if _, err := a.ATSync.SyncBlueskyRepoCached(ctx, viewerDID, a.Model); err != nil {
+				log.Error(ctx, "could not sync viewer repo", "error", err, "viewerDID", viewerDID)
+			}
+		}
 		conn, err := upgrader.Upgrade(w, req, nil)
 		if err != nil {
 			apierrors.WriteHTTPInternalServerError(w, "could not upgrade to websocket", err)
@@ -110,10 +117,26 @@ func (a *StreamplaceAPI) HandleWebsocket(ctx context.Context) httprouter.Handle 
 			return nil
 		})
 		go func() {
+			blockedDIDs := make(map[string]bool)
+			if viewerDID != "" {
+				dids, err := a.Model.GetBlockedDIDs(ctx, viewerDID)
+				if err != nil {
+					log.Error(ctx, "could not get blocked DIDs", "error", err)
+				}
+				for _, did := range dids {
+					blockedDIDs[did] = true
+				}
+			}
 
 			ch := a.Bus.Subscribe(repoDID)
 			defer a.Bus.Unsubscribe(repoDID, ch)
-			// Create a ticker that fires every 3 seconds
+
+			var viewerCh <-chan bus.Message
+			if viewerDID != "" {
+				viewerCh = a.Bus.Subscribe(viewerDID)
+				defer a.Bus.Unsubscribe(viewerDID, viewerCh)
+			}
+
 			ticker := time.NewTicker(3 * time.Second)
 			pingTicker := time.NewTicker(pingPeriod)
 			defer ticker.Stop()
@@ -133,10 +156,30 @@ func (a *StreamplaceAPI) HandleWebsocket(ctx context.Context) httprouter.Handle 
 				}
 			}
 
+			isBlockedChat := func(msg any) bool {
+				if len(blockedDIDs) == 0 {
+					return false
+				}
+				if chatMsg, ok := msg.(*streamplace.ChatDefs_MessageView); ok {
+					return chatMsg.Author != nil && blockedDIDs[chatMsg.Author.Did]
+				}
+				return false
+			}
+
 			for {
 				select {
 				case msg := <-ch:
+					if isBlockedChat(msg) {
+						continue
+					}
 					send(msg)
+				case msg := <-viewerCh:
+					if blockView, ok := msg.(*streamplace.Defs_BlockView); ok {
+						if blockView.Blocker != nil && blockView.Blocker.Did == viewerDID && blockView.Record != nil {
+							blockedDIDs[blockView.Record.Subject] = true
+							send(blockView)
+						}
+					}
 				case msg := <-initialBurst:
 					send(msg)
 				case <-ticker.C:
@@ -232,7 +275,7 @@ func (a *StreamplaceAPI) HandleWebsocket(ctx context.Context) httprouter.Handle 
 		}()
 
 		go func() {
-			messages, err := a.Model.MostRecentChatMessages(repoDID)
+			messages, err := a.Model.MostRecentChatMessagesForViewer(repoDID, viewerDID)
 			if err != nil {
 				log.Error(ctx, "could not get chat messages", "error", err)
 				return

--- a/pkg/model/block.go
+++ b/pkg/model/block.go
@@ -73,6 +73,15 @@ func (m *DBModel) GetBlock(ctx context.Context, rkey string) (*Block, error) {
 	return &block, nil
 }
 
+func (m *DBModel) GetBlockedDIDs(ctx context.Context, blockerDID string) ([]string, error) {
+	var dids []string
+	err := m.DB.Model(&Block{}).Where("repo_did = ?", blockerDID).Pluck("subject_did", &dids).Error
+	if err != nil {
+		return nil, err
+	}
+	return dids, nil
+}
+
 func (m *DBModel) GetUserBlock(ctx context.Context, userDID, subjectDID string) (*Block, error) {
 	var block Block
 	err := m.DB.Where("repo_did = ? AND subject_did = ?", userDID, subjectDID).First(&block).Error

--- a/pkg/model/chat_message.go
+++ b/pkg/model/chat_message.go
@@ -132,8 +132,12 @@ func (m *DBModel) GetChatMessage(uri string) (*ChatMessage, error) {
 }
 
 func (m *DBModel) MostRecentChatMessages(repoDID string) ([]*streamplace.ChatDefs_MessageView, error) {
+	return m.MostRecentChatMessagesForViewer(repoDID, "")
+}
+
+func (m *DBModel) MostRecentChatMessagesForViewer(repoDID, viewerDID string) ([]*streamplace.ChatDefs_MessageView, error) {
 	dbmessages := []ChatMessage{}
-	err := m.DB.
+	q := m.DB.
 		Preload("Repo").
 		Preload("ChatProfile").
 		Preload("ReplyTo").
@@ -150,8 +154,14 @@ func (m *DBModel) MostRecentChatMessages(repoDID string) ([]*streamplace.ChatDef
 		Joins("LEFT JOIN labels ON labels.uri = chat_messages.uri").
 		Where("labels.uri IS NULL"). // Only include messages where no label exists
 		// Exclude deleted messages
-		Where("chat_messages.deleted_at IS NULL").
-		Limit(100).
+		Where("chat_messages.deleted_at IS NULL")
+
+	if viewerDID != "" {
+		q = q.Joins("LEFT JOIN blocks AS viewer_blocks ON viewer_blocks.repo_did = ? AND viewer_blocks.subject_did = chat_messages.repo_did", viewerDID).
+			Where("viewer_blocks.rkey IS NULL")
+	}
+
+	err := q.Limit(100).
 		Order("chat_messages.created_at DESC").
 		Find(&dbmessages).Error
 	if err != nil {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -71,11 +71,13 @@ type Model interface {
 
 	CreateBlock(ctx context.Context, block *Block) error
 	GetBlock(ctx context.Context, rkey string) (*Block, error)
+	GetBlockedDIDs(ctx context.Context, blockerDID string) ([]string, error)
 	GetUserBlock(ctx context.Context, userDID, subjectDID string) (*Block, error)
 	DeleteBlock(ctx context.Context, rkey string) error
 
 	CreateChatMessage(ctx context.Context, message *ChatMessage) error
 	MostRecentChatMessages(repoDID string) ([]*streamplace.ChatDefs_MessageView, error)
+	MostRecentChatMessagesForViewer(repoDID, viewerDID string) ([]*streamplace.ChatDefs_MessageView, error)
 	GetChatMessage(uri string) (*ChatMessage, error)
 	DeleteChatMessage(ctx context.Context, uri string, deletedAt *time.Time) error
 

--- a/pkg/spxrpc/place_stream_live.go
+++ b/pkg/spxrpc/place_stream_live.go
@@ -113,10 +113,21 @@ func (s *Server) handlePlaceStreamLiveGetSegments(ctx context.Context, before st
 }
 
 func (s *Server) handlePlaceStreamLiveGetLiveUsers(ctx context.Context, before string, limit int) (*placestreamtypes.LiveGetLiveUsers_Output, error) {
-	// Check cache first
+	session, _ := oatproxy.GetOAuthSession(ctx)
+	var viewerDID string
+	if session != nil {
+		viewerDID = session.DID
+		if _, err := s.ATSync.SyncBlueskyRepoCached(ctx, viewerDID, s.model); err != nil {
+			log.Error(ctx, "could not sync viewer repo", "error", err, "viewerDID", viewerDID)
+		}
+	}
+
+	// Check cache first (only for anonymous requests)
 	cacheKey := fmt.Sprintf("live_users_%s_%d", before, limit)
-	if cached, found := s.LiveUsersCache.Get(cacheKey); found {
-		return cached.(*placestreamtypes.LiveGetLiveUsers_Output), nil
+	if viewerDID == "" {
+		if cached, found := s.LiveUsersCache.Get(cacheKey); found {
+			return cached.(*placestreamtypes.LiveGetLiveUsers_Output), nil
+		}
 	}
 
 	var beforeTime *time.Time
@@ -140,27 +151,44 @@ func (s *Server) handlePlaceStreamLiveGetLiveUsers(ctx context.Context, before s
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Failed to fetch livestreams")
 	}
 
-	streams := make([]*placestreamtypes.Livestream_LivestreamView, len(ls))
+	var blockedDIDs map[string]bool
+	if viewerDID != "" {
+		dids, err := s.model.GetBlockedDIDs(ctx, viewerDID)
+		if err != nil {
+			log.Error(ctx, "could not get blocked DIDs for viewer", "error", err)
+		} else {
+			blockedDIDs = make(map[string]bool, len(dids))
+			for _, did := range dids {
+				blockedDIDs[did] = true
+			}
+		}
+	}
 
-	for i, l := range ls {
+	streams := make([]*placestreamtypes.Livestream_LivestreamView, 0, len(ls))
+
+	for _, l := range ls {
 		stream, err := l.ToLivestreamView()
 		if err != nil {
 			return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to convert livestream to streamplace livestream: %s", err))
+		}
+		if blockedDIDs[stream.Author.Did] {
+			continue
 		}
 		viewers := spmetrics.GetViewCount(stream.Author.Did)
 		stream.ViewerCount = &placestreamtypes.Livestream_ViewerCount{
 			LexiconTypeID: "place.stream.livestream#viewerCount",
 			Count:         int64(viewers),
 		}
-		streams[i] = stream
+		streams = append(streams, stream)
 	}
 
 	liveUsers := &placestreamtypes.LiveGetLiveUsers_Output{
 		Streams: streams,
 	}
 
-	// Cache the result
-	s.LiveUsersCache.SetDefault(cacheKey, liveUsers)
+	if viewerDID == "" {
+		s.LiveUsersCache.SetDefault(cacheKey, liveUsers)
+	}
 
 	return liveUsers, nil
 }


### PR DESCRIPTION
Add client-side filtering based on the viewer's Bluesky block list:
- Fetch block records using com.atproto.repo.listRecords on login
- Subscribe to real-time block/unblock events via Jetstream
- Filter blocked users' streams from the home screen
- Filter blocked users' messages from chat
- Uses @skyware/jetstream for real-time updates when blocks are created or deleted.

Addresses bullet point 2 in #784

I opted not to address mutes, as I feel like mutes might be used more for bluesky-specific content and so filtering atproto content out there would be surprising or incorrect. Let me know what you think. Also mutes would require polling since they are private.

Notably, I failed to implement code that would use `app.bsky.graph.getBlocks`. I just couldn't get the oauth to work, even after adding a scope and proxied streamplace XRPC pathway for it. Let me know if you have any insight. But since all we need are DIDs, using listRecords is more efficient anyway.