### PR TITLE
fix: only have a single theme context

### DIFF
--- a/js/components/src/lib/theme/theme.tsx
+++ b/js/components/src/lib/theme/theme.tsx
@@ -475,13 +475,20 @@ export function ThemeProvider({
     ],
   );
 
+  const parentTheme = useContext(ThemeContext);
+  const isRoot = !parentTheme;
+
   return (
     <ThemeContext.Provider value={value}>
-      <GestureHandlerRootView>
-        {children}
-        <PortalHost />
-        <ToastProvider />
-      </GestureHandlerRootView>
+      {isRoot ? (
+        <GestureHandlerRootView>
+          {children}
+          <PortalHost />
+          <ToastProvider />
+        </GestureHandlerRootView>
+      ) : (
+        children
+      )}
     </ThemeContext.Provider>
   );
 }


### PR DESCRIPTION
Our theme stuff includes a portal host and in certain situations we had multiple portal hosts in our theme context, which led to duplicate items when they are portaled