### PR TITLE
Fix webhook event label rendering

### DIFF
--- a/js/app/components/settings/webhook-manager.tsx
+++ b/js/app/components/settings/webhook-manager.tsx
@@ -96,6 +96,15 @@ const EVENT_OPTIONS = [
   { value: "stream.received", labelKey: "events-stream-received" },
 ];
 
+const EVENT_LABEL_KEYS = new Map(
+  EVENT_OPTIONS.map((option) => [option.value, option.labelKey]),
+);
+
+function getEventLabel(t: (key: string) => string, event: string) {
+  const labelKey = EVENT_LABEL_KEYS.get(event);
+  return labelKey ? t(labelKey) : event;
+}
+
 function WebhookRow({
   webhook,
   onEdit,
@@ -168,7 +177,7 @@ function WebhookRow({
               key={event}
               style={[z.bg.muted, zero.px[2], zero.py[1], zero.r.full]}
             >
-              <Text size="sm">{t(`events-${event}`)}</Text>
+              <Text size="sm">{getEventLabel(t, event)}</Text>
             </View>
           ))}
         </View>


### PR DESCRIPTION
## Summary

Fixes a frontend crash in the webhook settings page when rendering saved webhook event labels for event values containing dots, such as `stream.received`.

The backend event value is unchanged. This only updates the UI label lookup to use the existing event option label keys instead of deriving an i18n key directly from the raw event value.

## Testing

- Ran `pnpm run check` from `js/app`