### PR TITLE
feat: signup pds picker

### DIFF
--- a/js/app/components/login/login-form.tsx
+++ b/js/app/components/login/login-form.tsx
@@ -20,9 +20,15 @@ import { useLogin } from "store/hooks";
 
 interface LoginFormProps {
   onSuccess?: () => void;
+  onCloseModal?: () => void;
+  onOpenPdsModal?: () => void;
 }
 
-export default function LoginForm({ onSuccess }: LoginFormProps) {
+export default function LoginForm({
+  onSuccess,
+  onCloseModal,
+  onOpenPdsModal,
+}: LoginFormProps) {
   const { theme } = useTheme();
   const loginAction = useStore((state) => state.login);
   const openLoginLink = useStore((state) => state.openLoginLink);
@@ -74,8 +80,8 @@ export default function LoginForm({ onSuccess }: LoginFormProps) {
   };
 
   const onSignup = () => {
-    // TODO: remove requirement for oauth-protected-resource in oatproxy
-    loginAction("https://bsky.social", openLoginLink);
+    onCloseModal?.();
+    onOpenPdsModal?.();
   };
 
   const isMobile = Platform.OS === "ios" || Platform.OS === "android";

--- a/js/app/components/login/login-form.tsx
+++ b/js/app/components/login/login-form.tsx
@@ -290,7 +290,7 @@ export default function LoginForm({
         ]}
       >
         <Button width="min" onPress={() => onSignup()} variant="ghost">
-          <Text style={[{ color: "white" }]}>Sign Up on Bluesky</Text>
+          <Text style={[{ color: "white" }]}>Sign Up</Text>
         </Button>
         <Button
           onPress={submit}
@@ -299,7 +299,7 @@ export default function LoginForm({
           width="min"
           loading={loginState.loading}
         >
-          <Text style={[{ color: "white" }]}>Log in</Text>
+          <Text style={[{ color: "white" }]}>Log In</Text>
         </Button>
       </View>
     </>

--- a/js/app/components/login/login-modal.tsx
+++ b/js/app/components/login/login-modal.tsx
@@ -6,9 +6,14 @@ import LoginForm from "./login-form";
 interface LoginModalProps {
   visible: boolean;
   onClose: () => void;
+  onOpenPdsModal: () => void;
 }
 
-export default function LoginModal({ visible, onClose }: LoginModalProps) {
+export default function LoginModal({
+  visible,
+  onClose,
+  onOpenPdsModal,
+}: LoginModalProps) {
   const { theme, zero: z } = useTheme();
 
   return (
@@ -64,7 +69,11 @@ export default function LoginModal({ visible, onClose }: LoginModalProps) {
             </TouchableOpacity>
           </View>
 
-          <LoginForm onSuccess={onClose} />
+          <LoginForm
+            onSuccess={onClose}
+            onCloseModal={onClose}
+            onOpenPdsModal={onOpenPdsModal}
+          />
         </Pressable>
       </View>
     </Modal>

--- a/js/app/components/login/login.tsx
+++ b/js/app/components/login/login.tsx
@@ -12,6 +12,7 @@ import LoginForm from "./login-form";
 export default function Login() {
   const { theme } = useTheme();
   const closeLoginModal = useStore((state) => state.closeLoginModal);
+  const openPdsModal = useStore((state) => state.openPdsModal);
   const userProfile = useUserProfile();
   const navigation = useNavigation();
   const isReady = useIsReady();
@@ -103,7 +104,7 @@ export default function Login() {
             <Text style={[{ fontSize: 36, fontWeight: "200", color: "white" }]}>
               Log in
             </Text>
-            <LoginForm />
+            <LoginForm onOpenPdsModal={openPdsModal} />
           </View>
         </View>
       </ScrollView>

--- a/js/app/components/login/pds-host-selector-modal.tsx
+++ b/js/app/components/login/pds-host-selector-modal.tsx
@@ -4,8 +4,10 @@ import {
   Checkbox,
   Input,
   ResponsiveDialog,
+  Trans as T,
   Text,
   useTheme,
+  useTranslation,
   zero,
 } from "@streamplace/components";
 import { Check, ExternalLink } from "lucide-react-native";
@@ -93,6 +95,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
   const [handlePolicyChecked, hasCheckedHandlePolicy] = useState(false);
 
   const { theme } = useTheme();
+  const { t } = useTranslation();
 
   const selectedHostObj =
     SHUFFLED_PDS_HOSTS.find((host) => host.value === selectedHost) ||
@@ -145,11 +148,10 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
       <View style={[{ maxWidth: 500 }]}>
         <View style={[zero.my[4]]}>
           <Text size="2xl" style={[zero.mb[2]]}>
-            New to the Atmosphere?
+            {t("pds-selector-title")}
           </Text>
           <Text style={[{ color: theme.colors.textMuted }]}>
-            You'll need to select a PDS (Personal Data Server) to access apps on
-            the Atmosphere, such as Bluesky, Tangled, and Spark.
+            {t("pds-selector-description")}
           </Text>
         </View>
         <View style={[zero.pb[2]]}>
@@ -226,14 +228,14 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
               ]}
             >
               <View style={[zero.flex[1]]}>
-                <Text>Another PDS</Text>
+                <Text>{t("pds-selector-custom-label")}</Text>
                 <Text
                   style={[
                     zero.mt[1],
                     { fontSize: 14, color: theme.colors.textMuted },
                   ]}
                 >
-                  Enter your own PDS host URL
+                  {t("pds-selector-custom-description")}
                 </Text>
               </View>
               {useCustom && <Check size={20} color={theme.colors.primary} />}
@@ -250,7 +252,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
               ]}
             >
               <Text style={[{ color: theme.colors.ring, fontSize: 14 }]}>
-                Learn more about self-hosting
+                {t("pds-selector-learn-more")}
               </Text>
               <ExternalLink size={16} color={theme.colors.ring} />
             </Pressable>
@@ -259,12 +261,12 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
           {useCustom && (
             <View style={[zero.mt[3]]}>
               <Text style={[zero.mb[2], { color: theme.colors.textMuted }]}>
-                PDS URL
+                {t("pds-selector-custom-url-label")}
               </Text>
               <Input
                 value={customHost}
                 onChangeText={setCustomHost}
-                placeholder="https://pds.example.com"
+                placeholder={t("pds-selector-custom-url-placeholder")}
                 autoCapitalize="none"
                 autoCorrect={false}
                 keyboardType="url"
@@ -272,28 +274,27 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
             </View>
           )}
           <Admonition variant="info" style={[zero.my[4]] as any}>
-            <Text style={[zero.mb[2]]}>
-              Each host has their own policies and reliability standards. Your
-              ATProto data lives on the host you choose and you can migrate
-              later.
-            </Text>
+            <Text style={[zero.mb[2]]}>{t("pds-selector-info")}</Text>
             {!useCustom && (
               <Text style={[zero.mb[2]]}>
-                Read {selectedHostObj?.label}'s{" "}
-                <Text
-                  onPress={handleTOS}
-                  style={[{ color: theme.colors.ring }]}
-                >
-                  Terms of Service
-                </Text>{" "}
-                and{" "}
-                <Text
-                  onPress={handlePrivacy}
-                  style={[{ color: theme.colors.ring }]}
-                >
-                  Privacy Policy
-                </Text>{" "}
-                before continuing.
+                <T
+                  i18nKey="pds-selector-read-policies"
+                  values={{ label: selectedHostObj?.label }}
+                  components={{
+                    tosLink: (
+                      <Text
+                        onPress={handleTOS}
+                        style={[{ color: theme.colors.ring }]}
+                      />
+                    ),
+                    privacyLink: (
+                      <Text
+                        onPress={handlePrivacy}
+                        style={[{ color: theme.colors.ring }]}
+                      />
+                    ),
+                  }}
+                />
               </Text>
             )}
           </Admonition>
@@ -313,15 +314,21 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
                 onCheckedChange={hasCheckedHandlePolicy}
               />
               <Text style={[zero.flex[1]]}>
-                I have read and agree to the{" "}
-                <Text
-                  onPress={() =>
-                    Linking.openURL(selectedHostObj.handlePolicyDocs!)
-                  }
-                  style={[{ color: theme.colors.ring }]}
-                >
-                  {selectedHostObj.label} guidelines and handle policy
-                </Text>
+                <T
+                  i18nKey="pds-selector-handle-policy-checkbox"
+                  components={{
+                    policyLink: (
+                      <Text
+                        onPress={() =>
+                          Linking.openURL(selectedHostObj.handlePolicyDocs!)
+                        }
+                        style={[{ color: theme.colors.ring }]}
+                      >
+                        {selectedHostObj.label} guidelines and handle policy
+                      </Text>
+                    ),
+                  }}
+                />
               </Text>
             </View>
           )}
@@ -335,7 +342,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
           ]}
         >
           <Button width="min" variant="secondary" onPress={handleCancel}>
-            <Text>Cancel</Text>
+            <Text>{t("cancel")}</Text>
           </Button>
           <Button
             width="min"
@@ -346,7 +353,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
               (!handlePolicyChecked && !!selectedHostObj.handlePolicyDocs)
             }
           >
-            <Text>Continue</Text>
+            <Text>{t("continue")}</Text>
           </Button>
         </View>
       </View>

--- a/js/app/components/login/pds-host-selector-modal.tsx
+++ b/js/app/components/login/pds-host-selector-modal.tsx
@@ -55,6 +55,25 @@ const PDS_HOSTS = [
   },
 ];
 
+// Shuffle the hosts
+// items with handle policies should never be first !
+const shuffleArray = <T,>(array: T[]): T[] => {
+  const arr = [...array];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+};
+
+const SHUFFLED_PDS_HOSTS = (() => {
+  const withPolicies = PDS_HOSTS.filter((h) => h.handlePolicyDocs);
+  const [first, ...withoutPolicies] = PDS_HOSTS.filter(
+    (h) => !h.handlePolicyDocs,
+  );
+  return [first, ...shuffleArray(withPolicies.concat(withoutPolicies))];
+})();
+
 interface PdsHostSelectorModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -67,7 +86,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
   onSubmit,
 }) => {
   const [selectedHost, setSelectedHost] = useState<string | null>(
-    PDS_HOSTS[0].value,
+    SHUFFLED_PDS_HOSTS[0].value,
   );
   const [customHost, setCustomHost] = useState<string>("");
   const [useCustom, setUseCustom] = useState(false);
@@ -76,10 +95,11 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
   const { theme } = useTheme();
 
   const selectedHostObj =
-    PDS_HOSTS.find((host) => host.value === selectedHost) || PDS_HOSTS[0];
+    SHUFFLED_PDS_HOSTS.find((host) => host.value === selectedHost) ||
+    SHUFFLED_PDS_HOSTS[0];
 
   const handleCancel = () => {
-    setSelectedHost(PDS_HOSTS[0].value);
+    setSelectedHost(SHUFFLED_PDS_HOSTS[0].value);
     setCustomHost("");
     setUseCustom(false);
     onOpenChange(false);
@@ -133,7 +153,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
           </Text>
         </View>
         <View style={[zero.pb[2]]}>
-          {PDS_HOSTS.map((host, index) => (
+          {SHUFFLED_PDS_HOSTS.map((host, index) => (
             <Pressable
               key={host.value}
               onPress={() => handleSelectHost(host.value)}

--- a/js/app/components/login/pds-host-selector-modal.tsx
+++ b/js/app/components/login/pds-host-selector-modal.tsx
@@ -1,0 +1,336 @@
+import {
+  Admonition,
+  Button,
+  Checkbox,
+  Input,
+  ResponsiveDialog,
+  Text,
+  useTheme,
+  zero,
+} from "@streamplace/components";
+import { Check, ExternalLink } from "lucide-react-native";
+import React, { useState } from "react";
+import { Linking, Pressable, View } from "react-native";
+
+interface PdsHost {
+  value: string;
+  label: string;
+  description: string;
+  handlePolicyDocs?: string;
+  terms: string;
+  privacy: string;
+}
+
+const PDS_HOSTS = [
+  {
+    value: "https://selfhosted.social",
+    label: "selfhosted.social",
+    description: "A popular community-run PDS",
+    terms: "https://selfhosted.social/legal#terms",
+    privacy: "https://selfhosted.social/legal",
+  },
+  {
+    // will redirect to https://bsky.social for sign in :thumb:
+    value: "https://witchesbutter.us-west.host.bsky.network",
+    label: "Bluesky",
+    description: "The main Bluesky PDS instance",
+    terms: "https://bsky.social/about/support/tos",
+    privacy: "https://bsky.social/about/support/privacy-policy",
+  },
+  {
+    value: "https://blacksky.app",
+    label: "Blacksky PDS",
+    description: "A PDS service by Blacksky Algorithms",
+    terms: "https://blackskyweb.xyz/about/support/tos",
+    privacy: "https://blackskyweb.xyz/about/support/privacy-policy/",
+    handlePolicyDocs:
+      "https://docs.blacksky.community/migrating-to-blacksky-pds-complete-guide#who-can-use-blacksky-services",
+  },
+  {
+    value: "https://pds.tophhie.cloud",
+    label: "Tophhie Cloud",
+    description: "A PDS service by Tophhie",
+    terms: "https://blog.tophhie.cloud/atproto-tos/",
+    privacy: "https://blog.tophhie.cloud/atproto-privacy-policy/",
+  },
+];
+
+interface PdsHostSelectorModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (pdsHost: string) => void;
+}
+
+export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
+  open,
+  onOpenChange,
+  onSubmit,
+}) => {
+  const [selectedHost, setSelectedHost] = useState<string | null>(
+    PDS_HOSTS[0].value,
+  );
+  const [customHost, setCustomHost] = useState<string>("");
+  const [useCustom, setUseCustom] = useState(false);
+  const [handlePolicyChecked, hasCheckedHandlePolicy] = useState(false);
+
+  const { theme } = useTheme();
+
+  const selectedHostObj =
+    PDS_HOSTS.find((host) => host.value === selectedHost) || PDS_HOSTS[0];
+
+  const handleCancel = () => {
+    setSelectedHost(PDS_HOSTS[0].value);
+    setCustomHost("");
+    setUseCustom(false);
+    onOpenChange(false);
+  };
+
+  const handleSubmit = () => {
+    const hostToUse = useCustom ? customHost : selectedHost;
+    if (!hostToUse) return;
+
+    onSubmit(hostToUse);
+    handleCancel();
+  };
+
+  const handleLearnMore = () => {
+    Linking.openURL("https://atproto.com/guides/self-hosting");
+  };
+  const handleTOS = () => {
+    Linking.openURL(selectedHostObj.terms);
+  };
+  const handlePrivacy = () => {
+    Linking.openURL(selectedHostObj.privacy);
+  };
+
+  const handleSelectHost = (value: string) => {
+    setSelectedHost(value);
+    setUseCustom(false);
+  };
+
+  const handleSelectCustom = () => {
+    setUseCustom(true);
+  };
+
+  return (
+    <ResponsiveDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      showCloseButton={false}
+      variant="default"
+      size="sm"
+      dismissible={true}
+      position="center"
+    >
+      <View style={[{ maxWidth: 500 }]}>
+        <View style={[zero.my[4]]}>
+          <Text size="2xl" style={[zero.mb[2]]}>
+            Choose your PDS host
+          </Text>
+          <Text style={[{ color: theme.colors.textMuted }]}>
+            Select a Personal Data Server (PDS) to access apps on the
+            Atmosphere.
+          </Text>
+        </View>
+        <View style={[zero.pb[2]]}>
+          {PDS_HOSTS.map((host, index) => (
+            <Pressable
+              key={host.value}
+              onPress={() => handleSelectHost(host.value)}
+              style={[
+                zero.py[2],
+                zero.px[3],
+                zero.r.lg,
+                {
+                  borderWidth: 1,
+                  borderColor:
+                    !useCustom && selectedHost === host.value
+                      ? theme.colors.primary
+                      : theme.colors.border,
+                  backgroundColor:
+                    !useCustom && selectedHost === host.value
+                      ? "rgba(0, 122, 255, 0.05)"
+                      : "transparent",
+                },
+                index > 0 && zero.mt[2],
+              ]}
+            >
+              <View
+                style={[
+                  zero.layout.flex.row,
+                  zero.layout.flex.spaceBetween,
+                  zero.layout.flex.alignCenter,
+                ]}
+              >
+                <View style={[zero.flex[1]]}>
+                  <Text>{host.label}</Text>
+                  <Text
+                    style={[
+                      zero.mt[1],
+                      { fontSize: 14, color: theme.colors.textMuted },
+                    ]}
+                  >
+                    {host.description}
+                  </Text>
+                </View>
+                {!useCustom && selectedHost === host.value && (
+                  <Check size={20} color={theme.colors.primary} />
+                )}
+              </View>
+            </Pressable>
+          ))}
+
+          <Pressable
+            onPress={handleSelectCustom}
+            style={[
+              zero.py[2],
+              zero.px[3],
+              zero.r.lg,
+              zero.mt[2],
+              {
+                borderWidth: 1,
+                borderColor: useCustom
+                  ? theme.colors.primary
+                  : theme.colors.border,
+                backgroundColor: useCustom
+                  ? "rgba(0, 122, 255, 0.05)"
+                  : "transparent",
+              },
+            ]}
+          >
+            <View
+              style={[
+                zero.layout.flex.row,
+                zero.layout.flex.spaceBetween,
+                zero.layout.flex.alignCenter,
+              ]}
+            >
+              <View style={[zero.flex[1]]}>
+                <Text>Custom PDS</Text>
+                <Text
+                  style={[
+                    zero.mt[1],
+                    { fontSize: 14, color: theme.colors.textMuted },
+                  ]}
+                >
+                  Enter your own PDS host URL
+                </Text>
+              </View>
+              {useCustom && <Check size={20} color={theme.colors.primary} />}
+            </View>
+          </Pressable>
+
+          <View style={[zero.mt[4]]}>
+            <Pressable
+              onPress={handleLearnMore}
+              style={[
+                zero.layout.flex.row,
+                zero.gap.all[1],
+                zero.layout.flex.alignCenter,
+              ]}
+            >
+              <Text style={[{ color: theme.colors.ring, fontSize: 14 }]}>
+                Learn more about self-hosting
+              </Text>
+              <ExternalLink size={16} color={theme.colors.ring} />
+            </Pressable>
+          </View>
+
+          {useCustom && (
+            <View style={[zero.mt[3]]}>
+              <Text style={[zero.mb[2], { color: theme.colors.textMuted }]}>
+                Custom PDS URL
+              </Text>
+              <Input
+                value={customHost}
+                onChangeText={setCustomHost}
+                placeholder="https://pds.example.com"
+                autoCapitalize="none"
+                autoCorrect={false}
+                keyboardType="url"
+              />
+            </View>
+          )}
+          <Admonition variant="info" style={[zero.my[4]] as any}>
+            <Text style={[zero.mb[2]]}>
+              Each host has their own policies and reliability standards. Your
+              ATProto data lives on the host you choose and you can migrate
+              later.
+            </Text>
+            {!useCustom && (
+              <Text>
+                Read {selectedHostObj?.label}'s{" "}
+                <Text
+                  onPress={handleTOS}
+                  style={[{ color: theme.colors.ring }]}
+                >
+                  Terms of Service
+                </Text>{" "}
+                and{" "}
+                <Text
+                  onPress={handlePrivacy}
+                  style={[{ color: theme.colors.ring }]}
+                >
+                  Privacy Policy
+                </Text>{" "}
+                before continuing.
+              </Text>
+            )}
+          </Admonition>
+          {!useCustom && selectedHostObj.handlePolicyDocs && (
+            <View
+              style={[
+                zero.layout.flex.row,
+                zero.layout.flex.align.center,
+                zero.layout.flex.justify.start,
+                zero.gap.all[2],
+                zero.my[4],
+              ]}
+            >
+              <Checkbox
+                checked={handlePolicyChecked}
+                onCheckedChange={hasCheckedHandlePolicy}
+              />
+              <Text style={[zero.flex[1]]}>
+                I have read and agree to the{" "}
+                <Text
+                  onPress={() =>
+                    Linking.openURL(selectedHostObj.handlePolicyDocs!)
+                  }
+                  style={[{ color: theme.colors.ring }]}
+                >
+                  {selectedHostObj.label} handle policy
+                </Text>
+              </Text>
+            </View>
+          )}
+        </View>
+        <View
+          style={[
+            zero.flex[1],
+            zero.layout.flex.row,
+            zero.layout.flex.justify.end,
+            zero.gap.all[2],
+          ]}
+        >
+          <Button width="min" variant="secondary" onPress={handleCancel}>
+            <Text>Cancel</Text>
+          </Button>
+          <Button
+            width="min"
+            variant="primary"
+            onPress={handleSubmit}
+            disabled={
+              (useCustom && !customHost.trim()) ||
+              (!handlePolicyChecked && !!selectedHostObj.handlePolicyDocs)
+            }
+          >
+            <Text>Continue</Text>
+          </Button>
+        </View>
+      </View>
+    </ResponsiveDialog>
+  );
+};
+
+export default PdsHostSelectorModal;

--- a/js/app/components/login/pds-host-selector-modal.tsx
+++ b/js/app/components/login/pds-host-selector-modal.tsx
@@ -139,7 +139,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
       showCloseButton={false}
       variant="default"
       size="sm"
-      dismissible={true}
+      dismissible={false}
       position="center"
     >
       <View style={[{ maxWidth: 500 }]}>
@@ -226,7 +226,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
               ]}
             >
               <View style={[zero.flex[1]]}>
-                <Text>Custom PDS</Text>
+                <Text>Another PDS</Text>
                 <Text
                   style={[
                     zero.mt[1],
@@ -259,7 +259,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
           {useCustom && (
             <View style={[zero.mt[3]]}>
               <Text style={[zero.mb[2], { color: theme.colors.textMuted }]}>
-                Custom PDS URL
+                PDS URL
               </Text>
               <Input
                 value={customHost}
@@ -278,7 +278,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
               later.
             </Text>
             {!useCustom && (
-              <Text>
+              <Text style={[zero.mb[2]]}>
                 Read {selectedHostObj?.label}'s{" "}
                 <Text
                   onPress={handleTOS}
@@ -304,7 +304,8 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
                 zero.layout.flex.align.center,
                 zero.layout.flex.justify.start,
                 zero.gap.all[2],
-                zero.my[4],
+                zero.mb[4],
+                zero.mt[2],
               ]}
             >
               <Checkbox
@@ -319,7 +320,7 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
                   }
                   style={[{ color: theme.colors.ring }]}
                 >
-                  {selectedHostObj.label} handle policy
+                  {selectedHostObj.label} guidelines and handle policy
                 </Text>
               </Text>
             </View>

--- a/js/app/components/login/pds-host-selector-modal.tsx
+++ b/js/app/components/login/pds-host-selector-modal.tsx
@@ -145,11 +145,11 @@ export const PdsHostSelectorModal: React.FC<PdsHostSelectorModalProps> = ({
       <View style={[{ maxWidth: 500 }]}>
         <View style={[zero.my[4]]}>
           <Text size="2xl" style={[zero.mb[2]]}>
-            Choose your PDS host
+            New to the Atmosphere?
           </Text>
           <Text style={[{ color: theme.colors.textMuted }]}>
-            Select a Personal Data Server (PDS) to access apps on the
-            Atmosphere.
+            You'll need to select a PDS (Personal Data Server) to access apps on
+            the Atmosphere, such as Bluesky, Tangled, and Spark.
           </Text>
         </View>
         <View style={[zero.pb[2]]}>

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -81,6 +81,7 @@ import KeyManager from "components/settings/key-manager";
 import HomeScreen from "./screens/home";
 
 import { useUrl } from "@streamplace/components";
+import PdsHostSelectorModal from "components/login/pds-host-selector-modal";
 import { BrandingAdmin } from "components/settings/branding-admin";
 import { LanguagesCategorySettings } from "components/settings/languages-category-settings";
 import MultistreamManager from "components/settings/multistream-manager";
@@ -477,7 +478,12 @@ export function StreamplaceDrawer() {
   const pollMySegments = useStore((state) => state.pollMySegments);
   const showLoginModal = useStore((state) => state.showLoginModal);
   const closeLoginModal = useStore((state) => state.closeLoginModal);
+  const showPdsModal = useStore((state) => state.showPdsModal);
+  const openPdsModal = useStore((state) => state.openPdsModal);
+  const closePdsModal = useStore((state) => state.closePdsModal);
   const [livePopup, setLivePopup] = useState(false);
+  const loginAction = useStore((state) => state.login);
+  const openLoginLink = useStore((state) => state.openLoginLink);
   const siteTitle = useSiteTitle();
   const defaultStreamer = useDefaultStreamer();
 
@@ -784,7 +790,18 @@ export function StreamplaceDrawer() {
           }}
         />
       </Drawer.Navigator>
-      <LoginModal visible={showLoginModal} onClose={closeLoginModal} />
+      <LoginModal
+        visible={showLoginModal}
+        onClose={closeLoginModal}
+        onOpenPdsModal={openPdsModal}
+      />
+      <PdsHostSelectorModal
+        open={showPdsModal}
+        onOpenChange={closePdsModal}
+        onSubmit={(pdsHost) => {
+          loginAction(pdsHost, openLoginLink);
+        }}
+      />
     </>
   );
 }

--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -298,6 +298,7 @@ const NavigationButton = ({ canGoBack }: { canGoBack?: boolean }) => {
 const AvatarButton = () => {
   const userProfile = useUserProfile();
   const openLoginModal = useStore((state) => state.openLoginModal);
+  const openPDSModal = useStore((state) => state.openPdsModal);
   const loginAction = useStore((state) => state.login);
   const openLoginLink = useStore((state) => state.openLoginLink);
   const { theme } = useTheme();
@@ -333,11 +334,6 @@ const AvatarButton = () => {
     );
   }
 
-  const handleSignup = () => {
-    // TODO: remove requirement for oauth-protected-resource in oatproxy
-    loginAction("https://bsky.social", openLoginLink);
-  };
-
   if (isCompact) {
     return (
       <Button
@@ -370,7 +366,7 @@ const AvatarButton = () => {
         <Text style={{ color: theme.colors.text }}>Log In</Text>
       </Button>
       <Button
-        onPress={handleSignup}
+        onPress={() => openPDSModal()}
         variant="primary"
         width="min"
         style={[zero.r.full]}
@@ -799,6 +795,7 @@ export function StreamplaceDrawer() {
         open={showPdsModal}
         onOpenChange={closePdsModal}
         onSubmit={(pdsHost) => {
+          closePdsModal();
           loginAction(pdsHost, openLoginLink);
         }}
       />

--- a/js/app/store/slices/blueskySlice.ts
+++ b/js/app/store/slices/blueskySlice.ts
@@ -86,6 +86,9 @@ export interface BlueskySlice {
   showLoginModal: boolean;
   openLoginModal: (returnRoute?: { name: string; params?: any }) => void;
   closeLoginModal: () => void;
+  showPdsModal: boolean;
+  openPdsModal: () => void;
+  closePdsModal: () => void;
   golivePost: (
     text: string,
     now: Date,
@@ -210,6 +213,7 @@ export const createBlueskySlice: StateCreator<
   serverSettings: null,
   returnRoute: null,
   showLoginModal: false,
+  showPdsModal: false,
   notification: null,
 
   clearNotification: () => {
@@ -237,6 +241,14 @@ export const createBlueskySlice: StateCreator<
   closeLoginModal: () => {
     console.log("closeLoginModal");
     set({ showLoginModal: false });
+  },
+
+  openPdsModal: () => {
+    set({ showPdsModal: true });
+  },
+
+  closePdsModal: () => {
+    set({ showPdsModal: false });
   },
 
   loadOAuthClient: async () => {

--- a/js/components/locales/en-US/common.ftl
+++ b/js/components/locales/en-US/common.ftl
@@ -51,7 +51,7 @@ user-offline-message = { $source ->
     [streamer] Looks like <1>@{ $handle } is offline</1>, but they recommend checking out:
    *[default] Looks like <1>@{ $handle } is offline</1>, but we recommend checking out:
 }
-user-offline-no-recommendations = 
+user-offline-no-recommendations =
   Looks like <1>@{ $handle } is offline</1> right now.
   Check back later.
 streaming-title = streaming { $title }
@@ -60,3 +60,15 @@ viewer-count = { $count ->
     [1] 1 viewer
    *[other] { $count } viewers
 }
+
+## PDS Host Selector
+pds-selector-title = New to the Atmosphere?
+pds-selector-description = You'll need to select a PDS (Personal Data Server) to access apps on the Atmosphere, such as Bluesky, Tangled, and Spark.
+pds-selector-custom-label = Another PDS
+pds-selector-custom-description = Enter your own PDS host URL
+pds-selector-custom-url-label = Custom PDS URL
+pds-selector-custom-url-placeholder = https://pds.example.com
+pds-selector-learn-more = Learn more about self-hosting
+pds-selector-info = Each host has their own policies and reliability standards. Your ATProto data lives on the host you choose and you can migrate later. Note: Streamplace has its own moderation rules - you can be banned from Streamplace regardless of which host you choose.
+pds-selector-read-policies = Read { $label }'s <tosLink>Terms of Service</tosLink> and <privacyLink>Privacy Policy</privacyLink> before continuing.
+pds-selector-handle-policy-checkbox = I have read and agree to the <policyLink>handle policy</policyLink>


### PR DESCRIPTION
Adds a modal that lets users choose which PDS to sign up to, instead of defaulting to Bluesky.

At the moment, there are options for selfhosted.social, Bluesky, Blacksky, Tophhie, and a custom URL. The order is randomized, and the first is picked by default. 

PDSes with custom handle policies (e.g. Blacksky, Northsky) will not show up first (but they can show up second and after), and thus will never be picked by default. They have an extra checkbox to check as well, as the sign up process may not disclose these things. This is meant to have users actively read their handle policy rather than just clicking next and ignoring their policies.

<img width="548" height="802" alt="image" src="https://github.com/user-attachments/assets/c1684275-06bb-4e2a-8353-a01e536f5579" />


