### PR TITLE
fix: offset 'scroll to bottom' when closed to not interfere with chat

### DIFF
--- a/js/components/src/components/chat/chat.tsx
+++ b/js/components/src/components/chat/chat.tsx
@@ -261,7 +261,7 @@ export function Chat({
 
   useEffect(() => {
     buttonOpacity.value = withTiming(isScrolledUp ? 1 : 0, { duration: 200 });
-    buttonTranslateY.value = withTiming(isScrolledUp ? 0 : 20, {
+    buttonTranslateY.value = withTiming(isScrolledUp ? 0 : 50, {
       duration: 200,
     });
   }, [isScrolledUp]);
@@ -345,7 +345,7 @@ export function Chat({
           onPress={scrollToBottom}
           style={[
             {
-              pointerEvents: "auto",
+              pointerEvents: isScrolledUp ? "auto" : "none",
               backgroundColor: theme.colors.primary,
               opacity: 0.9,
               borderRadius: 20,


### PR DESCRIPTION
Offset it to the bottom a little. Previously, it blocked the last line of chat such that no links were clickable, etc.
<img width="572" height="117" alt="image" src="https://github.com/user-attachments/assets/5945ab9a-e0b9-44df-b046-89847f3b7d4a" />
