### PR TITLE
fix: show slash command errors in chat

### DIFF
--- a/js/components/src/components/chat/chat-box.tsx
+++ b/js/components/src/components/chat/chat-box.tsx
@@ -24,6 +24,7 @@ import {
   w,
 } from "../../lib/theme/atoms";
 import {
+  useAddSystemMessage,
   useChat,
   useCreateChatMessage,
   useLivestream,
@@ -76,6 +77,7 @@ export function ChatBox({
 
   const chat = useChat();
   const createChatMessage = useCreateChatMessage();
+  const addSystemMessage = useAddSystemMessage();
   const replyTo = useReplyToMessage();
   const setReplyToMessage = useSetReplyToMessage();
   const textAreaRef = useRef<TextInput>(null);
@@ -280,7 +282,7 @@ export function ChatBox({
       if (result.handled) {
         if (result.error) {
           console.error("Slash command error:", result.error);
-          SystemMessages.commandError(result.error);
+          addSystemMessage(SystemMessages.commandError(result.error));
         }
         return;
       }

--- a/js/components/src/components/chat/system-message.tsx
+++ b/js/components/src/components/chat/system-message.tsx
@@ -1,7 +1,7 @@
 import { View } from "react-native";
 import { Main } from "streamplace/src/lexicons/types/place/stream/richtext/facet";
 import { SystemMessageType } from "../../lib/system-messages";
-import { colors, flex, gap, layout, ml, pb, pl, px, w } from "../../ui";
+import { bg, colors, flex, gap, layout, ml, pb, pl, px, r, w } from "../../ui";
 import { Code, Text } from "../ui/text";
 import { RichTextMessage } from "./chat-message";
 
@@ -18,8 +18,18 @@ export function SystemMessage({
   timestamp,
   facets,
 }: SystemMessageProps) {
+  const isError = variant === SystemMessageType.command_error;
+
   return (
-    <View style={[w.percent[100], px[2], pb[2]]}>
+    <View
+      style={[
+        w.percent[100],
+        px[2],
+        pb[2],
+        isError && bg.red[950],
+        isError && r.md,
+      ]}
+    >
       <Code color="muted" tracking="widest" style={[pl[12], ml[1]]}>
         SYSTEM MESSAGE
       </Code>

--- a/js/components/src/livestream-store/chat.tsx
+++ b/js/components/src/livestream-store/chat.tsx
@@ -155,6 +155,18 @@ export const useDeleteChatMessage = () => {
   };
 };
 
+export const useAddSystemMessage = () => {
+  const store = getStoreFromContext();
+  return useCallback(
+    (message: ChatMessageViewHydrated) => {
+      const state = store.getState();
+      const newState = reduceChat(state, [message], []);
+      store.setState(newState);
+    },
+    [store],
+  );
+};
+
 const buildSortedChatList = (
   chatIndex: { [key: string]: ChatMessageViewHydrated },
   existingChatList: ChatMessageViewHydrated[],


### PR DESCRIPTION
When sending `/teleport`, as an example:
<img width="504" height="275" alt="image" src="https://github.com/user-attachments/assets/b20004a7-e7d2-4e20-8a55-2f3d122eeb45" />
