### PR TITLE
oatproxy: add aqhttp *http.Client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/slok/go-http-metrics v0.13.0
 	github.com/starttoaster/prometheus-exporter-scraper v0.0.1
 	github.com/streamplace/atproto-oauth-golang v0.0.0-20250619231223-a9c04fb888ac
-	github.com/streamplace/oatproxy v0.0.0-20260112011721-d74b4913c93f
+	github.com/streamplace/oatproxy v0.0.0-20260130124113-420429019d3b
 	github.com/stretchr/testify v1.11.1
 	github.com/tdewolff/canvas v0.0.0-20250728095813-50d4cb1eee71
 	github.com/whyrusleeping/cbor-gen v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -1319,6 +1319,8 @@ github.com/streamplace/go-dpop v0.0.0-20250510031900-c897158a8ad4 h1:L1fS4HJSaAy
 github.com/streamplace/go-dpop v0.0.0-20250510031900-c897158a8ad4/go.mod h1:bGUXY9Wd4mnd+XUrOYZr358J2f6z9QO/dLhL1SsiD+0=
 github.com/streamplace/oatproxy v0.0.0-20260112011721-d74b4913c93f h1:hhbQ8CtcAZVlLit/r7b9QDK7qEgOth4hgE13xV6ViBI=
 github.com/streamplace/oatproxy v0.0.0-20260112011721-d74b4913c93f/go.mod h1:pXi24hA7xBHj8eEywX6wGqJOR9FaEYlGwQ/72rN6okw=
+github.com/streamplace/oatproxy v0.0.0-20260130124113-420429019d3b h1:BB/R1egvkEqZhGeKL3tqAlTn0mkoOaaMY6r6s18XJYA=
+github.com/streamplace/oatproxy v0.0.0-20260130124113-420429019d3b/go.mod h1:pXi24hA7xBHj8eEywX6wGqJOR9FaEYlGwQ/72rN6okw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/pkg/cmd/streamplace.go
+++ b/pkg/cmd/streamplace.go
@@ -385,6 +385,7 @@ func start(build *config.BuildFlags, platformJobs []jobFunc) error {
 		DownstreamJWK:      cli.AccessJWK,
 		ClientMetadata:     clientMetadata,
 		Public:             cli.PublicOAuth,
+		HTTPClient:         &aqhttp.Client,
 	})
 	d := director.NewDirector(mm, mod, &cli, b, op, state, replicator, ldb)
 	a, err := api.MakeStreamplaceAPI(&cli, mod, state, noter, mm, ms, b, atsync, d, op, ldb)

--- a/pkg/spxrpc/com_atproto_identity.go
+++ b/pkg/spxrpc/com_atproto_identity.go
@@ -5,10 +5,11 @@ import (
 
 	comatprototypes "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/streamplace/oatproxy/pkg/oatproxy"
+	"stream.place/streamplace/pkg/aqhttp"
 )
 
 func (s *Server) handleComAtprotoIdentityResolveHandle(ctx context.Context, handle string) (*comatprototypes.IdentityResolveHandle_Output, error) {
-	did, err := oatproxy.ResolveHandle(ctx, handle)
+	did, err := oatproxy.ResolveHandleWithClient(ctx, handle, &aqhttp.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/spxrpc/com_atproto_repo.go
+++ b/pkg/spxrpc/com_atproto_repo.go
@@ -15,6 +15,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/streamplace/oatproxy/pkg/oatproxy"
 	"go.opentelemetry.io/otel"
+	"stream.place/streamplace/pkg/aqhttp"
 	"stream.place/streamplace/pkg/atproto"
 	"stream.place/streamplace/pkg/log"
 )
@@ -23,13 +24,13 @@ func resolveRepoService(ctx context.Context, repo string) (string, string, strin
 	did := repo
 	var err error
 	if !strings.HasPrefix(repo, "did:") {
-		did, err = oatproxy.ResolveHandle(ctx, repo)
+		did, err = oatproxy.ResolveHandleWithClient(ctx, repo, &aqhttp.Client)
 		if err != nil {
 			return "", "", "", fmt.Errorf("failed to resolve handle %q: %w", repo, err)
 		}
 	}
 
-	service, handle, err := oatproxy.ResolveService(ctx, did)
+	service, handle, err := oatproxy.ResolveServiceWithClient(ctx, did, &aqhttp.Client)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to resolve service for did %q: %w", did, err)
 	}


### PR DESCRIPTION
Fixes https://bsky.app/profile/iame.li/post/3mdncdwj5b22w by putting our actual user-agent string in there (which we shoulda been doing anyway)

Also has the added advantage of hardening handle/service resolution against local addresses and whatnot. Will that make it fail CI? Let's find out!