### PR TITLE
fix: lazyize/memoize navigation and such

### DIFF
--- a/js/app/components/aqlink.tsx
+++ b/js/app/components/aqlink.tsx
@@ -1,8 +1,4 @@
-import {
-  useNavigation,
-  useNavigationState,
-  useRoute,
-} from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import usePlatform from "hooks/usePlatform";
 import { useEffect } from "react";
 import { Pressable, StyleProp, ViewStyle } from "react-native";
@@ -45,18 +41,18 @@ export default function AQLink({
 }) {
   const { isWeb } = usePlatform();
   const navigation = useNavigation();
-  const route = useRoute();
   const openLoginModal = useStore((state) => state.openLoginModal);
   const { href } = useAQLinkHref(to);
 
-  // get the deepest active route for nested navigators
-  const currentRoute = useNavigationState((state) => {
+  const getCurrentRoute = () => {
+    const state = navigation.getState();
+    if (!state) return { name: undefined, params: undefined };
     let route: any = state.routes[state.index];
     while (route.state?.index !== undefined) {
       route = route.state.routes[route.state.index];
     }
     return { name: route.name, params: route.params };
-  });
+  };
 
   const baseStyle: StyleProp<ViewStyle> = {
     display: "flex",
@@ -71,12 +67,12 @@ export default function AQLink({
     if (to.screen === "Login") {
       console.log(
         "AQLink intercepting login navigation, current route:",
-        currentRoute,
+        getCurrentRoute(),
       );
-      openLoginModal(currentRoute as any);
+      openLoginModal(getCurrentRoute() as any);
       console.log(
         "AQLink login navigation intercepted, current route:",
-        currentRoute,
+        getCurrentRoute(),
       );
       return;
     }
@@ -87,7 +83,7 @@ export default function AQLink({
       rootNav.navigate(to.screen, to.params);
       console.log(
         "AQLink root navigation intercepted, current route:",
-        currentRoute,
+        getCurrentRoute(),
       );
       return;
     }
@@ -95,7 +91,10 @@ export default function AQLink({
     const converted = convertNavigationParams(to);
     // @ts-expect-error - dynamic navigation with LinkParams
     navigation.navigate(converted.screen, converted.params);
-    console.log("AQLink navigation intercepted, current route:", currentRoute);
+    console.log(
+      "AQLink navigation intercepted, current route:",
+      getCurrentRoute(),
+    );
   };
 
   // use Pressable with href on web to render as <a> tag for copy/paste support

--- a/js/app/components/mobile/chat.tsx
+++ b/js/app/components/mobile/chat.tsx
@@ -5,8 +5,6 @@ import {
   Resizable,
   StreamNotificationProvider,
   Text,
-  useHandle,
-  useLivestreamInfo,
   View,
   zero,
 } from "@streamplace/components";
@@ -143,9 +141,6 @@ export function MobileChatPanel({ isPlayerRatioGreater }) {
 }
 
 function ChatPanel() {
-  const { profile } = useLivestreamInfo();
-  const handle = useHandle();
-
   let agent = usePDSAgent();
 
   const navigation = useNavigation();

--- a/js/app/components/mobile/chat.tsx
+++ b/js/app/components/mobile/chat.tsx
@@ -19,7 +19,7 @@ import Animated, {
   withSpring,
 } from "react-native-reanimated";
 
-import { useNavigation, useNavigationState } from "@react-navigation/native";
+import { useNavigation } from "@react-navigation/native";
 import { usePDSAgent } from "@streamplace/components/src/streamplace-store/xrpc";
 import { EmojiPicker } from "components/emoji-picker/emoji-picker";
 import { ArrowRight } from "lucide-react-native";
@@ -153,15 +153,6 @@ function ChatPanel() {
   const emojiData = useEmojiData();
   const customEmoji: any[] = [];
 
-  // get the deepest active route for nested navigators
-  const currentRoute = useNavigationState((state) => {
-    let route: any = state.routes[state.index];
-    while (route.state?.index !== undefined) {
-      route = route.state.routes[route.state.index];
-    }
-    return { name: route.name, params: route.params };
-  });
-
   return (
     <View
       style={[
@@ -205,7 +196,18 @@ function ChatPanel() {
           </View>
         ) : (
           <Pressable
-            onPress={() => openLoginModal(currentRoute as any)}
+            onPress={() => {
+              const state = navigation.getState();
+              if (!state) {
+                openLoginModal();
+                return;
+              }
+              let route: any = state.routes[state.index];
+              while (route.state?.index !== undefined) {
+                route = route.state.routes[route.state.index];
+              }
+              openLoginModal({ name: route.name, params: route.params } as any);
+            }}
             style={[
               layout.flex.row,
               layout.flex.center,

--- a/js/app/components/settings/settings.tsx
+++ b/js/app/components/settings/settings.tsx
@@ -29,7 +29,6 @@ import {
 import { ScrollView } from "react-native";
 
 import { LiquidGlassView } from "@callstack/liquid-glass";
-import { useNavigationState } from "@react-navigation/native";
 import Mu from "components/mobile/desktop-ui/mu";
 import { useStore } from "store";
 import { useUserProfile } from "store/hooks";
@@ -40,15 +39,6 @@ export function Settings() {
   const userProfile = useUserProfile();
   const danmuUnlocked = useDanmuUnlocked();
   const openLoginModal = useStore((state) => state.openLoginModal);
-
-  // get the deepest active route for nested navigators
-  const currentRoute = useNavigationState((state) => {
-    let route: any = state.routes[state.index];
-    while (route.state?.index !== undefined) {
-      route = route.state.routes[route.state.index];
-    }
-    return { name: route.name, params: route.params };
-  });
 
   const adminDids = useStreamplaceStore((state) => state.adminDIDs);
   const did = useDID();

--- a/js/components/src/components/chat/chat-message.tsx
+++ b/js/components/src/components/chat/chat-message.tsx
@@ -4,7 +4,7 @@ import {
   Mention,
 } from "@atproto/api/dist/client/types/app/bsky/richtext/facet";
 import { memo, useCallback } from "react";
-import { Linking, View } from "react-native";
+import { Linking, Platform, View } from "react-native";
 import { ChatMessageViewHydrated } from "streamplace";
 import { RichtextSegment, segmentize } from "../../lib/facet";
 import { borders, flex, gap, ml, mr, opacity, pl } from "../../lib/theme/atoms";
@@ -85,9 +85,8 @@ export const RichTextMessage = ({
   text: string;
   facets: ChatMessageViewHydrated["record"]["facets"];
 }) => {
-  if (!facets?.length) return <Text>{text}</Text>;
-
   const userCache = useLivestreamStore((state) => state.authors);
+  if (!facets?.length) return <Text>{text}</Text>;
 
   let segs = segmentize(text, facets as Facet[]);
 
@@ -177,7 +176,7 @@ export const RenderChatMessage = memo(
                 style={
                   {
                     // display: inline is a no-op on mobile
-                    display: "inline",
+                    display: Platform.OS === "web" ? "inline" : undefined,
                     alignItems: "center",
                     justifyContent: "flex-end",
                     flexDirection: "row",

--- a/js/components/src/components/chat/user-profile-card.tsx
+++ b/js/components/src/components/chat/user-profile-card.tsx
@@ -63,8 +63,9 @@ export const ProfileCardProvider = ({
   children: React.ReactNode;
 }) => {
   const [openUri, setOpenUri] = useState<string | null>(null);
+  const value = useMemo(() => ({ openUri, setOpenUri }), [openUri]);
   return (
-    <OpenCardContext.Provider value={{ openUri, setOpenUri }}>
+    <OpenCardContext.Provider value={value}>
       {children}
     </OpenCardContext.Provider>
   );

--- a/js/components/src/components/ui/resizeable.tsx
+++ b/js/components/src/components/ui/resizeable.tsx
@@ -13,6 +13,7 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
+  withTiming,
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useKeyboardSlide } from "../../hooks";
@@ -23,6 +24,11 @@ const AnimatedView = Animated.createAnimatedComponent(View);
 
 const { height: SCREEN_HEIGHT } = Dimensions.get("window");
 
+const TIMING_CONFIG = {
+  duration: 300,
+  easing: Easing.inOut(Easing.quad),
+};
+
 type ResizableChatSheetProps = {
   startingPercentage?: number;
   isPlayerRatioGreater: boolean;
@@ -30,8 +36,6 @@ type ResizableChatSheetProps = {
   children?: React.ReactNode;
   renderAbove?: (isCollapsed: boolean) => React.ReactNode;
 };
-
-const SPRING_CONFIG = { damping: 20, stiffness: 100 };
 
 export function Resizable({
   startingPercentage,
@@ -56,7 +60,7 @@ export function Resizable({
       const targetHeight = startingPercentage
         ? startingPercentage * SCREEN_HEIGHT
         : MIN_HEIGHT;
-      sheetHeight.value = withSpring(targetHeight, SPRING_CONFIG);
+      sheetHeight.value = withTiming(targetHeight, TIMING_CONFIG);
       setIsCollapsed(targetHeight < COLLAPSE_HEIGHT);
     }, 1000);
   }, []);
@@ -73,7 +77,7 @@ export function Resizable({
 
       const nowCollapsed = newHeight < COLLAPSE_HEIGHT;
       if (nowCollapsed && !wasCollapsed.value) {
-        sheetHeight.value = withSpring(MIN_HEIGHT, SPRING_CONFIG);
+        sheetHeight.value = withTiming(MIN_HEIGHT, SPRING_CONFIG);
         wasCollapsed.value = true;
         runOnJS(setIsCollapsed)(true);
       } else if (!nowCollapsed && wasCollapsed.value) {
@@ -139,8 +143,8 @@ export function Resizable({
           onPress={() => {
             const isCurrentlyCollapsed = sheetHeight.value === MIN_HEIGHT;
             sheetHeight.value = isCurrentlyCollapsed
-              ? withSpring(MAX_HEIGHT, SPRING_CONFIG)
-              : withSpring(MIN_HEIGHT, SPRING_CONFIG);
+              ? withTiming(MAX_HEIGHT, SPRING_CONFIG)
+              : withTiming(MIN_HEIGHT, SPRING_CONFIG);
             setIsCollapsed(!isCurrentlyCollapsed);
           }}
         >

--- a/js/components/src/components/ui/resizeable.tsx
+++ b/js/components/src/components/ui/resizeable.tsx
@@ -7,6 +7,7 @@ import {
   Pressable,
 } from "react-native-gesture-handler";
 import Animated, {
+  Easing,
   Extrapolation,
   interpolate,
   runOnJS,
@@ -77,7 +78,7 @@ export function Resizable({
 
       const nowCollapsed = newHeight < COLLAPSE_HEIGHT;
       if (nowCollapsed && !wasCollapsed.value) {
-        sheetHeight.value = withTiming(MIN_HEIGHT, SPRING_CONFIG);
+        sheetHeight.value = withTiming(MIN_HEIGHT, TIMING_CONFIG);
         wasCollapsed.value = true;
         runOnJS(setIsCollapsed)(true);
       } else if (!nowCollapsed && wasCollapsed.value) {
@@ -143,8 +144,8 @@ export function Resizable({
           onPress={() => {
             const isCurrentlyCollapsed = sheetHeight.value === MIN_HEIGHT;
             sheetHeight.value = isCurrentlyCollapsed
-              ? withTiming(MAX_HEIGHT, SPRING_CONFIG)
-              : withTiming(MIN_HEIGHT, SPRING_CONFIG);
+              ? withTiming(MAX_HEIGHT, TIMING_CONFIG)
+              : withTiming(MIN_HEIGHT, TIMING_CONFIG);
             setIsCollapsed(!isCurrentlyCollapsed);
           }}
         >

--- a/js/components/src/context/profile-cache.tsx
+++ b/js/components/src/context/profile-cache.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -85,8 +86,13 @@ export function ProfileCacheProvider({
     [flush],
   );
 
+  const value = useMemo(
+    () => ({ profiles, requestProfiles }),
+    [profiles, requestProfiles],
+  );
+
   return (
-    <ProfileCacheContext.Provider value={{ profiles, requestProfiles }}>
+    <ProfileCacheContext.Provider value={value}>
       {children}
     </ProfileCacheContext.Provider>
   );


### PR DESCRIPTION
I was getting this issue when running in prod, right when the mobile chat box reached its peak in its animation:
> `Unhandled JS Exception: Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.`

I think it extended from one of two issues:

1. It turns our that`useNavigationState` returns an object literal on each call. Because of how react-navigation compares, it saw a new render on each new call. The fix here is to read navigation state lazily, so we simply shouldn't run into that issue. 
2. There was an unmemoized context value derived from a useState passed into the profile card provider's open card context provider. This created a new object on every render which cascaded. Memoizing this beforehand should fix this issue.