### PR TITLE
fix mobile playback issues

### DIFF
--- a/js/app/components/mobile/ui.tsx
+++ b/js/app/components/mobile/ui.tsx
@@ -1,6 +1,7 @@
 import { useNavigation } from "@react-navigation/native";
 import {
   ContentWarningBadge,
+  PlayerStatus,
   PlayerUI,
   Slider,
   Text,
@@ -80,6 +81,21 @@ export function MobileUi({
 
   const muteWasForced = usePlayerStore((state) => state.muteWasForced);
   const setMuteWasForced = usePlayerStore((state) => state.setMuteWasForced);
+  const [playerIsReady, setPlayerIsReady] = useState(false);
+  const playerStatusReady = usePlayerStore(
+    (state) => state.status === PlayerStatus.PLAYING,
+  );
+  useEffect(() => {
+    if (playerIsReady) return;
+    if (playerStatusReady) {
+      setPlayerIsReady(true);
+    } else {
+      const handle = setTimeout(() => {
+        setPlayerIsReady(true);
+      }, 5000);
+      return () => clearTimeout(handle);
+    }
+  }, [playerStatusReady]);
   const muted = useMuted();
   const setMuted = useSetMuted();
   const ls = useLivestream();
@@ -268,7 +284,7 @@ export function MobileUi({
           <PlayerUI.AutoplayButton />
         </View>
       </GestureDetector>
-      {showChat === undefined && !isSelfAndNotLive && (
+      {showChat === undefined && !isSelfAndNotLive && playerIsReady && (
         <MobileChatPanel isPlayerRatioGreater={isPlayerRatioGreater} />
       )}
     </>

--- a/js/components/src/components/chat/chat.tsx
+++ b/js/components/src/components/chat/chat.tsx
@@ -142,22 +142,34 @@ const ActionsBar = memo(
   },
 );
 
-const ChatLine = memo(({
-  item,
-  isHovered,
-  onHoverIn,
-  onHoverOut,
-  hoverTimeoutRef,
-}: {
-  item: ChatMessageViewHydrated;
-  isHovered?: boolean;
-  onHoverIn?: () => void;
-  onHoverOut?: () => void;
-  hoverTimeoutRef?: React.MutableRefObject<NodeJS.Timeout | null>;
-}) => {
+const ChatLine = memo(({ item }: { item: ChatMessageViewHydrated }) => {
   const setReply = useSetReplyToMessage();
   const setModMsg = usePlayerStore((state) => state.setModMessage);
   const swipeableRef = useRef<SwipeableMethods | null>(null);
+  const [isHovered, setIsHovered] = useState(false);
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleHoverIn = () => {
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current);
+      hoverTimeoutRef.current = null;
+    }
+    setIsHovered(true);
+  };
+
+  const handleHoverOut = () => {
+    hoverTimeoutRef.current = setTimeout(() => {
+      setIsHovered(false);
+    }, 50);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current);
+      }
+    };
+  }, []);
 
   if (item.author.did === "did:sys:system") {
     return (
@@ -184,22 +196,23 @@ const ChatLine = memo(({
           },
           isHovered && bg.gray[950],
         ]}
-        onPointerEnter={onHoverIn}
-        onPointerLeave={onHoverOut}
+        onPointerEnter={handleHoverIn}
+        onPointerLeave={handleHoverOut}
       >
         <Pressable style={[{ minWidth: 0, maxWidth: "100%" }]}>
           <RenderChatMessage item={item} />
         </Pressable>
         <ActionsBar
           item={item}
-          visible={!!isHovered}
-          hoverTimeoutRef={hoverTimeoutRef!}
+          visible={isHovered}
+          hoverTimeoutRef={hoverTimeoutRef}
         />
       </View>
     );
   }
 
   return (
+    <>
       <Swipeable
         containerStyle={[py[1]]}
         friction={2}
@@ -226,6 +239,7 @@ const ChatLine = memo(({
       >
         <RenderChatMessage item={item} />
       </Swipeable>
+    </>
   );
 });
 
@@ -241,22 +255,6 @@ export function Chat({
   const chat = useChat();
   const [isScrolledUp, setIsScrolledUp] = useState(false);
   const flatListRef = useRef<FlatList>(null);
-  const [hoveredMessageUri, setHoveredMessageUri] = useState<string | null>(null);
-  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const handleHoverIn = (uri: string) => {
-    if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current);
-      hoverTimeoutRef.current = null;
-    }
-    setHoveredMessageUri(uri);
-  };
-
-  const handleHoverOut = () => {
-    hoverTimeoutRef.current = setTimeout(() => {
-      setHoveredMessageUri(null);
-    }, 50);
-  };
 
   // Animation for scroll-to-bottom button
   const buttonOpacity = useSharedValue(0);
@@ -323,15 +321,7 @@ export function Chat({
           data={chat.slice(0, shownMessages)}
           inverted={true}
           keyExtractor={keyExtractor}
-          renderItem={({ item }) => (
-            <ChatLine
-              item={item}
-              isHovered={hoveredMessageUri === item.uri}
-              onHoverIn={() => handleHoverIn(item.uri)}
-              onHoverOut={handleHoverOut}
-              hoverTimeoutRef={hoverTimeoutRef}
-            />
-          )}
+          renderItem={({ item, index }) => <ChatLine item={item} />}
           removeClippedSubviews={true}
           maxToRenderPerBatch={10}
           initialNumToRender={10}

--- a/js/components/src/components/chat/chat.tsx
+++ b/js/components/src/components/chat/chat.tsx
@@ -142,65 +142,64 @@ const ActionsBar = memo(
   },
 );
 
-const ChatLine = memo(
-  ({
-    item,
-    isHovered,
-    onHoverIn,
-    onHoverOut,
-    hoverTimeoutRef,
-  }: {
-    item: ChatMessageViewHydrated;
-    isHovered?: boolean;
-    onHoverIn?: () => void;
-    onHoverOut?: () => void;
-    hoverTimeoutRef?: React.MutableRefObject<NodeJS.Timeout | null>;
-  }) => {
-    const setReply = useSetReplyToMessage();
-    const setModMsg = usePlayerStore((state) => state.setModMessage);
-    const swipeableRef = useRef<SwipeableMethods | null>(null);
+const ChatLine = memo(({
+  item,
+  isHovered,
+  onHoverIn,
+  onHoverOut,
+  hoverTimeoutRef,
+}: {
+  item: ChatMessageViewHydrated;
+  isHovered?: boolean;
+  onHoverIn?: () => void;
+  onHoverOut?: () => void;
+  hoverTimeoutRef?: React.MutableRefObject<NodeJS.Timeout | null>;
+}) => {
+  const setReply = useSetReplyToMessage();
+  const setModMsg = usePlayerStore((state) => state.setModMessage);
+  const swipeableRef = useRef<SwipeableMethods | null>(null);
 
-    if (item.author.did === "did:sys:system") {
-      return (
-        <SystemMessage
-          variant={getSystemMessageType(item) || SystemMessageType.notification}
-          timestamp={new Date(item.record.createdAt)}
-          title={item.record.text}
-          facets={item.record.facets}
-        />
-      );
-    }
-
-    if (Platform.OS === "web") {
-      return (
-        <View
-          style={[
-            py[1],
-            px[2],
-            {
-              position: "relative",
-              borderRadius: 8,
-              minWidth: 0,
-              maxWidth: "100%",
-            },
-            isHovered && bg.gray[950],
-          ]}
-          onPointerEnter={onHoverIn}
-          onPointerLeave={onHoverOut}
-        >
-          <Pressable style={[{ minWidth: 0, maxWidth: "100%" }]}>
-            <RenderChatMessage item={item} />
-          </Pressable>
-          <ActionsBar
-            item={item}
-            visible={!!isHovered}
-            hoverTimeoutRef={hoverTimeoutRef!}
-          />
-        </View>
-      );
-    }
-
+  if (item.author.did === "did:sys:system") {
     return (
+      <SystemMessage
+        variant={getSystemMessageType(item) || SystemMessageType.notification}
+        timestamp={new Date(item.record.createdAt)}
+        title={item.record.text}
+        facets={item.record.facets}
+      />
+    );
+  }
+
+  if (Platform.OS === "web") {
+    return (
+      <View
+        style={[
+          py[1],
+          px[2],
+          {
+            position: "relative",
+            borderRadius: 8,
+            minWidth: 0,
+            maxWidth: "100%",
+          },
+          isHovered && bg.gray[950],
+        ]}
+        onPointerEnter={onHoverIn}
+        onPointerLeave={onHoverOut}
+      >
+        <Pressable style={[{ minWidth: 0, maxWidth: "100%" }]}>
+          <RenderChatMessage item={item} />
+        </Pressable>
+        <ActionsBar
+          item={item}
+          visible={!!isHovered}
+          hoverTimeoutRef={hoverTimeoutRef!}
+        />
+      </View>
+    );
+  }
+
+  return (
       <Swipeable
         containerStyle={[py[1]]}
         friction={2}
@@ -227,9 +226,8 @@ const ChatLine = memo(
       >
         <RenderChatMessage item={item} />
       </Swipeable>
-    );
-  },
-);
+  );
+});
 
 export function Chat({
   shownMessages = SHOWN_MSGS,
@@ -243,9 +241,7 @@ export function Chat({
   const chat = useChat();
   const [isScrolledUp, setIsScrolledUp] = useState(false);
   const flatListRef = useRef<FlatList>(null);
-  const [hoveredMessageUri, setHoveredMessageUri] = useState<string | null>(
-    null,
-  );
+  const [hoveredMessageUri, setHoveredMessageUri] = useState<string | null>(null);
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleHoverIn = (uri: string) => {

--- a/js/components/src/components/mobile-player/video-async.native.tsx
+++ b/js/components/src/components/mobile-player/video-async.native.tsx
@@ -186,11 +186,7 @@ export function NativeWHEP(props?: {
 }) {
   const selectedRendition = usePlayerStore((x) => x.selectedRendition);
   const src = usePlayerStore((x) => x.src);
-  const { url } = srcToUrl(
-    { src: src, selectedRendition },
-    PlayerProtocol.WEBRTC,
-  );
-  const [stream, stuck] = useWebRTC(url);
+  const [stream, stuck] = useWebRTC(src);
   const status = usePlayerStore((x) => x.status);
 
   const setPlayerWidth = usePlayerStore((x) => x.setPlayerWidth);

--- a/js/components/src/components/mobile-player/video-retry.tsx
+++ b/js/components/src/components/mobile-player/video-retry.tsx
@@ -8,7 +8,7 @@ export default function VideoRetry(props: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!playing) {
-      const jitter = 500 + Math.random() * 1500;
+      const jitter = 2000 + Math.random() * 1500;
       retryTimeoutRef.current = setTimeout(() => {
         console.log("Retrying video playback...");
         setRetries((prevRetries) => prevRetries + 1);

--- a/pkg/director/stream_session.go
+++ b/pkg/director/stream_session.go
@@ -473,9 +473,9 @@ var livestreamUpdateInterval = time.Second * 30
 func (ss *StreamSession) UpdateLivestream(ctx context.Context, repoDID string) {
 	select {
 	case ss.livestreamUpdateChan <- struct{}{}:
-		log.Warn(ctx, "livestream update signal sent")
+		log.Debug(ctx, "livestream update signal sent")
 	default:
-		log.Warn(ctx, "livestream update channel full, signal already pending")
+		log.Debug(ctx, "livestream update channel full, signal already pending")
 		// Channel full, signal already pending
 	}
 }
@@ -489,7 +489,7 @@ func (ss *StreamSession) livestreamUpdateLoop(ctx context.Context, repoDID strin
 			return nil
 		case <-ss.livestreamUpdateChan:
 			if time.Since(ss.lastLivestreamTime) < livestreamUpdateInterval {
-				log.Warn(ctx, "not updating livestream, last livestream was less than 30 seconds ago")
+				log.Debug(ctx, "not updating livestream, last livestream was less than 30 seconds ago")
 				continue
 			}
 			if err := ss.doUpdateLivestream(ctx, repoDID); err != nil {
@@ -547,7 +547,7 @@ func (ss *StreamSession) doUpdateLivestream(ctx context.Context, repoDID string)
 		return fmt.Errorf("could not update livestream record: %w", err)
 	}
 
-	log.Warn(ctx, "updated livestream record", "uri", lastLivestream.URI)
+	log.Debug(ctx, "updated livestream record", "uri", lastLivestream.URI)
 	ss.lastLivestreamTime = time.Now()
 
 	return nil


### PR DESCRIPTION
So we had a problem where chat was loading very slowly on native (in particular Android Debug, the slowest-rendering platform of them all) which was causing video-retry to trigger. The following changes have been made:

1. @JordanWeatherby I had to revert https://github.com/streamplace/streamplace/pull/921 unfortunately, something about it was breaking the memo() call and the chat lines were rerendering every few seconds - very expensive on Android
2. We now give the video up to 5 seconds to start playing before even trying to render chat; it's a slightly more awkward visual experience but gets you into a better state more quickly
3. <VideoRetry /> was being too aggressive; giving up on the first playback after 500ms was unrealistic. Bumped it up to 2s and now the initial SDP call is much more likely to succeed on mobile
4. SDP Post was completely broken on mobile whoops