### PR TITLE
fix: clear pin on unmount

### DIFF
--- a/js/components/src/livestream-provider/index.tsx
+++ b/js/components/src/livestream-provider/index.tsx
@@ -144,6 +144,12 @@ export function PinnedCommentWatcher() {
   const store = getStoreFromContext();
   const prevPinnedRef = useRef<string | null>(null);
 
+  useEffect(() => {
+    return () => {
+      StreamNotifications.pinnedCommentDismiss();
+    };
+  }, []);
+
   // Show/hide notification when pinned comment changes
   useEffect(() => {
     const currentUri = pinnedComment?.uri ?? null;


### PR DESCRIPTION
Clears the pin on unmount, so when one navigates to another stream, the pin  from the previous stream does not remain