### PR TITLE
fix: enable bottom bar on non-wide web

### DIFF
--- a/js/app/hooks/useSidebarControl.tsx
+++ b/js/app/hooks/useSidebarControl.tsx
@@ -13,7 +13,7 @@ import {
 } from "store/hooks";
 
 // Returns *true* if the screen is > 1024px
-function useIsLargeScreen() {
+export function useIsLargeScreen() {
   const { width } = useWindowDimensions();
   // gtMd breakpoint
   return width >= 980 + 1;

--- a/js/app/src/screens/launch-go-live.tsx
+++ b/js/app/src/screens/launch-go-live.tsx
@@ -22,7 +22,7 @@ export default function LaunchGoLive() {
           zero.layout.flex.alignCenter,
         ]}
       >
-        <View style={[zero.r.full, zero.bg.primary]}>
+        <View style={[zero.r.full]}>
           <Video size={48} color="white" />
         </View>
         <Text size="3xl" weight="bold" center>

--- a/js/app/src/shell.tsx
+++ b/js/app/src/shell.tsx
@@ -32,7 +32,8 @@ import { SidebarOverlay } from "components/sidebar/sidebar-overlay";
 import { useBlueskyNotifications } from "hooks/useBlueskyNotifications";
 import { useLiveUser } from "hooks/useLiveUser";
 import usePlatform from "hooks/usePlatform";
-import { useSidebarControl } from "hooks/useSidebarControl";
+import { useIsLargeScreen, useSidebarControl } from "hooks/useSidebarControl";
+import { Cog, Home, Video } from "lucide-react-native";
 import { useEffect, useRef, useState } from "react";
 import { Platform, StatusBar, View } from "react-native";
 import Animated, { useAnimatedStyle } from "react-native-reanimated";
@@ -239,11 +240,12 @@ const getIcon = (
       type: "sfSymbol",
       name: IOS_ICONS[name],
     };
+  } else {
+    return {
+      type: "materialSymbol",
+      name: ANDROID_ICONS[name],
+    };
   }
-  return {
-    type: "materialSymbol",
-    name: ANDROID_ICONS[name],
-  };
 };
 
 // Tab navigator (main app sections, navigation on web is handled in sidebar)
@@ -251,6 +253,7 @@ function TabNavigator() {
   const { isNative, isBrowser } = usePlatform();
   const accentColor = useAccentColor();
   const primaryColor = usePrimaryColor();
+  const isLargeScreen = useIsLargeScreen();
   const z = useTheme();
 
   return (
@@ -258,8 +261,12 @@ function TabNavigator() {
       screenOptions={{
         lazy: true,
         headerShown: false,
-        // Hide tab bar on web
-        tabBarStyle: isNative ? undefined : { display: "none" },
+        // Hide tab bar on web and < 800px
+        tabBarStyle: isNative
+          ? undefined
+          : !isLargeScreen
+            ? undefined
+            : { display: "none" },
         // doesn't seem to work on iOS?
         // tabBarInactiveTintColor: primaryColor || accentColor || "#f0f",
         // tabBarActiveTintColor: accentColor || primaryColor || "#06f",
@@ -273,9 +280,15 @@ function TabNavigator() {
         component={HomeNavigator}
         options={{
           title: "Home",
-          ...(isNative && {
-            tabBarIcon: getIcon("Home"),
-          }),
+          ...(isNative
+            ? {
+                tabBarIcon: getIcon("Home"),
+              }
+            : {
+                tabBarIcon: ({ color, size }) => (
+                  <Home size={size} color={color} />
+                ),
+              }),
         }}
       />
       <Tab.Screen
@@ -283,9 +296,15 @@ function TabNavigator() {
         component={LaunchGoLive}
         options={{
           title: "Go Live",
-          ...(isNative && {
-            tabBarIcon: getIcon("GoLive"),
-          }),
+          ...(isNative
+            ? {
+                tabBarIcon: getIcon("GoLive"),
+              }
+            : {
+                tabBarIcon: ({ color, size }) => (
+                  <Video size={size} color={color} />
+                ),
+              }),
           headerShown: true,
           headerTransparent: true,
         }}
@@ -295,9 +314,15 @@ function TabNavigator() {
         component={SettingsNavigator}
         options={{
           title: "Settings",
-          ...(isNative && {
-            tabBarIcon: getIcon("Settings"),
-          }),
+          ...(isNative
+            ? {
+                tabBarIcon: getIcon("Settings"),
+              }
+            : {
+                tabBarIcon: ({ color, size }) => (
+                  <Cog size={size} color={color} />
+                ),
+              }),
           headerShown: false,
         }}
       />


### PR DESCRIPTION
This PR enables the bottom bar on non-wide web environments so they have a way to navigate around.

<img width="320" alt="Screen Shot 2026-03-13 at 17 47 02" src="https://github.com/user-attachments/assets/55abc06f-b422-46d0-9a78-97ee1e67629d" />
