### PR TITLE
fix: Stop chat hover flickering on desktop

### DIFF
--- a/js/components/src/components/chat/chat.tsx
+++ b/js/components/src/components/chat/chat.tsx
@@ -141,64 +141,65 @@ const ActionsBar = memo(
   },
 );
 
-const ChatLine = memo(({
-  item,
-  isHovered,
-  onHoverIn,
-  onHoverOut,
-  hoverTimeoutRef,
-}: {
-  item: ChatMessageViewHydrated;
-  isHovered?: boolean;
-  onHoverIn?: () => void;
-  onHoverOut?: () => void;
-  hoverTimeoutRef?: React.MutableRefObject<NodeJS.Timeout | null>;
-}) => {
-  const setReply = useSetReplyToMessage();
-  const setModMsg = usePlayerStore((state) => state.setModMessage);
-  const swipeableRef = useRef<SwipeableMethods | null>(null);
+const ChatLine = memo(
+  ({
+    item,
+    isHovered,
+    onHoverIn,
+    onHoverOut,
+    hoverTimeoutRef,
+  }: {
+    item: ChatMessageViewHydrated;
+    isHovered?: boolean;
+    onHoverIn?: () => void;
+    onHoverOut?: () => void;
+    hoverTimeoutRef?: React.MutableRefObject<NodeJS.Timeout | null>;
+  }) => {
+    const setReply = useSetReplyToMessage();
+    const setModMsg = usePlayerStore((state) => state.setModMessage);
+    const swipeableRef = useRef<SwipeableMethods | null>(null);
 
-  if (item.author.did === "did:sys:system") {
-    return (
-      <SystemMessage
-        variant={getSystemMessageType(item) || SystemMessageType.notification}
-        timestamp={new Date(item.record.createdAt)}
-        title={item.record.text}
-        facets={item.record.facets}
-      />
-    );
-  }
-
-  if (Platform.OS === "web") {
-    return (
-      <View
-        style={[
-          py[1],
-          px[2],
-          {
-            position: "relative",
-            borderRadius: 8,
-            minWidth: 0,
-            maxWidth: "100%",
-          },
-          isHovered && bg.gray[950],
-        ]}
-        onPointerEnter={onHoverIn}
-        onPointerLeave={onHoverOut}
-      >
-        <Pressable style={[{ minWidth: 0, maxWidth: "100%" }]}>
-          <RenderChatMessage item={item} />
-        </Pressable>
-        <ActionsBar
-          item={item}
-          visible={!!isHovered}
-          hoverTimeoutRef={hoverTimeoutRef!}
+    if (item.author.did === "did:sys:system") {
+      return (
+        <SystemMessage
+          variant={getSystemMessageType(item) || SystemMessageType.notification}
+          timestamp={new Date(item.record.createdAt)}
+          title={item.record.text}
+          facets={item.record.facets}
         />
-      </View>
-    );
-  }
+      );
+    }
 
-  return (
+    if (Platform.OS === "web") {
+      return (
+        <View
+          style={[
+            py[1],
+            px[2],
+            {
+              position: "relative",
+              borderRadius: 8,
+              minWidth: 0,
+              maxWidth: "100%",
+            },
+            isHovered && bg.gray[950],
+          ]}
+          onPointerEnter={onHoverIn}
+          onPointerLeave={onHoverOut}
+        >
+          <Pressable style={[{ minWidth: 0, maxWidth: "100%" }]}>
+            <RenderChatMessage item={item} />
+          </Pressable>
+          <ActionsBar
+            item={item}
+            visible={!!isHovered}
+            hoverTimeoutRef={hoverTimeoutRef!}
+          />
+        </View>
+      );
+    }
+
+    return (
       <Swipeable
         containerStyle={[py[1]]}
         friction={2}
@@ -225,8 +226,9 @@ const ChatLine = memo(({
       >
         <RenderChatMessage item={item} />
       </Swipeable>
-  );
-});
+    );
+  },
+);
 
 export function Chat({
   shownMessages = SHOWN_MSGS,
@@ -240,7 +242,9 @@ export function Chat({
   const chat = useChat();
   const [isScrolledUp, setIsScrolledUp] = useState(false);
   const flatListRef = useRef<FlatList>(null);
-  const [hoveredMessageUri, setHoveredMessageUri] = useState<string | null>(null);
+  const [hoveredMessageUri, setHoveredMessageUri] = useState<string | null>(
+    null,
+  );
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleHoverIn = (uri: string) => {

--- a/js/components/src/components/chat/chat.tsx
+++ b/js/components/src/components/chat/chat.tsx
@@ -141,34 +141,22 @@ const ActionsBar = memo(
   },
 );
 
-const ChatLine = memo(({ item }: { item: ChatMessageViewHydrated }) => {
+const ChatLine = memo(({
+  item,
+  isHovered,
+  onHoverIn,
+  onHoverOut,
+  hoverTimeoutRef,
+}: {
+  item: ChatMessageViewHydrated;
+  isHovered?: boolean;
+  onHoverIn?: () => void;
+  onHoverOut?: () => void;
+  hoverTimeoutRef?: React.MutableRefObject<NodeJS.Timeout | null>;
+}) => {
   const setReply = useSetReplyToMessage();
   const setModMsg = usePlayerStore((state) => state.setModMessage);
   const swipeableRef = useRef<SwipeableMethods | null>(null);
-  const [isHovered, setIsHovered] = useState(false);
-  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const handleHoverIn = () => {
-    if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current);
-      hoverTimeoutRef.current = null;
-    }
-    setIsHovered(true);
-  };
-
-  const handleHoverOut = () => {
-    hoverTimeoutRef.current = setTimeout(() => {
-      setIsHovered(false);
-    }, 50);
-  };
-
-  useEffect(() => {
-    return () => {
-      if (hoverTimeoutRef.current) {
-        clearTimeout(hoverTimeoutRef.current);
-      }
-    };
-  }, []);
 
   if (item.author.did === "did:sys:system") {
     return (
@@ -195,23 +183,22 @@ const ChatLine = memo(({ item }: { item: ChatMessageViewHydrated }) => {
           },
           isHovered && bg.gray[950],
         ]}
-        onPointerEnter={handleHoverIn}
-        onPointerLeave={handleHoverOut}
+        onPointerEnter={onHoverIn}
+        onPointerLeave={onHoverOut}
       >
         <Pressable style={[{ minWidth: 0, maxWidth: "100%" }]}>
           <RenderChatMessage item={item} />
         </Pressable>
         <ActionsBar
           item={item}
-          visible={isHovered}
-          hoverTimeoutRef={hoverTimeoutRef}
+          visible={!!isHovered}
+          hoverTimeoutRef={hoverTimeoutRef!}
         />
       </View>
     );
   }
 
   return (
-    <>
       <Swipeable
         containerStyle={[py[1]]}
         friction={2}
@@ -238,7 +225,6 @@ const ChatLine = memo(({ item }: { item: ChatMessageViewHydrated }) => {
       >
         <RenderChatMessage item={item} />
       </Swipeable>
-    </>
   );
 });
 
@@ -254,6 +240,22 @@ export function Chat({
   const chat = useChat();
   const [isScrolledUp, setIsScrolledUp] = useState(false);
   const flatListRef = useRef<FlatList>(null);
+  const [hoveredMessageUri, setHoveredMessageUri] = useState<string | null>(null);
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleHoverIn = (uri: string) => {
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+      hoverTimeoutRef.current = null;
+    }
+    setHoveredMessageUri(uri);
+  };
+
+  const handleHoverOut = () => {
+    hoverTimeoutRef.current = setTimeout(() => {
+      setHoveredMessageUri(null);
+    }, 50);
+  };
 
   // Animation for scroll-to-bottom button
   const buttonOpacity = useSharedValue(0);
@@ -319,7 +321,15 @@ export function Chat({
         data={chat.slice(0, shownMessages)}
         inverted={true}
         keyExtractor={keyExtractor}
-        renderItem={({ item, index }) => <ChatLine item={item} />}
+        renderItem={({ item }) => (
+          <ChatLine
+            item={item}
+            isHovered={hoveredMessageUri === item.uri}
+            onHoverIn={() => handleHoverIn(item.uri)}
+            onHoverOut={handleHoverOut}
+            hoverTimeoutRef={hoverTimeoutRef}
+          />
+        )}
         removeClippedSubviews={true}
         maxToRenderPerBatch={10}
         initialNumToRender={10}


### PR DESCRIPTION
Fixes https://github.com/streamplace/streamplace/issues/722

Having the hover ref on the chat line component meant that you would briefly see two chat actions when mousing from one chat line to another. 

Moving the hover ref up one level means the chat can keep track of which chat message is hovered and only have one hovered at a time, stopping flickering when mousing over many.

Side note: I spent some time trying to have the actionsbar capture the pointer when it goes outside the area of the chat message (shown in red here for debugging) but couldn't manage to figure it out.

<img width="199" height="96" alt="image" src="https://github.com/user-attachments/assets/245aa04c-5ec4-4eb2-ad5a-c7c17692dbc9" />
