### PR TITLE
feat: add headphone play/pause button support

### DIFF
--- a/js/components/src/components/mobile-player/use-media-button.native.tsx
+++ b/js/components/src/components/mobile-player/use-media-button.native.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { DeviceEventEmitter } from "react-native";
+
+export function useMediaButton(onPress: () => void) {
+  useEffect(() => {
+    const subscription = DeviceEventEmitter.addListener(
+      "mediaButtonPress",
+      () => {
+        onPress();
+      },
+    );
+    return () => {
+      subscription.remove();
+    };
+  }, [onPress]);
+}

--- a/js/components/src/components/mobile-player/use-media-button.tsx
+++ b/js/components/src/components/mobile-player/use-media-button.tsx
@@ -1,0 +1,1 @@
+export function useMediaButton(_onPress: () => void) {}

--- a/js/components/src/components/mobile-player/video-async.native.tsx
+++ b/js/components/src/components/mobile-player/video-async.native.tsx
@@ -32,6 +32,7 @@ import {
   p,
 } from "../../lib/theme/atoms";
 import { srcToUrl } from "./shared";
+import { useMediaButton } from "./use-media-button";
 import useWebRTC, { useWebRTCIngest } from "./use-webrtc";
 import { mediaDevices, WebRTCMediaStream } from "./webrtc-primitives.native";
 
@@ -116,6 +117,16 @@ export function NativeVideo(props?: {
     player.play();
   });
 
+  useMediaButton(
+    useCallback(() => {
+      if (player.playing) {
+        player.pause();
+      } else {
+        player.play();
+      }
+    }, [player]),
+  );
+
   useEffect(() => {
     player.muted = muted;
   }, [muted, player]);
@@ -161,7 +172,6 @@ export function NativeVideo(props?: {
   }, [player, playerEvent, setStatus, spurl]);
 
   return (
-    <>
       <VideoView
         ref={videoRef}
         player={player}
@@ -176,7 +186,6 @@ export function NativeVideo(props?: {
         allowsPictureInPicture={props?.pictureInPictureEnabled !== false}
         onLayout={handleLayout}
       />
-    </>
   );
 }
 
@@ -228,6 +237,18 @@ export function NativeWHEP(props?: {
   }, [stuck, status]);
 
   const mediaStream = stream as unknown as MediaStream;
+  const [paused, setPaused] = useState(false);
+
+  useMediaButton(
+    useCallback(() => {
+      if (!mediaStream) return;
+      const next = !paused;
+      setPaused(next);
+      mediaStream.getTracks().forEach((track) => {
+        track.enabled = !next;
+      });
+    }, [mediaStream, paused]),
+  );
 
   // useEffect(() => {
   //   if (!mediaStream) {
@@ -260,7 +281,6 @@ export function NativeWHEP(props?: {
   }
 
   return (
-    <>
       <RTCView
         mirror={false}
         objectFit={props?.objectFit || "contain"}
@@ -278,7 +298,6 @@ export function NativeWHEP(props?: {
           flex: 1,
         }}
       />
-    </>
   );
 }
 

--- a/js/components/src/components/mobile-player/video-async.native.tsx
+++ b/js/components/src/components/mobile-player/video-async.native.tsx
@@ -172,20 +172,20 @@ export function NativeVideo(props?: {
   }, [player, playerEvent, setStatus, spurl]);
 
   return (
-      <VideoView
-        ref={videoRef}
-        player={player}
-        allowsFullscreen
-        nativeControls={fullscreen}
-        onFullscreenEnter={() => {
-          setFullscreen(true);
-        }}
-        onFullscreenExit={() => {
-          setFullscreen(false);
-        }}
-        allowsPictureInPicture={props?.pictureInPictureEnabled !== false}
-        onLayout={handleLayout}
-      />
+    <VideoView
+      ref={videoRef}
+      player={player}
+      allowsFullscreen
+      nativeControls={fullscreen}
+      onFullscreenEnter={() => {
+        setFullscreen(true);
+      }}
+      onFullscreenExit={() => {
+        setFullscreen(false);
+      }}
+      allowsPictureInPicture={props?.pictureInPictureEnabled !== false}
+      onLayout={handleLayout}
+    />
   );
 }
 
@@ -281,23 +281,23 @@ export function NativeWHEP(props?: {
   }
 
   return (
-      <RTCView
-        mirror={false}
-        objectFit={props?.objectFit || "contain"}
-        streamURL={mediaStream.toURL()}
-        onLayout={handleLayout}
-        pictureInPictureEnabled={props?.pictureInPictureEnabled !== false}
-        autoStartPictureInPicture={true}
-        pictureInPicturePreferredSize={{
-          width: 160,
-          height: 90,
-        }}
-        style={{
-          minWidth: "100%",
-          minHeight: "100%",
-          flex: 1,
-        }}
-      />
+    <RTCView
+      mirror={false}
+      objectFit={props?.objectFit || "contain"}
+      streamURL={mediaStream.toURL()}
+      onLayout={handleLayout}
+      pictureInPictureEnabled={props?.pictureInPictureEnabled !== false}
+      autoStartPictureInPicture={true}
+      pictureInPicturePreferredSize={{
+        width: 160,
+        height: 90,
+      }}
+      style={{
+        minWidth: "100%",
+        minHeight: "100%",
+        flex: 1,
+      }}
+    />
   );
 }
 


### PR DESCRIPTION
Allow pausing/unpausing of the stream with headphone play/pause buttons. This is a feature I found annoying to be missing when passively watching the office hours stream yesterday.

This also works in picture in picture mode (tested on android, would appreciate iOS testing)

The stream just shows a black screen when paused, it would be better to show a freeze frame of the stream when paused but I wasn't sure of how to implement this - happy to add if someone has pointers on how to do it.