### PR TITLE
media: fix audio transcoding with non-1s segments

### DIFF
--- a/pkg/media/transcode.go
+++ b/pkg/media/transcode.go
@@ -276,6 +276,40 @@ func maxU32(a, b uint32) uint32 {
 	return b
 }
 
+// concatTracksByID reassembles a bare canonical .m4s from a segment event's
+// per-track bytes in ascending track-id order (the canonical track order) — the
+// inverse of how catalogAndTracks/the segmenter split a segment into ev.Tracks.
+func concatTracksByID(tracks map[string][]byte) []byte {
+	ids := make([]int, 0, len(tracks))
+	for k := range tracks {
+		if n, err := strconv.Atoi(k); err == nil {
+			ids = append(ids, n)
+		}
+	}
+	sort.Ints(ids)
+	var out []byte
+	for _, id := range ids {
+		out = append(out, tracks[strconv.Itoa(id)]...)
+	}
+	return out
+}
+
+// concatTrackAcrossSegments returns one track's bytes concatenated across EVERY
+// segment event in a muxl event stream. catalogAndTracks deliberately returns
+// only the first segment's tracks, so it silently drops data whenever a wrapper
+// holds more than one segment — which canonicalize produces when it re-segments
+// its input into multiple GoPs. Use this when the input may span several.
+func concatTrackAcrossSegments(events []*muxl.MuxlEvent, tid uint32) []byte {
+	key := strconv.FormatUint(uint64(tid), 10)
+	var out []byte
+	for _, ev := range events {
+		if ev.Type == "segment" || ev.Type == "signed-segment" {
+			out = append(out, ev.Tracks[key]...)
+		}
+	}
+	return out
+}
+
 // filterSegmentToCodec returns a bare canonical .m4s containing every video
 // track plus the single audio track matching the requested codec (Opus when
 // wantOpus, else AAC) — how an output consumer "asks for the audio it needs"

--- a/pkg/media/transcode_stream.go
+++ b/pkg/media/transcode_stream.go
@@ -338,7 +338,12 @@ func (t *streamTranscoder) run(feedR *io.PipeReader) error {
 			continue
 		}
 
-		completed, err := t.mm.finishTranscodedSegment(ctx, job.src, transAudio, audioTID, t.cert, t.keyPEM)
+		// Pass the WHOLE transcoded segment (video + audio), not the audio alone:
+		// finishTranscodedSegment re-canonicalizes it to relabel the audio track,
+		// and canonicalize needs the video keyframe as its cut clock to emit one
+		// segment per GoP. Audio by itself has no keyframes to anchor on.
+		transSeg := concatTracksByID(ev.Tracks)
+		completed, err := t.mm.finishTranscodedSegment(ctx, job.src, transSeg, audioTID, t.cert, t.keyPEM)
 		if err != nil {
 			log.Error(ctx, "stream transcode: finish segment failed", "error", err)
 			continue
@@ -357,12 +362,23 @@ func (t *streamTranscoder) run(feedR *io.PipeReader) error {
 }
 
 // finishTranscodedSegment assembles one completed dual-codec segment: relabel
-// the freshly-segmented transcoded audio (transAudio, at transTID) to a free
-// track id so it won't collide with the source tracks, sign it as a
-// c2pa.transcoded derivative of the source segment's audio (node identity), and
-// append it to the source segment. The relabel is a lossless re-container (no
-// re-encode), so the continuous encoder's gaplessness is preserved.
-func (mm *MediaManager) finishTranscodedSegment(ctx context.Context, srcSeg, transAudio []byte, transTID uint32, cert, keyPEM []byte) ([]byte, error) {
+// the freshly-segmented transcoded audio (the audio track transTID within
+// transSeg) to a free track id so it won't collide with the source tracks, sign
+// it as a c2pa.transcoded derivative of the source segment's audio (node
+// identity), and append it to the source segment. The relabel is a lossless
+// re-container (no re-encode), so the continuous encoder's gaplessness is
+// preserved.
+//
+// transSeg is the FULL emitted transcoded segment (video + transcoded audio),
+// not the audio track alone. The relabel goes through muxl's canonicalize,
+// which re-segments its input; with audio only there are no keyframes to anchor
+// on, so it falls back to a ~1s cadence and splits each ~2s GoP's audio in two —
+// and only the first survived extraction, silently halving the transcoded track
+// (every output segment carried ~1s of audio against ~2s of video, audible as
+// the audio cutting out for the back half of each segment). Carrying the
+// passed-through video as the cut clock makes canonicalize emit one segment per
+// GoP, exactly like the source track.
+func (mm *MediaManager) finishTranscodedSegment(ctx context.Context, srcSeg, transSeg []byte, transTID uint32, cert, keyPEM []byte) ([]byte, error) {
 	events, err := unwrapMuxlEvents(ctx, srcSeg)
 	if err != nil {
 		return nil, fmt.Errorf("unwrap source segment: %w", err)
@@ -387,11 +403,14 @@ func (mm *MediaManager) finishTranscodedSegment(ctx context.Context, srcSeg, tra
 	}
 	freeTID := maxTID + 1
 
-	// Relabel transTID → freeTID: wrap to fMP4, canonicalize with the remap,
-	// extract the relabeled track. Pure re-container; no re-encode.
+	// Relabel transTID → freeTID: wrap the full segment to fMP4, canonicalize
+	// with the remap (the video keyframe anchors one segment per GoP), extract
+	// the relabeled audio track. Pure re-container; no re-encode. Concatenate the
+	// track across every emitted segment so nothing is dropped if canonicalize
+	// ever splits the GoP (see catalogAndTracks / concatTrackAcrossSegments).
 	var fmp4 bytes.Buffer
-	if err := muxl.RunMuxlWrap(ctx, bytes.NewReader(transAudio), "fmp4", &fmp4); err != nil {
-		return nil, fmt.Errorf("wrap transcoded audio: %w", err)
+	if err := muxl.RunMuxlWrap(ctx, bytes.NewReader(transSeg), "fmp4", &fmp4); err != nil {
+		return nil, fmt.Errorf("wrap transcoded segment: %w", err)
 	}
 	canon, err := muxl.RunMuxlCanonicalize(ctx, fmp4.Bytes(), map[uint32]uint32{transTID: freeTID})
 	if err != nil {
@@ -401,8 +420,7 @@ func (mm *MediaManager) finishTranscodedSegment(ctx context.Context, srcSeg, tra
 	if err != nil {
 		return nil, fmt.Errorf("unwrap relabeled audio: %w", err)
 	}
-	_, canonTracks := catalogAndTracks(canonEvents)
-	output := canonTracks[strconv.FormatUint(uint64(freeTID), 10)]
+	output := concatTrackAcrossSegments(canonEvents, freeTID)
 	if len(output) == 0 {
 		return nil, fmt.Errorf("relabeled audio track %d missing", freeTID)
 	}

--- a/pkg/media/transcode_stream_test.go
+++ b/pkg/media/transcode_stream_test.go
@@ -145,17 +145,33 @@ func TestStreamTranscoderGapless(t *testing.T) {
 		require.NotContains(t, out, `"validation_state":"Invalid"`, "segment %d must validate", i)
 
 		o, a := audioDurationsSeconds(t, ctx, c)
+		// Each completed segment must carry a FULL GoP of transcoded audio, not a
+		// fraction of it. Relabeling the transcoded track to a free id runs it back
+		// through muxl's canonicalize, which re-segments; cut audio-only (no video
+		// keyframe to anchor on) it splits each ~2 s GoP into ~1 s pieces, and a bug
+		// that extracted only the first piece silently HALVED the track — every
+		// segment played ~1 s of AAC against ~2 s of Opus/video, audible as the
+		// audio cutting out for the back half of each segment. This proportional
+		// guard catches that (and any gross under-fill) independent of segment
+		// count; finishTranscodedSegment now carries the video through as the cut
+		// clock so the audio re-canonicalizes as one full segment per GoP.
+		require.Greater(t, a, 0.65*o,
+			"segment %d: transcoded AAC %.3fs far short of source Opus %.3fs (halved track?)", i, a, o)
 		totalOpus += o
 		totalAAC += a
 	}
 
 	t.Logf("completed=%d totalOpus=%.3fs totalAAC=%.3fs delta=%.3fs",
 		len(completed), totalOpus, totalAAC, totalAAC-totalOpus)
-	// Gapless: the transcoded track tracks the source duration. Per-segment
-	// priming would inflate the AAC track by ~one priming (40–80 ms) at EVERY
-	// segment boundary; a continuous encode pays it once at stream start (and
-	// the init's edit list absorbs even that). The measured delta is ~1 ms, so
-	// a 40 ms bound cleanly fails the gappy regression while staying robust.
-	require.InDelta(t, totalOpus, totalAAC, 0.040,
-		"transcoded AAC track is inflated vs source Opus — per-segment priming leaked in")
+	// Gapless: the transcoded track tracks the source duration with no per-segment
+	// accumulation. The continuous encoder pays its priming ONCE at stream start
+	// (the gappy per-segment transcoder this replaced paid 40–80 ms at EVERY
+	// boundary), and each segment's audio is cut on the video keyframe — which need
+	// not land on an AAC frame — so per-segment durations quantize by ±1 AAC frame
+	// (~21 ms) around the source without drifting (measured ~0.15 ms/segment over a
+	// 10-min real stream). The fixture is only a few short segments, too few to
+	// average the one-time priming, so bound = priming + ~one frame per segment.
+	tol := 0.040 + 0.025*float64(len(completed))
+	require.InDelta(t, totalOpus, totalAAC, tol,
+		"transcoded AAC total drifts from source Opus beyond priming + boundary quantization")
 }


### PR DESCRIPTION
fixes weird chopped-up audio in HLS output