### PR TITLE
fix: add 'collapse sidebar' buttons to every stack possible

### DIFF
--- a/js/app/src/router.tsx
+++ b/js/app/src/router.tsx
@@ -91,7 +91,7 @@ export const NavigationButton = ({ canGoBack }: { canGoBack?: boolean }) => {
         { flexDirection: "row" },
         {
           marginLeft: Platform.OS === "android" ? 0 : 12,
-          marginRight: Platform.OS === "android" ? 12 : 0,
+          marginRight: 12,
         },
       ]}
     >

--- a/js/app/src/shell.tsx
+++ b/js/app/src/shell.tsx
@@ -3,7 +3,10 @@ import {
   createBottomTabNavigator,
 } from "@react-navigation/bottom-tabs";
 import { useLinkTo, useNavigation } from "@react-navigation/native";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import {
+  createNativeStackNavigator,
+  NativeStackHeaderBackProps,
+} from "@react-navigation/native-stack";
 import {
   Text,
   useAccentColor,
@@ -69,6 +72,25 @@ const SettingsStack = createNativeStackNavigator();
 // Home navigator (contains home + all general navigation screens)
 function HomeNavigator() {
   const title = useSiteTitle() || "Streamplace Station";
+  const isNative = Platform.OS !== "web";
+  const z = useTheme();
+
+  const headerScreenOptions = {
+    headerShown: !isNative,
+    headerLeft: isNative
+      ? undefined
+      : ({ canGoBack }: NativeStackHeaderBackProps) => (
+          <NavigationButton canGoBack={canGoBack} />
+        ),
+    headerRight: () => <LGAvatarButton />,
+    ...(isNative && {
+      headerTransparent: true,
+    }),
+    headerTitleStyle: {
+      fontFamily: z.theme.typography.universal.base.fontFamily,
+    },
+  };
+
   return (
     <HomeStack.Navigator
       screenOptions={{
@@ -111,32 +133,35 @@ function HomeNavigator() {
       <HomeStack.Screen
         name="About"
         component={AboutScreen}
-        options={{ title: "What's Streamplace?" }}
+        options={{
+          title: "What's Streamplace?",
+          ...headerScreenOptions,
+        }}
       />
       <HomeStack.Screen
         name="Download"
         component={DownloadScreen}
-        options={{ title: "Download" }}
+        options={{ title: "Download", ...headerScreenOptions }}
       />
       <HomeStack.Screen
         name="LiveDashboard"
         component={LiveDashboard}
-        options={{ title: "Live Dashboard" }}
+        options={{ title: "Live Dashboard", ...headerScreenOptions }}
       />
       <HomeStack.Screen
         name="Login"
         component={Login}
-        options={{ title: "Login" }}
+        options={{ title: "Login", ...headerScreenOptions }}
       />
       <HomeStack.Screen
         name="Multi"
         component={MultiScreen}
-        options={{ title: "Multi-stream" }}
+        options={{ title: "Multi-stream", ...headerScreenOptions }}
       />
       <HomeStack.Screen
         name="Support"
         component={SupportScreen}
-        options={{ title: "Support" }}
+        options={{ title: "Support", ...headerScreenOptions }}
       />
     </HomeStack.Navigator>
   );
@@ -145,16 +170,29 @@ function HomeNavigator() {
 // Settings stack navigator
 function SettingsNavigator() {
   const z = useTheme();
+  const isNative = Platform.OS !== "web";
+  const headerScreenOptions = {
+    headerShown: true,
+    headerLeft: isNative
+      ? undefined
+      : ({ canGoBack }: NativeStackHeaderBackProps) => (
+          <NavigationButton canGoBack={canGoBack} />
+        ),
+    headerRight: () => <LGAvatarButton />,
+    ...(isNative && {
+      headerTransparent: true,
+    }),
+    headerTitleStyle: {
+      fontFamily: z.theme.typography.universal.base.fontFamily,
+    },
+  };
   return (
     <SettingsStack.Navigator
       initialRouteName="MainSettings"
       screenOptions={{
-        headerShown: true,
         headerTransparent: Platform.OS === "ios",
         headerBackButtonDisplayMode: "minimal",
-        headerTitleStyle: {
-          fontFamily: z.theme.typography.universal["2xl"].fontFamily,
-        },
+        ...headerScreenOptions,
       }}
     >
       <SettingsStack.Screen


### PR DESCRIPTION
fixes #973 
We seem to have missed a bunch of these when transitioning to the new tab-driven layout  so i've added analogues to that everywhere there wasn't one.