### PR TITLE
feat: install wasm32-wasip1 target when building muxl-wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ dev-setup-meson-configure:
 
 .PHONY: muxl-wasm
 muxl-wasm:
+	rustup target add wasm32-wasip1
 	cargo build -p muxl-wasm --target wasm32-wasip1 --release
 	cp target/wasm32-wasip1/release/muxl-wasm.wasm pkg/muxl/muxl.wasm
 


### PR DESCRIPTION
totally missed that this wasn't installed when building 🤨 so now i've added it so nobody else ever misses it again 🫨 