### PR TITLE
fix: show golive overlay

### DIFF
--- a/js/app/components/mobile/desktop-ui.tsx
+++ b/js/app/components/mobile/desktop-ui.tsx
@@ -95,12 +95,13 @@ export function DesktopUi({
     setIsControlsVisible(true);
 
     if (selectedRendition === "audio") return;
+    if (ingest !== null) return;
 
     fadeTimeout.current = setTimeout(() => {
       fadeOpacity.value = withTiming(0, { duration: 400 });
       setIsControlsVisible(false);
     }, FADE_OUT_DELAY);
-  }, [fadeOpacity, selectedRendition]);
+  }, [fadeOpacity, selectedRendition, ingest]);
 
   const onPlayerHover = useCallback(() => {
     resetFadeTimer();

--- a/js/app/components/mobile/player.tsx
+++ b/js/app/components/mobile/player.tsx
@@ -503,7 +503,7 @@ export function PlayerInner(
             {showFullDesktopMode || fullscreen ? (
               <DesktopUi dropdownPortalContainer={dropdownPortalRef.current} />
             ) : (
-              isLandscape && (
+              (isLandscape || !!props.ingest) && (
                 <MobileUi
                   setShowChat={props.setShowChat}
                   showChat={props.showChat}

--- a/js/app/components/mobile/ui.tsx
+++ b/js/app/components/mobile/ui.tsx
@@ -127,6 +127,7 @@ export function MobileUi({
     fadeOpacity.value = withTiming(1, { duration: 200 });
     if (fadeTimeout.current) clearTimeout(fadeTimeout.current);
     if (selectedRendition === "audio") return;
+    if (ingest !== null) return;
     fadeTimeout.current = setTimeout(() => {
       fadeOpacity.value = withTiming(0, { duration: 400 });
     }, FADE_OUT_DELAY);


### PR DESCRIPTION
The old changes seems to have made ingest overlay disappear exactly when it needed to have not. This reverses that change + also makes the UI not disappear in ingest mode