### PR TITLE
Docker: use azure ubuntu archives everywhere

### DIFF
--- a/docker/bunny.Dockerfile
+++ b/docker/bunny.Dockerfile
@@ -3,6 +3,10 @@ FROM ubuntu:24.04
 # testing container that bundles a big video file. it downloads the video first
 # for efficient docker layer caching
 
+ADD docker/sources.list /etc/apt/sources.list
+ADD docker/winehq.key /etc/apt/keyrings/winehq-archive.key
+ADD docker/llvm-snapshot.key /etc/apt/keyrings/llvm-snapshot.key
+
 RUN apt-get update && apt-get install -y ca-certificates curl
 RUN curl https://storage.googleapis.com/streamplace-crap/BigBuckBunny_1sGOP_4kp60_NoBframes.mp4 -o /bunny.mp4
 COPY bunny.sh /bunny.sh

--- a/docker/mistserver.Dockerfile
+++ b/docker/mistserver.Dockerfile
@@ -1,5 +1,10 @@
 ARG TARGETARCH
 FROM --platform=linux/$TARGETARCH ubuntu:24.04
+
+ADD docker/sources.list /etc/apt/sources.list
+ADD docker/winehq.key /etc/apt/keyrings/winehq-archive.key
+ADD docker/llvm-snapshot.key /etc/apt/keyrings/llvm-snapshot.key
+
 RUN apt update && apt install -y curl
 ARG STREAMPLACE_URL
 ENV STREAMPLACE_URL $STREAMPLACE_URL


### PR DESCRIPTION
More reliable than archive.ubuntu.org which is presently down, I guess