### PR TITLE
Stop camera access when navigating away from go live screen

### DIFF
--- a/js/components/src/components/mobile-player/video-async.native.tsx
+++ b/js/components/src/components/mobile-player/video-async.native.tsx
@@ -315,10 +315,13 @@ export function NativeIngestPlayer(props?: {
   const localMediaStream = lms;
 
   useEffect(() => {
+    let acquiredStream: WebRTCMediaStream | null = null;
+
     if (ingestMediaSource === IngestMediaSource.DISPLAY) {
       mediaDevices
         .getDisplayMedia()
         .then((stream: WebRTCMediaStream) => {
+          acquiredStream = stream;
           console.log("display media", stream);
           setLocalMediaStream(stream);
         })
@@ -344,6 +347,7 @@ export function NativeIngestPlayer(props?: {
           },
         })
         .then((stream: WebRTCMediaStream) => {
+          acquiredStream = stream;
           setLocalMediaStream(stream);
 
           let errs: string[] = [];
@@ -374,6 +378,13 @@ export function NativeIngestPlayer(props?: {
           );
         });
     }
+
+    return () => {
+      if (acquiredStream) {
+        acquiredStream.getTracks().forEach((track) => track.stop());
+      }
+      setLocalMediaStream(null);
+    };
   }, [ingestMediaSource, ingestCamera]);
 
   useEffect(() => {


### PR DESCRIPTION
Add NativeIngestPlayer useEffect cleanup function that runs on unmount. 
This stops the OS reporting that the camera is being accessed when navigating away from the go live screen

Fixes https://github.com/streamplace/streamplace/issues/920

Tested on android but not on iOS (I assume the bug happens on iOS too but not 100% sure)