### PR TITLE
fix: handle missing livestream in stopLivestream without panic

### DIFF
--- a/pkg/model/livestream.go
+++ b/pkg/model/livestream.go
@@ -27,6 +27,9 @@ type Livestream struct {
 }
 
 func (ls *Livestream) ToLivestreamView() (*streamplace.Livestream_LivestreamView, error) {
+	if ls == nil || ls.Livestream == nil {
+		return nil, fmt.Errorf("livestream record is nil")
+	}
 	rec, err := lexutil.CborDecodeValue(*ls.Livestream)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding feed post: %w", err)

--- a/pkg/model/livestream_test.go
+++ b/pkg/model/livestream_test.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"testing"
+)
+
+// TestToLivestreamViewNil verifies ToLivestreamView returns an error instead of
+// panicking when called on a nil receiver or when the embedded Livestream blob
+// is nil. Reproduces the panic reported in
+// https://github.com/streamplace/streamplace/issues/1079.
+func TestToLivestreamViewNil(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var ls *Livestream
+		view, err := ls.ToLivestreamView()
+		if err == nil {
+			t.Fatalf("expected error for nil receiver, got nil")
+		}
+		if view != nil {
+			t.Fatalf("expected nil view for nil receiver, got %+v", view)
+		}
+	})
+
+	t.Run("nil livestream blob", func(t *testing.T) {
+		ls := &Livestream{}
+		view, err := ls.ToLivestreamView()
+		if err == nil {
+			t.Fatalf("expected error for nil livestream blob, got nil")
+		}
+		if view != nil {
+			t.Fatalf("expected nil view for nil livestream blob, got %+v", view)
+		}
+	})
+}

--- a/pkg/spxrpc/place_stream_live.go
+++ b/pkg/spxrpc/place_stream_live.go
@@ -561,6 +561,9 @@ func (s *Server) handlePlaceStreamLiveStopLivestream(ctx context.Context, body *
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "error getting livestream", err)
 	}
+	if livestream == nil || livestream.Livestream == nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "no active livestream for this repo")
+	}
 
 	livestreamView, err := livestream.ToLivestreamView()
 	if err != nil {


### PR DESCRIPTION
Fixes #1079.

`handlePlaceStreamLiveStopLivestream` calls `s.model.GetLatestLivestreamForRepo`, which returns `(nil, nil)` when the repo has no rows. The code then calls `livestream.ToLivestreamView()` on the nil pointer, which dereferences `*ls.Livestream` and panics (matches the stack in the issue).

This adds the missing nil check in the handler and a defensive guard in `ToLivestreamView` itself. `TestToLivestreamViewNil` reproduces the panic on `next` and passes after the fix.