### PR TITLE
fix: mute param works now

### DIFF
--- a/js/app/components/live-dashboard/stream-monitor.tsx
+++ b/js/app/components/live-dashboard/stream-monitor.tsx
@@ -104,7 +104,11 @@ export default function StreamMonitor({
       <View style={[flex.values[1], layout.flex.center, bg.neutral[900]]}>
         {isLive && userProfile ? (
           isStreamVisible ? (
-            <Player src={userProfile.did} name={userProfile.handle}>
+            <Player
+              src={userProfile.did}
+              name={userProfile.handle}
+              muted={true}
+            >
               <DesktopUi />
               <PlayerUI.ViewerLoadingOverlay />
               <OfflineCounter isMobile={true} />

--- a/js/components/src/components/mobile-player/player.tsx
+++ b/js/components/src/components/mobile-player/player.tsx
@@ -5,7 +5,11 @@ import {
   PlayerStatusTracker,
   usePlayerStore,
 } from "../../player-store";
-import { useStreamplaceStore } from "../../streamplace-store";
+import {
+  useMuted,
+  useSetMuted,
+  useStreamplaceStore,
+} from "../../streamplace-store";
 import { Text, View } from "../ui";
 import { Fullscreen } from "./fullscreen";
 import { PlayerProps } from "./props";
@@ -28,6 +32,20 @@ export function Player(
   const reportModalOpen = usePlayerStore((x) => x.reportModalOpen);
   const setReportModalOpen = usePlayerStore((x) => x.setReportModalOpen);
   const reportSubject = usePlayerStore((x) => x.reportSubject);
+
+  const setMuted = useSetMuted();
+  const muted = useMuted();
+
+  // if we set muted, set it and restore after
+  useEffect(() => {
+    let wasMuted = muted;
+    if (props.muted) {
+      setMuted(props.muted);
+    }
+    return () => {
+      setMuted(wasMuted);
+    };
+  });
 
   useEffect(() => {
     setReportingURL(props.reportingURL ?? null);

--- a/js/components/src/components/mobile-player/player.tsx
+++ b/js/components/src/components/mobile-player/player.tsx
@@ -45,7 +45,7 @@ export function Player(
     return () => {
       setMuted(wasMuted);
     };
-  });
+  }, [props.muted]);
 
   useEffect(() => {
     setReportingURL(props.reportingURL ?? null);

--- a/js/components/src/components/mobile-player/player.tsx
+++ b/js/components/src/components/mobile-player/player.tsx
@@ -38,12 +38,15 @@ export function Player(
 
   // if we set muted, set it and restore after
   useEffect(() => {
-    let wasMuted = muted;
-    if (props.muted) {
-      setMuted(props.muted);
-    }
+    let wasMuted: null | boolean = null;
+    setTimeout(() => {
+      if (props.muted != undefined) {
+        wasMuted = muted;
+        setMuted(props.muted);
+      }
+    }, 200);
     return () => {
-      setMuted(wasMuted);
+      wasMuted !== null && setMuted(wasMuted);
     };
   }, [props.muted]);
 


### PR DESCRIPTION
If you add mute param (e.g. on stream monitor). it respects it, but restores the last property on unmount