### PR TITLE
Add stream.received webhook event

### DIFF
--- a/js/app/components/settings/webhook-manager.tsx
+++ b/js/app/components/settings/webhook-manager.tsx
@@ -75,9 +75,25 @@ interface WebhookFormData {
   description: string;
 }
 
+type WebhookEvent =
+  | "livestream"
+  | "chat"
+  | "follow"
+  | "mention"
+  | "stream.received";
+
+const VALID_WEBHOOK_EVENTS: WebhookEvent[] = [
+  "livestream",
+  "chat",
+  "follow",
+  "mention",
+  "stream.received",
+];
+
 const EVENT_OPTIONS = [
   { value: "livestream", labelKey: "events-livestream" },
   { value: "chat", labelKey: "events-chat" },
+  { value: "stream.received", labelKey: "events-stream-received" },
 ];
 
 function WebhookRow({
@@ -631,13 +647,13 @@ export default function WebhookManager() {
       const response = await agent.place.stream.server.listWebhooks({
         limit: 50,
       });
-      // if not type "livestream" | "chat" | "follow" | "mention"[] just return
+      // Filter out unknown event types returned by the server.
       // todo: find a better way to check this
       if (response.data.webhooks) {
         for (const webhook of response.data.webhooks) {
           webhook.events = (webhook.events as string[]).filter((event) =>
-            ["livestream", "chat", "follow", "mention"].includes(event),
-          ) as ("livestream" | "chat" | "follow" | "mention")[];
+            VALID_WEBHOOK_EVENTS.includes(event as WebhookEvent),
+          ) as WebhookEvent[];
         }
       }
       setWebhooks((response.data.webhooks as any) || []);
@@ -663,7 +679,7 @@ export default function WebhookManager() {
       await agent.place.stream.server.createWebhook({
         name: data.name || undefined,
         url: data.url,
-        events: data.events as ("livestream" | "chat" | "follow" | "mention")[],
+        events: data.events as WebhookEvent[],
         active: data.active,
         prefix: data.prefix || undefined,
         suffix: data.suffix || undefined,
@@ -700,7 +716,7 @@ export default function WebhookManager() {
         id: editingWebhook.id,
         name: data.name || undefined,
         url: data.url,
-        events: data.events as ("livestream" | "chat" | "follow" | "mention")[],
+        events: data.events as WebhookEvent[],
         active: data.active,
         prefix: data.prefix || undefined,
         suffix: data.suffix || undefined,

--- a/js/components/locales/en-US/settings.ftl
+++ b/js/components/locales/en-US/settings.ftl
@@ -145,6 +145,7 @@ activates-on = Activates on:
 events = Events
 events-livestream = Livestream Events
 events-chat = Chat Events
+events-stream-received = Stream Received Events
 untitled-webhook = Untitled Webhook
 inactive = Inactive
 active = Active

--- a/js/docs/src/content/docs/lex-reference/openapi.json
+++ b/js/docs/src/content/docs/lex-reference/openapi.json
@@ -619,7 +619,13 @@
                     "description": "The types of events this webhook should receive.",
                     "items": {
                       "type": "string",
-                      "enum": ["chat", "livestream", "follow", "mention"]
+                      "enum": [
+                        "chat",
+                        "livestream",
+                        "follow",
+                        "mention",
+                        "stream.received"
+                      ]
                     }
                   },
                   "active": {
@@ -976,7 +982,13 @@
             "schema": {
               "type": "string",
               "description": "Filter webhooks that handle this event type.",
-              "enum": ["chat", "livestream", "follow", "mention"]
+              "enum": [
+                "chat",
+                "livestream",
+                "follow",
+                "mention",
+                "stream.received"
+              ]
             }
           }
         ]
@@ -1059,7 +1071,13 @@
                     "description": "The types of events this webhook should receive.",
                     "items": {
                       "type": "string",
-                      "enum": ["chat", "livestream", "follow", "mention"]
+                      "enum": [
+                        "chat",
+                        "livestream",
+                        "follow",
+                        "mention",
+                        "stream.received"
+                      ]
                     }
                   },
                   "active": {
@@ -6008,7 +6026,13 @@
             "description": "The types of events this webhook should receive.",
             "items": {
               "type": "string",
-              "enum": ["chat", "livestream", "follow", "mention"]
+              "enum": [
+                "chat",
+                "livestream",
+                "follow",
+                "mention",
+                "stream.received"
+              ]
             }
           },
           "active": {

--- a/js/docs/src/content/docs/lex-reference/server/place-stream-server-createwebhook.md
+++ b/js/docs/src/content/docs/lex-reference/server/place-stream-server-createwebhook.md
@@ -80,7 +80,13 @@ Create a new webhook for receiving Streamplace events.
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["chat", "livestream", "follow", "mention"]
+                "enum": [
+                  "chat",
+                  "livestream",
+                  "follow",
+                  "mention",
+                  "stream.received"
+                ]
               },
               "description": "The types of events this webhook should receive."
             },

--- a/js/docs/src/content/docs/lex-reference/server/place-stream-server-defs.md
+++ b/js/docs/src/content/docs/lex-reference/server/place-stream-server-defs.md
@@ -93,7 +93,13 @@ S3 storage configuration for backups.
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["chat", "livestream", "follow", "mention"]
+            "enum": [
+              "chat",
+              "livestream",
+              "follow",
+              "mention",
+              "stream.received"
+            ]
           },
           "description": "The types of events this webhook should receive."
         },

--- a/js/docs/src/content/docs/lex-reference/server/place-stream-server-listwebhooks.md
+++ b/js/docs/src/content/docs/lex-reference/server/place-stream-server-listwebhooks.md
@@ -17,12 +17,12 @@ List webhooks for the authenticated user.
 
 **Parameters:**
 
-| Name     | Type      | Req'd | Description                                  | Constraints                                     |
-| -------- | --------- | ----- | -------------------------------------------- | ----------------------------------------------- |
-| `limit`  | `integer` | ❌    | The number of webhooks to return.            | Min: 1<br/>Max: 100<br/>Default: `50`           |
-| `cursor` | `string`  | ❌    | An optional cursor for pagination.           |                                                 |
-| `active` | `boolean` | ❌    | Filter webhooks by active status.            |                                                 |
-| `event`  | `string`  | ❌    | Filter webhooks that handle this event type. | Enum: `chat`, `livestream`, `follow`, `mention` |
+| Name     | Type      | Req'd | Description                                  | Constraints                                                        |
+| -------- | --------- | ----- | -------------------------------------------- | ------------------------------------------------------------------ |
+| `limit`  | `integer` | ❌    | The number of webhooks to return.            | Min: 1<br/>Max: 100<br/>Default: `50`                              |
+| `cursor` | `string`  | ❌    | An optional cursor for pagination.           |                                                                    |
+| `active` | `boolean` | ❌    | Filter webhooks by active status.            |                                                                    |
+| `event`  | `string`  | ❌    | Filter webhooks that handle this event type. | Enum: `chat`, `livestream`, `follow`, `mention`, `stream.received` |
 
 **Output:**
 
@@ -72,7 +72,13 @@ List webhooks for the authenticated user.
           },
           "event": {
             "type": "string",
-            "enum": ["chat", "livestream", "follow", "mention"],
+            "enum": [
+              "chat",
+              "livestream",
+              "follow",
+              "mention",
+              "stream.received"
+            ],
             "description": "Filter webhooks that handle this event type."
           }
         }

--- a/js/docs/src/content/docs/lex-reference/server/place-stream-server-updatewebhook.md
+++ b/js/docs/src/content/docs/lex-reference/server/place-stream-server-updatewebhook.md
@@ -86,7 +86,13 @@ Update an existing webhook configuration.
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["chat", "livestream", "follow", "mention"]
+                "enum": [
+                  "chat",
+                  "livestream",
+                  "follow",
+                  "mention",
+                  "stream.received"
+                ]
               },
               "description": "The types of events this webhook should receive."
             },

--- a/lexicons/place/stream/server/createWebhook.json
+++ b/lexicons/place/stream/server/createWebhook.json
@@ -21,7 +21,13 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["chat", "livestream", "follow", "mention"]
+                "enum": [
+                  "chat",
+                  "livestream",
+                  "follow",
+                  "mention",
+                  "stream.received"
+                ]
               },
               "description": "The types of events this webhook should receive."
             },

--- a/lexicons/place/stream/server/defs.json
+++ b/lexicons/place/stream/server/defs.json
@@ -20,7 +20,13 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["chat", "livestream", "follow", "mention"]
+            "enum": [
+              "chat",
+              "livestream",
+              "follow",
+              "mention",
+              "stream.received"
+            ]
           },
           "description": "The types of events this webhook should receive."
         },

--- a/lexicons/place/stream/server/listWebhooks.json
+++ b/lexicons/place/stream/server/listWebhooks.json
@@ -25,7 +25,13 @@
           },
           "event": {
             "type": "string",
-            "enum": ["chat", "livestream", "follow", "mention"],
+            "enum": [
+              "chat",
+              "livestream",
+              "follow",
+              "mention",
+              "stream.received"
+            ],
             "description": "Filter webhooks that handle this event type."
           }
         }

--- a/lexicons/place/stream/server/updateWebhook.json
+++ b/lexicons/place/stream/server/updateWebhook.json
@@ -25,7 +25,13 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "enum": ["chat", "livestream", "follow", "mention"]
+                "enum": [
+                  "chat",
+                  "livestream",
+                  "follow",
+                  "mention",
+                  "stream.received"
+                ]
               },
               "description": "The types of events this webhook should receive."
             },

--- a/pkg/director/stream_session.go
+++ b/pkg/director/stream_session.go
@@ -38,18 +38,19 @@ import (
 )
 
 type StreamSession struct {
-	mm             *media.MediaManager
-	mod            model.Model
-	cli            *config.CLI
-	bus            *bus.Bus
-	op             *oatproxy.OATProxy
-	lp             *livepeer.LivepeerSession
-	repoDID        string
-	segmentChan    chan struct{}
-	lastStatus     time.Time
-	lastStatusCID  *string
-	lastOriginTime time.Time
-	localDB        localdb.LocalDB
+	mm                     *media.MediaManager
+	mod                    model.Model
+	cli                    *config.CLI
+	bus                    *bus.Bus
+	op                     *oatproxy.OATProxy
+	lp                     *livepeer.LivepeerSession
+	repoDID                string
+	segmentChan            chan struct{}
+	lastStatus             time.Time
+	lastStatusCID          *string
+	lastOriginTime         time.Time
+	localDB                localdb.LocalDB
+	streamReceivedNotified bool
 
 	// Channels for background workers
 	statusUpdateChan     chan struct{} // Signal to update status
@@ -240,6 +241,21 @@ func (ss *StreamSession) NewSegment(ctx context.Context, notif *media.NewSegment
 	spseg, err := notif.Segment.ToStreamplaceSegment()
 	if err != nil {
 		return fmt.Errorf("could not convert segment to streamplace segment: %w", err)
+	}
+
+	// stream.received is enqueued once per StreamSession when the first local media segment is accepted.
+	if notif.Local && !ss.streamReceivedNotified {
+		ss.streamReceivedNotified = true
+		ss.Go(ctx, func() error {
+			task := &statedb.StreamReceivedTask{
+				StreamerDID: spseg.Creator,
+			}
+			_, err := ss.statefulDB.EnqueueTask(ctx, statedb.TaskStreamReceived, task, statedb.WithTaskKey(fmt.Sprintf("stream-received::%s::%s", spseg.Creator, notif.Segment.ID)))
+			if err != nil {
+				log.Error(ctx, "failed to enqueue stream.received task", "err", err)
+			}
+			return nil
+		})
 	}
 
 	// Record to S3 for live-to-VOD only while the stream is live (an un-ended

--- a/pkg/integrations/discord/send-stream-received.go
+++ b/pkg/integrations/discord/send-stream-received.go
@@ -1,0 +1,52 @@
+package discord
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"stream.place/streamplace/pkg/aqhttp"
+	"stream.place/streamplace/pkg/integrations/discord/discordtypes"
+)
+
+func SendStreamReceived(ctx context.Context, w *discordtypes.Webhook, streamerDID string) error {
+	content := fmt.Sprintf("stream.received %s", streamerDID)
+	for _, rewrite := range w.Rewrite {
+		content = strings.ReplaceAll(content, rewrite.From, rewrite.To)
+	}
+
+	payload := discordtypes.Payload{
+		Content: fmt.Sprintf("%s%s%s", w.Prefix, content, w.Suffix),
+	}
+
+	jsonPayload, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", w.URL, bytes.NewReader(jsonPayload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := aqhttp.Do(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %w", err)
+		}
+		return fmt.Errorf("failed to send request (http %d): %s", resp.StatusCode, string(body))
+	}
+
+	return nil
+}

--- a/pkg/integrations/webhook/manager.go
+++ b/pkg/integrations/webhook/manager.go
@@ -44,6 +44,16 @@ func SendLivestreamWebhook(ctx context.Context, webhook *streamplace.ServerDefs_
 	return discord.SendLivestream(ctx, discordWebhook, pdsURL, lsv, postView, spcp)
 }
 
+// SendStreamReceivedWebhook sends a stream.received event to a specific webhook.
+func SendStreamReceivedWebhook(ctx context.Context, webhook *streamplace.ServerDefs_Webhook, streamerDID string) error {
+	discordWebhook, err := webhookToDiscordWebhook(webhook)
+	if err != nil {
+		return fmt.Errorf("failed to convert webhook: %w", err)
+	}
+
+	return discord.SendStreamReceived(ctx, discordWebhook, streamerDID)
+}
+
 // webhookToDiscordWebhook converts streamplace.ServerDefs_Webhook to discordtypes.Webhook
 func webhookToDiscordWebhook(webhook *streamplace.ServerDefs_Webhook) (*discordtypes.Webhook, error) {
 	var rewriteRules []*discordtypes.WebhookRewrite

--- a/pkg/statedb/queue_processor.go
+++ b/pkg/statedb/queue_processor.go
@@ -24,6 +24,7 @@ import (
 
 var TaskNotification = "notification"
 var TaskChat = "chat"
+var TaskStreamReceived = "stream_received"
 var TaskFinalizeLivestream = "finalize_livestream"
 var TaskFinalizeLivestreamVOD = "finalize_livestream_vod"
 var TaskVODProcess = "vod_process"
@@ -38,6 +39,7 @@ var TaskViewCountAggregate = "view_count_aggregate"
 var nonVODTaskTypes = []string{
 	TaskNotification,
 	TaskChat,
+	TaskStreamReceived,
 	TaskFinalizeLivestream,
 	TaskViewCountAggregate,
 }
@@ -51,6 +53,10 @@ type NotificationTask struct {
 
 type ChatTask struct {
 	MessageView *streamplace.ChatDefs_MessageView
+}
+
+type StreamReceivedTask struct {
+	StreamerDID string `json:"streamerDID"`
 }
 
 type FinalizeLivestreamTask struct {
@@ -154,6 +160,8 @@ func (state *StatefulDB) processTask(ctx context.Context, task *AppTask) error {
 		return state.processNotificationTask(ctx, task)
 	case TaskChat:
 		return state.processChatMessageTask(ctx, task)
+	case TaskStreamReceived:
+		return state.processStreamReceivedTask(ctx, task)
 	case TaskFinalizeLivestream:
 		return state.processFinalizeLivestreamTask(ctx, task)
 	case TaskVODProcess:
@@ -479,6 +487,42 @@ func (state *StatefulDB) processNotificationTask(ctx context.Context, task *AppT
 				}
 			}(lexiconWebhook, w.ID)
 		}
+	}
+	return nil
+}
+
+func (state *StatefulDB) processStreamReceivedTask(ctx context.Context, task *AppTask) error {
+	var streamReceivedTask StreamReceivedTask
+	if err := json.Unmarshal(task.Payload, &streamReceivedTask); err != nil {
+		return err
+	}
+
+	webhooks, err := state.GetActiveWebhooksForUser(streamReceivedTask.StreamerDID, "stream.received")
+	if err != nil {
+		return fmt.Errorf("failed to get stream.received webhooks: %w", err)
+	}
+	for _, w := range webhooks {
+		lexiconWebhook, err := w.ToLexicon()
+		if err != nil {
+			log.Error(ctx, "failed to convert webhook to lexicon", "err", err, "webhook_id", w.ID)
+			continue
+		}
+		go func(lexiconWebhook *streamplace.ServerDefs_Webhook, wid string) {
+			err := webhook.SendStreamReceivedWebhook(ctx, lexiconWebhook, streamReceivedTask.StreamerDID)
+			if err != nil {
+				log.Error(ctx, "failed to send stream.received webhook", "err", err, "webhook_id", wid)
+				err = state.IncrementWebhookError(wid)
+				if err != nil {
+					log.Error(ctx, "failed to increment webhook error count", "err", err, "webhook_id", wid)
+				}
+			} else {
+				log.Log(ctx, "sent stream.received webhook", "webhook_id", wid)
+				err = state.ResetWebhookError(wid)
+				if err != nil {
+					log.Error(ctx, "failed to reset webhook error count", "err", err, "webhook_id", wid)
+				}
+			}
+		}(lexiconWebhook, w.ID)
 	}
 	return nil
 }

--- a/pkg/statedb/webhook_test.go
+++ b/pkg/statedb/webhook_test.go
@@ -25,6 +25,24 @@ func TestWebhookCreation(t *testing.T) {
 	})
 }
 
+func TestWebhookStreamReceivedEventLookup(t *testing.T) {
+	WithAllDatabases(t, func(state *StatefulDB) {
+		webhook := &Webhook{
+			UserDID: "did:web:example.com",
+			URL:     "https://example.com",
+			Events:  []byte(`["stream.received"]`),
+			Active:  true,
+		}
+		err := state.CreateWebhook(webhook)
+		require.NoError(t, err)
+
+		activeWebhooks, err := state.GetActiveWebhooksForUser("did:web:example.com", "stream.received")
+		require.NoError(t, err)
+		require.Len(t, activeWebhooks, 1)
+		require.Equal(t, webhook.URL, activeWebhooks[0].URL)
+	})
+}
+
 func TestWebhookUpdatePartially(t *testing.T) {
 	WithAllDatabases(t, func(state *StatefulDB) {
 		webhook := &Webhook{


### PR DESCRIPTION
**Summary**

Adds a new stream.received webhook event that is enqueued once per StreamSession when the first local media segment is accepted.

This is intended to let integrations react when media has actually started arriving, without waiting for a published livestream record.

Changes included:

Add stream.received to webhook lexicon event enums.
Expose stream.received in the webhook settings UI.
Enqueue a stream_received task after a local segment is accepted.
Send the event through the existing webhook manager / Discord-shaped webhook sender path.
Add a statedb test for looking up active stream.received webhooks.
**Notes**

The event is enqueued once per StreamSession using a session-local guard. Delivery follows the existing webhook task behavior.

**Testing**

Focused package tests passed:

PKG_CONFIG_PATH=/home/ecash/dev/streamplace/build-linux-amd64/lib/pkgconfig:/home/ecash/dev/streamplace/build-linux-amd64/lib/gstreamer-1.0/pkgconfig:/home/ecash/dev/streamplace/build-linux-amd64/meson-uninstalled LD_LIBRARY_PATH=/home/ecash/dev/streamplace/build-linux-amd64/lib CGO_LDFLAGS="-lm" go test ./pkg/director ./pkg/statedb ./pkg/integrations/webhook ./pkg/integrations/discord

Result:

ok stream.place/streamplace/pkg/director
ok stream.place/streamplace/pkg/statedb
? stream.place/streamplace/pkg/integrations/webhook [no test files]
? stream.place/streamplace/pkg/integrations/discord [no test files]

Full make dev-test was attempted locally but blocked by an existing local GStreamer runtime issue in pkg/multitest:

failed to create appsrc element: could not create element: appsrc