### PR TITLE
fix: delegate and persist pins

### DIFF
--- a/js/app/src/screens/chat-popout.tsx
+++ b/js/app/src/screens/chat-popout.tsx
@@ -22,6 +22,7 @@ interface ChatPopoutParams {
   reverse?: string;
   hideAfter?: string;
   hideChatBox?: string;
+  hidePinnedComments?: string;
   showNotifications?: string;
 }
 
@@ -65,7 +66,7 @@ export function PopoutChatInner({ params }: { params: ChatPopoutParams }) {
     ? parseInt(params.hideAfter, 10)
     : undefined;
   const hideChatBox = params.hideChatBox === "true";
-  const showNotifications = params.showNotifications === "true";
+  const hidePinnedComments = params.hidePinnedComments === "true";
 
   useEffect(() => {
     setSrc(params.user);
@@ -88,7 +89,7 @@ export function PopoutChatInner({ params }: { params: ChatPopoutParams }) {
         { maxHeight: "100vh" },
       ]}
     >
-      {showNotifications ? (
+      {!hidePinnedComments ? (
         <StreamNotificationProvider position="top">
           {chat}
         </StreamNotificationProvider>

--- a/js/components/src/components/dashboard/moderator-panel.tsx
+++ b/js/components/src/components/dashboard/moderator-panel.tsx
@@ -596,6 +596,53 @@ function AddModeratorDialog({
               </Text>
             </View>
           </Pressable>
+
+          <Pressable
+            onPress={() =>
+              setPermissions((p) => ({
+                ...p,
+                "message.pin": !p["message.pin"],
+              }))
+            }
+            style={[
+              layout.flex.row,
+              layout.flex.alignCenter,
+              p[3],
+              r.md,
+              bg.neutral[800],
+              borders.width.thin,
+              borders.color.neutral[700],
+            ]}
+          >
+            <View
+              style={[
+                {
+                  width: 20,
+                  height: 20,
+                  borderRadius: 4,
+                },
+                borders.width.thin,
+                borders.color.neutral[600],
+                permissions["message.pin"] ? bg.blue[600] : bg.neutral[900],
+                layout.flex.center,
+                { marginRight: 12 },
+              ]}
+            >
+              {permissions["message.pin"] && (
+                <Text style={[textStyle.white, { fontSize: 12 }]}>✓</Text>
+              )}
+            </View>
+            <View>
+              <Text
+                style={[textStyle.white, { fontSize: 14, fontWeight: "500" }]}
+              >
+                Pin Messages
+              </Text>
+              <Text style={[textStyle.gray[400], { fontSize: 12 }]}>
+                Pin and unpin chat messages
+              </Text>
+            </View>
+          </Pressable>
         </View>
       </View>
 

--- a/js/components/src/livestream-store/chat.tsx
+++ b/js/components/src/livestream-store/chat.tsx
@@ -479,22 +479,6 @@ export const usePinChatMessage = () => {
 
     // If streamer, create directly
     if (agent.did === streamerDID) {
-      // First delete any existing pinned records
-      const listResult = await agent.com.atproto.repo.listRecords({
-        repo: streamerDID,
-        collection: "place.stream.chat.pinnedRecord",
-      });
-      for (const rec of listResult.data.records) {
-        const rkey = rec.uri.split("/").pop();
-        if (rkey) {
-          await agent.com.atproto.repo.deleteRecord({
-            repo: streamerDID,
-            collection: "place.stream.chat.pinnedRecord",
-            rkey,
-          });
-        }
-      }
-
       const record = {
         $type: "place.stream.chat.pinnedRecord",
         pinnedMessage: messageUri,

--- a/js/docs/src/content/docs/features/chat-popout.md
+++ b/js/docs/src/content/docs/features/chat-popout.md
@@ -63,3 +63,16 @@ Example:
 ```
 https://stream.place/chat-popout/did:plc:abcdef123456...?hideChatBox=true
 ```
+
+### `hidePinnedComments`
+
+Hides pinned comment notifications in the popout.
+
+- Type: `boolean` (values: `"true"`, `"false"`)
+- Default: `"false"`
+
+Example:
+
+```
+https://stream.place/chat-popout/did:plc:abcdef123456...?hidePinnedComments=true
+```

--- a/pkg/spxrpc/place_stream_moderation.go
+++ b/pkg/spxrpc/place_stream_moderation.go
@@ -376,25 +376,6 @@ func (s *Server) handlePlaceStreamModerationCreatePin(ctx context.Context, input
 		return nil, err
 	}
 
-	// Check that the streamer has an active livestream
-	ls, err := s.model.GetLatestLivestreamForRepo(input.Streamer)
-	if err != nil {
-		log.Error(ctx, "failed to get livestream for streamer", "err", err)
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, "failed to check livestream status")
-	}
-	if ls == nil || ls.Livestream == nil {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "no active livestream for this streamer")
-	}
-	lsRec, err := lexutil.CborDecodeValue(*ls.Livestream)
-	if err != nil {
-		log.Error(ctx, "failed to decode livestream record", "err", err)
-		return nil, echo.NewHTTPError(http.StatusInternalServerError, "failed to check livestream status")
-	}
-	lsTyped, ok := lsRec.(*streamplace.Livestream)
-	if ok && lsTyped.EndedAt != nil {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "livestream has ended, cannot pin comments")
-	}
-
 	// Delete existing pinned records for this streamer (single-pin semantics)
 	var listOutput comatproto.RepoListRecords_Output
 	err = modCtx.StreamerClient.Do(ctx, xrpc.Query, "application/json", "com.atproto.repo.listRecords",

--- a/pkg/spxrpc/place_stream_moderation.go
+++ b/pkg/spxrpc/place_stream_moderation.go
@@ -376,34 +376,7 @@ func (s *Server) handlePlaceStreamModerationCreatePin(ctx context.Context, input
 		return nil, err
 	}
 
-	// Delete existing pinned records for this streamer (single-pin semantics)
-	var listOutput comatproto.RepoListRecords_Output
-	err = modCtx.StreamerClient.Do(ctx, xrpc.Query, "application/json", "com.atproto.repo.listRecords",
-		map[string]any{
-			"repo":       input.Streamer,
-			"collection": constants.PLACE_STREAM_CHAT_PINNED_RECORD,
-		}, nil, &listOutput)
-	if err != nil {
-		log.Error(ctx, "failed to list existing pinned records", "err", err)
-	} else {
-		for _, rec := range listOutput.Records {
-			rkey, delErr := extractRKey(rec.Uri)
-			if delErr != nil {
-				continue
-			}
-			deleteInput := comatproto.RepoDeleteRecord_Input{
-				Collection: constants.PLACE_STREAM_CHAT_PINNED_RECORD,
-				Rkey:       rkey,
-				Repo:       input.Streamer,
-			}
-			deleteOutput := comatproto.RepoDeleteRecord_Output{}
-			if err := modCtx.StreamerClient.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.deleteRecord", map[string]any{}, deleteInput, &deleteOutput); err != nil {
-				log.Error(ctx, "failed to delete existing pinned record", "rkey", rkey, "err", err)
-			}
-		}
-	}
-
-	// Create the pinned record
+	// Create the pinned record (old pins persist as history)
 	pinnedRecord := &streamplace.ChatPinnedRecord{
 		LexiconTypeID: "place.stream.chat.pinnedRecord",
 		PinnedMessage: input.MessageUri,


### PR DESCRIPTION
Adds option to delegate pins to moderators, plus have previous pins in the repo (but still only display the last one).