### PR TITLE
fix: WebRTC frame loss at keyframes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -364,6 +364,7 @@ require (
 	github.com/kolesa-team/go-webp v1.0.5 // indirect
 	github.com/kulti/thelper v0.6.3 // indirect
 	github.com/kunwardeep/paralleltest v1.0.14 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/lasiar/canonicalheader v1.1.2 // indirect
 	github.com/ldez/exptostd v0.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1372,8 +1372,6 @@ github.com/streamplace/atmoq/go v0.0.4-0.20260701223355-13757de4ae08 h1:NiTRz8AX
 github.com/streamplace/atmoq/go v0.0.4-0.20260701223355-13757de4ae08/go.mod h1:3P8eSwKAGH7uh3SX5z1jlt/JgPTilJTUZngQJKhWY5s=
 github.com/streamplace/atproto-oauth-golang v0.0.0-20260413212710-98956064d06c h1:IzEPU2O4iL58Nb7aw+7lB9ttnesEwOVVE5oV9NEXemM=
 github.com/streamplace/atproto-oauth-golang v0.0.0-20260413212710-98956064d06c/go.mod h1:9LlKkqciiO5lRfbX0n4Wn5KNY9nvFb4R3by8FdW2TWc=
-github.com/streamplace/glex v0.0.0-20260715231618-ee553e32d7c7 h1:MSBBIH+QMR9AVfC0RuBLbBm/o1RAl7+bacek7txswDo=
-github.com/streamplace/glex v0.0.0-20260715231618-ee553e32d7c7/go.mod h1:LRaoeSMvSgOrhFX8s7ygjRlyka7wXdDa1s7JJ9o1IzY=
 github.com/streamplace/glex v0.0.0-20260716203108-f73ed7cc31c9 h1:HbIhx8i7wytiNg9mWg2EuHG59r8FXTVlDqlkZObjqbQ=
 github.com/streamplace/glex v0.0.0-20260716203108-f73ed7cc31c9/go.mod h1:LRaoeSMvSgOrhFX8s7ygjRlyka7wXdDa1s7JJ9o1IzY=
 github.com/streamplace/go-dpop v0.0.0-20250510031900-c897158a8ad4 h1:L1fS4HJSaAyNnkwfuZubgfeZy8rkWmA0cMtH5Z0HqNc=

--- a/pkg/bus/segchanman.go
+++ b/pkg/bus/segchanman.go
@@ -45,7 +45,9 @@ func (b *Bus) SubscribeSegment(ctx context.Context, user string, rendition strin
 }
 
 // get a channel to subscribe to new segments for a given user and rendition,
-// starting with bufSize cached segments that we already have
+// starting with bufSize cached segments that we already have. The channel is
+// buffered (chanSize) and preloaded with the cached segments, oldest first, so
+// a new player joins with a warmup buffer instead of at the bare live edge.
 func (b *Bus) SubscribeSegmentBuf(ctx context.Context, user string, rendition string, bufSize int) *SegChan {
 	key := segChanKey(user, rendition)
 	b.segChansMutex.Lock()
@@ -55,17 +57,16 @@ func (b *Bus) SubscribeSegmentBuf(ctx context.Context, user string, rendition st
 		chs = []*SegChan{}
 		b.segChans[key] = chs
 	}
-	ch := make(chan *Seg)
+	ch := make(chan *Seg, chanSize)
 	b.segBufMutex.RLock()
 	defer b.segBufMutex.RUnlock()
 	curBuf, ok := b.segBuf[key]
-	myCh := make(chan *Seg, chanSize)
 	if ok {
 		if bufSize > len(curBuf) {
 			bufSize = len(curBuf)
 		}
 		for i := 0; i < bufSize; i += 1 {
-			myCh <- curBuf[len(curBuf)-bufSize+i]
+			ch <- curBuf[len(curBuf)-bufSize+i]
 		}
 	}
 	segChan := &SegChan{C: ch, Context: ctx}
@@ -94,6 +95,11 @@ func (b *Bus) UnsubscribeSegment(ctx context.Context, user string, rendition str
 	b.segChans[key] = chs
 }
 
+// PublishSegment fans a segment out to every subscriber of the user+rendition
+// and folds it into the replay buffer new subscribers warm up from. Delivery
+// order per subscriber is always publish call order: sends are non-blocking
+// into buffered channels under the publish mutex, with no per-publish
+// goroutines that could complete out of order.
 func (b *Bus) PublishSegment(ctx context.Context, user string, rendition string, seg *Seg) {
 	ctx, span := otel.Tracer("signer").Start(ctx, "PublishSegment")
 	defer span.End()
@@ -117,16 +123,25 @@ func (b *Bus) PublishSegment(ctx context.Context, user string, rendition string,
 		return
 	}
 	for _, ch := range chs {
-		go func(segChan *SegChan) {
+		// Non-blocking under the publish mutex: subscriber channels are
+		// buffered, so delivery order is always publish order. A subscriber a
+		// full buffer behind loses its oldest queued segment instead of the
+		// live edge — with ordered delivery a skip recovers at the next
+		// keyframe, while falling ever further behind does not.
+		select {
+		case ch.C <- seg:
+		default:
 			select {
-			case segChan.C <- seg:
-			case <-segChan.Context.Done():
-				return
-			case <-time.After(1 * time.Minute):
-				log.Warn(ctx, "failed to send segment to channel, timing out", "user", user, "rendition", rendition)
+			case <-ch.C:
+			default:
 			}
-
-		}(ch)
+			select {
+			case ch.C <- seg:
+			default:
+			}
+			spmetrics.SegmentPublishDropped.WithLabelValues(user, rendition).Inc()
+			log.Warn(ctx, "subscriber a full buffer behind, dropped its oldest segment", "user", user, "rendition", rendition)
+		}
 	}
 }
 

--- a/pkg/bus/segchanman_test.go
+++ b/pkg/bus/segchanman_test.go
@@ -1,0 +1,67 @@
+package bus
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func publishSegments(b *Bus, user, rendition string, n, start int) {
+	for i := start; i < start+n; i++ {
+		b.PublishSegment(context.Background(), user, rendition, &Seg{Filepath: fmt.Sprintf("seg-%05d", i)})
+	}
+}
+
+func receiveSegments(t *testing.T, ch *SegChan, n int) []*Seg {
+	t.Helper()
+	out := []*Seg{}
+	for len(out) < n {
+		select {
+		case seg := <-ch.C:
+			out = append(out, seg)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for segment %d of %d", len(out)+1, n)
+		}
+	}
+	return out
+}
+
+// A subscriber that joins after segments were published gets the last bufSize
+// cached segments replayed, oldest first — the warmup buffer WebRTC playback
+// relies on.
+func TestSubscribeSegmentBufReplaysCachedSegments(t *testing.T) {
+	b := NewBus()
+	publishSegments(b, "user", "source", 5, 0)
+	segChan := b.SubscribeSegmentBuf(context.Background(), "user", "source", 2)
+	segs := receiveSegments(t, segChan, 2)
+	require.Equal(t, "seg-00003", segs[0].Filepath)
+	require.Equal(t, "seg-00004", segs[1].Filepath)
+}
+
+// Segments published back-to-back — faster than any reader drains — are
+// delivered in publish order. The old per-subscriber goroutine fanout over an
+// unbuffered channel made this a scheduling coin flip.
+func TestPublishSegmentDeliversInOrder(t *testing.T) {
+	b := NewBus()
+	segChan := b.SubscribeSegment(context.Background(), "user", "source")
+	publishSegments(b, "user", "source", 500, 0)
+	segs := receiveSegments(t, segChan, 500)
+	for i, seg := range segs {
+		require.Equal(t, fmt.Sprintf("seg-%05d", i), seg.Filepath)
+	}
+}
+
+// A subscriber that falls a full buffer behind loses its oldest queued
+// segments, not the live edge: with ordered delivery a skip recovers at the
+// next keyframe, while falling ever-further behind does not.
+func TestPublishSegmentDropsOldestForLaggingSubscriber(t *testing.T) {
+	b := NewBus()
+	segChan := b.SubscribeSegment(context.Background(), "user", "source")
+	publishSegments(b, "user", "source", chanSize+2, 0)
+	segs := receiveSegments(t, segChan, chanSize)
+	require.Equal(t, "seg-00002", segs[0].Filepath)
+	require.Equal(t, fmt.Sprintf("seg-%05d", chanSize+1), segs[chanSize-1].Filepath)
+}

--- a/pkg/director/director.go
+++ b/pkg/director/director.go
@@ -76,7 +76,6 @@ func (d *Director) Start(ctx context.Context) error {
 					bus:         d.bus,
 					segmentChan: make(chan struct{}),
 					op:          d.op,
-					packets:     make([]bus.PacketizedSegment, 0),
 					started:     make(chan struct{}),
 					statefulDB:  d.statefulDB,
 					replicator:  d.replicator,

--- a/pkg/director/stream_session.go
+++ b/pkg/director/stream_session.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -63,10 +64,19 @@ type StreamSession struct {
 	g          *errgroup.Group
 	started    chan struct{}
 	ctx        context.Context
-	packets    []bus.PacketizedSegment
 	statefulDB *statedb.StatefulDB
 	replicator replication.Replicator
 	atsync     *atproto.ATProtoSynchronizer
+
+	// playbackWorkers holds one ordered packetize+publish queue per rendition.
+	// Packetizing a segment spins up a full gst pipeline (~100-400ms, high
+	// variance); feeding segments to subscribers from per-segment goroutines
+	// let segment N+1 publish before segment N, which WebRTC playback — a
+	// strict arrival-order consumer — showed as frame loss at every keyframe.
+	playbackWorkers   map[string]chan playbackJob
+	playbackWorkersMu sync.Mutex
+	// addToWebRTCFn is a test seam; nil means AddToWebRTC.
+	addToWebRTCFn func(ctx context.Context, spseg *placestream.Segment, rendition string, seg *bus.Seg) error
 
 	lastLivestreamTime time.Time
 	lastViewCountTime  time.Time
@@ -274,13 +284,11 @@ func (ss *StreamSession) NewSegment(ctx context.Context, notif *media.NewSegment
 	}
 
 	ss.bus.Publish(spseg.Creator, spseg)
-	ss.Go(ctx, func() error {
-		return ss.AddPlaybackSegment(ctx, spseg, "source", &bus.Seg{
-			Filepath:  notif.Segment.ID,
-			Data:      notif.Data,
-			Muxl:      notif.Muxl,
-			Published: notif.Metadata.Published,
-		})
+	ss.AddPlaybackSegment(ctx, spseg, "source", &bus.Seg{
+		Filepath:  notif.Segment.ID,
+		Data:      notif.Data,
+		Muxl:      notif.Muxl,
+		Published: notif.Metadata.Published,
 	})
 
 	if notif.Local {
@@ -875,22 +883,86 @@ func (ss *StreamSession) Transcode(ctx context.Context, spseg *placestream.Segme
 		if err != nil {
 			return fmt.Errorf("failed to write transcoded segment file: %w", err)
 		}
-		ss.Go(ctx, func() error {
-			return ss.AddPlaybackSegment(ctx, spseg, rs[i].Name, &bus.Seg{
-				Filepath: fd.Name(),
-				Data:     seg,
-			})
+		// NOTE: renditions from concurrent Transcode calls can still enqueue
+		// out of segment order (transcode latency varies per segment); the
+		// ordered worker only guarantees publish order == enqueue order.
+		ss.AddPlaybackSegment(ctx, spseg, rs[i].Name, &bus.Seg{
+			Filepath: fd.Name(),
+			Data:     seg,
 		})
 
 	}
 	return nil
 }
 
-func (ss *StreamSession) AddPlaybackSegment(ctx context.Context, spseg *placestream.Segment, rendition string, seg *bus.Seg) error {
-	ss.Go(ctx, func() error {
-		return ss.AddToWebRTC(ctx, spseg, rendition, seg)
-	})
-	return nil
+// playbackJob is one segment awaiting packetization + publish on its
+// rendition's ordered queue. ctx is the caller's (director) context — it
+// outlives the session's own cancellation so queued segments can still be
+// packetized while the worker drains on shutdown.
+type playbackJob struct {
+	ctx       context.Context
+	spseg     *placestream.Segment
+	rendition string
+	seg       *bus.Seg
+}
+
+// AddPlaybackSegment queues a segment for packetization + publish to playback
+// subscribers. Each rendition has its own queue and worker, so publish order
+// always equals enqueue order and one rendition's backlog never delays
+// another's. A full queue (packetize wedged for dozens of segments) drops the
+// incoming segment rather than blocking the director's segment loop.
+func (ss *StreamSession) AddPlaybackSegment(ctx context.Context, spseg *placestream.Segment, rendition string, seg *bus.Seg) {
+	ss.playbackWorkersMu.Lock()
+	if ss.playbackWorkers == nil {
+		ss.playbackWorkers = map[string]chan playbackJob{}
+	}
+	q, ok := ss.playbackWorkers[rendition]
+	if !ok {
+		q = make(chan playbackJob, 64)
+		ss.playbackWorkers[rendition] = q
+		ss.g.Go(func() error {
+			return ss.playbackWorker(ss.ctx, rendition, q)
+		})
+	}
+	ss.playbackWorkersMu.Unlock()
+	select {
+	case q <- playbackJob{ctx: ctx, spseg: spseg, rendition: rendition, seg: seg}:
+	case <-ss.ctx.Done():
+	default:
+		spmetrics.PlaybackQueueDropped.WithLabelValues(spseg.Creator, rendition).Inc()
+		log.Error(ctx, "playback queue full, dropping segment", "rendition", rendition, "segID", seg.Filepath)
+	}
+}
+
+// playbackWorker packetizes and publishes one rendition's segments one at a
+// time, in queue order. On session teardown it drains the queue before
+// exiting so the stream's tail still publishes.
+func (ss *StreamSession) playbackWorker(ctx context.Context, rendition string, q chan playbackJob) error {
+	for {
+		select {
+		case <-ctx.Done():
+			for {
+				select {
+				case job := <-q:
+					ss.processPlaybackJob(job)
+				default:
+					return nil
+				}
+			}
+		case job := <-q:
+			ss.processPlaybackJob(job)
+		}
+	}
+}
+
+func (ss *StreamSession) processPlaybackJob(job playbackJob) {
+	fn := ss.addToWebRTCFn
+	if fn == nil {
+		fn = ss.AddToWebRTC
+	}
+	if err := fn(job.ctx, job.spseg, job.rendition, job.seg); err != nil {
+		log.Error(job.ctx, "error in playback worker", "error", err, "rendition", job.rendition)
+	}
 }
 
 func (ss *StreamSession) AddToWebRTC(ctx context.Context, spseg *placestream.Segment, rendition string, seg *bus.Seg) error {

--- a/pkg/director/stream_session_test.go
+++ b/pkg/director/stream_session_test.go
@@ -1,10 +1,20 @@
 package director
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"stream.place/streamplace/pkg/bus"
+	"stream.place/streamplace/pkg/config"
+	"stream.place/streamplace/pkg/placestream"
+	"stream.place/streamplace/pkg/spmetrics"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 func TestExceedsMaxBitrate(t *testing.T) {
@@ -50,4 +60,122 @@ func TestExceedsMaxBitrateMarginBoundary(t *testing.T) {
 	require.False(t, justInside, "8Mbit within 10%% of 7.3Mbit max should not kick")
 	require.True(t, justOutside, "8Mbit beyond 10%% of 7.2Mbit max should kick")
 	require.Equal(t, eightMbit, func() int { r, _ := exceedsMaxBitrate(megabyte, time.Second.Nanoseconds(), 1); return r }())
+}
+
+func newTestStreamSession(t *testing.T) (*StreamSession, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	g, gctx := errgroup.WithContext(ctx)
+	started := make(chan struct{})
+	close(started)
+	ss := &StreamSession{
+		cli:     &config.CLI{},
+		bus:     bus.NewBus(),
+		g:       g,
+		ctx:     gctx,
+		started: started,
+	}
+	return ss, cancel
+}
+
+// Playback segments must be packetized + published strictly in enqueue order:
+// the old ss.Go dispatch ran each segment's packetize concurrently, so a slow
+// segment N could publish after segment N+1 — and WebRTC playback, which
+// consumes segments strictly in arrival order, showed the swap as frame loss
+// at every keyframe.
+func TestPlaybackWorkerPublishesInSegmentOrder(t *testing.T) {
+	ss, cancel := newTestStreamSession(t)
+	segChan := ss.bus.SubscribeSegment(context.Background(), "did:test:streamer", "source")
+	ss.addToWebRTCFn = func(ctx context.Context, spseg *placestream.Segment, rendition string, seg *bus.Seg) error {
+		ss.bus.PublishSegment(ctx, spseg.Creator, rendition, seg)
+		return nil
+	}
+	// under the queue cap so the drop-on-full policy can't fire — this test
+	// isolates ordering
+	const n = 50
+	for i := 0; i < n; i++ {
+		ss.AddPlaybackSegment(context.Background(), &placestream.Segment{Creator: "did:test:streamer"}, "source", &bus.Seg{Filepath: fmt.Sprintf("seg-%05d", i)})
+	}
+	cancel()
+	require.NoError(t, ss.g.Wait())
+	for i := 0; i < n; i++ {
+		select {
+		case seg := <-segChan.C:
+			require.Equal(t, fmt.Sprintf("seg-%05d", i), seg.Filepath)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for segment %d", i)
+		}
+	}
+}
+
+// A wedged packetize pipeline must not stall the director's segment loop:
+// once a rendition's queue is full, new segments for it drop (loudly) instead
+// of blocking enqueue.
+func TestAddPlaybackSegmentDropsWhenQueueFull(t *testing.T) {
+	ss, cancel := newTestStreamSession(t)
+	gate := make(chan struct{})
+	entered := make(chan struct{})
+	var once sync.Once
+	processed := make(chan string, 128)
+	ss.addToWebRTCFn = func(ctx context.Context, spseg *placestream.Segment, rendition string, seg *bus.Seg) error {
+		once.Do(func() { close(entered) })
+		<-gate
+		processed <- seg.Filepath
+		return nil
+	}
+	enqueue := func(i int) {
+		ss.AddPlaybackSegment(context.Background(), &placestream.Segment{Creator: "did:test:streamer"}, "source", &bus.Seg{Filepath: fmt.Sprintf("seg-%05d", i)})
+	}
+	enqueue(0)
+	<-entered // worker now wedged inside packetize; queue empty
+	const queueCap = 64
+	for i := 1; i <= queueCap; i++ {
+		enqueue(i)
+	}
+	enqueue(queueCap + 1) // queue full — this one drops
+	require.Equal(t, float64(1), testutil.ToFloat64(spmetrics.PlaybackQueueDropped.WithLabelValues("did:test:streamer", "source")))
+	close(gate)
+	cancel()
+	require.NoError(t, ss.g.Wait())
+	got := []string{}
+	for {
+		select {
+		case fp := <-processed:
+			got = append(got, fp)
+		default:
+			require.Len(t, got, queueCap+1)
+			require.NotContains(t, got, fmt.Sprintf("seg-%05d", queueCap+1))
+			return
+		}
+	}
+}
+
+// Each rendition gets its own worker: one rendition's wedged queue must not
+// delay another rendition's segments.
+func TestPlaybackWorkersArePerRendition(t *testing.T) {
+	ss, cancel := newTestStreamSession(t)
+	gate := make(chan struct{})
+	entered := make(chan struct{})
+	var once sync.Once
+	processed := make(chan string, 16)
+	ss.addToWebRTCFn = func(ctx context.Context, spseg *placestream.Segment, rendition string, seg *bus.Seg) error {
+		if rendition == "source" {
+			once.Do(func() { close(entered) })
+			<-gate
+		}
+		processed <- rendition + ":" + seg.Filepath
+		return nil
+	}
+	ss.AddPlaybackSegment(context.Background(), &placestream.Segment{Creator: "did:test:streamer"}, "source", &bus.Seg{Filepath: "seg-00000"})
+	<-entered // source worker now wedged
+	ss.AddPlaybackSegment(context.Background(), &placestream.Segment{Creator: "did:test:streamer"}, "other", &bus.Seg{Filepath: "seg-00001"})
+	select {
+	case got := <-processed:
+		require.Equal(t, "other:seg-00001", got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("one rendition's wedged queue blocked another rendition")
+	}
+	close(gate)
+	cancel()
+	require.NoError(t, ss.g.Wait())
 }

--- a/pkg/media/ingest_daemon.go
+++ b/pkg/media/ingest_daemon.go
@@ -296,6 +296,15 @@ func (mm *MediaManager) MKVIngestDetached(ctx context.Context, conn net.Conn, pr
 		_ = proc.Kill()
 	})
 
+	// Same kill semantics as the ban watch above: a newer push for this
+	// streamer replaces this session, and replacement wants the old worker
+	// (and its media connection) dead, not just unconsumed.
+	release := mm.ClaimIngestSession(ms.Streamer(), func(reason string) {
+		log.Warn(ctx, "detached ingest worker: ending stream", "reason", reason, "streamer", ms.Streamer())
+		_ = proc.Kill()
+	})
+	defer release()
+
 	// Refresh the worker's manifest from live model state (pre-live → live), since
 	// it signs with a frozen one otherwise. Fixed start for stable change detection.
 	start := time.Now().UnixMilli()
@@ -473,6 +482,14 @@ func (mm *MediaManager) ResumeDetachedWorkers(ctx context.Context) {
 					log.Warn(wctx, "resumed ingest worker: ending stream", "reason", reason, "streamer", meta.StreamerDID)
 					killWorkerPID(wctx, meta.PID, meta.StreamerDID)
 				})
+				// Re-arm one-session-per-streamer for the resumed worker too (a
+				// metadata-less worker can't be killed by PID, so it can't be
+				// deduped this way).
+				release := mm.ClaimIngestSession(meta.StreamerDID, func(reason string) {
+					log.Warn(wctx, "resumed ingest worker: ending stream", "reason", reason, "streamer", meta.StreamerDID)
+					killWorkerPID(wctx, meta.PID, meta.StreamerDID)
+				})
+				defer release()
 				// Keep refreshing the resumed worker's manifest too (no signer needed —
 				// streamerManifest only uses the model + cli + the sidecar DID).
 				start := time.Now().UnixMilli()

--- a/pkg/media/ingest_session.go
+++ b/pkg/media/ingest_session.go
@@ -1,0 +1,47 @@
+package media
+
+import (
+	"sync"
+
+	"stream.place/streamplace/pkg/spmetrics"
+)
+
+// ingestSession is one streamer's registered live ingest: how to end it (ctx
+// cancel for an in-process pipeline, process kill for a detached worker).
+type ingestSession struct {
+	id  uint64
+	end func(reason string)
+}
+
+// ClaimIngestSession establishes did's single live ingest session, ending any
+// previous one. A streamer has exactly one live ingest: a second push for the
+// same DID is a stale/duplicate connection (an OBS reconnect whose old session
+// is still lingering server-side, or a stray second encoder), and running both
+// mints two segment streams into one stream — duplicate ingest work at best,
+// interleaved media timelines for realtime consumers at worst. The returned
+// release deregisters the session when it ends; it's a no-op if the session
+// was already replaced by a newer one.
+func (mm *MediaManager) ClaimIngestSession(did string, end func(reason string)) (release func()) {
+	mm.ingestSessionsMu.Lock()
+	if mm.ingestSessions == nil {
+		mm.ingestSessions = map[string]*ingestSession{}
+	}
+	s := &ingestSession{id: mm.nextIngestSession(), end: end}
+	prev := mm.ingestSessions[did]
+	mm.ingestSessions[did] = s
+	mm.ingestSessionsMu.Unlock()
+	if prev != nil {
+		spmetrics.IngestSessionsReplaced.WithLabelValues(did).Inc()
+		prev.end("replaced by a newer ingest session")
+	}
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			mm.ingestSessionsMu.Lock()
+			defer mm.ingestSessionsMu.Unlock()
+			if mm.ingestSessions[did] == s {
+				delete(mm.ingestSessions, did)
+			}
+		})
+	}
+}

--- a/pkg/media/ingest_session_test.go
+++ b/pkg/media/ingest_session_test.go
@@ -1,0 +1,47 @@
+package media
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A streamer has exactly one live ingest: claiming a second session for the
+// same DID ends the first, and a displaced session's release can't disturb
+// the session that replaced it.
+func TestClaimIngestSessionEndsPrevious(t *testing.T) {
+	mm := &MediaManager{}
+	var ends1, ends2, ends3 int
+	release1 := mm.ClaimIngestSession("did:test:a", func(reason string) { ends1++ })
+	release2 := mm.ClaimIngestSession("did:test:a", func(reason string) { ends2++ })
+	require.Equal(t, 1, ends1, "displaced session's end should fire exactly once")
+	require.Equal(t, 0, ends2)
+	release1() // already displaced — must not disturb session 2
+	release3 := mm.ClaimIngestSession("did:test:a", func(reason string) { ends3++ })
+	require.Equal(t, 1, ends2, "session 2 should be displaced by session 3")
+	require.Equal(t, 0, ends3)
+	release2() // already displaced — no-op
+	release3()
+	require.Equal(t, 0, ends3, "releasing the current session must not end it")
+}
+
+// Releasing a session deregisters it: the next claim finds no session to end.
+func TestClaimIngestSessionReleaseDeregisters(t *testing.T) {
+	mm := &MediaManager{}
+	release := mm.ClaimIngestSession("did:test:a", func(reason string) {
+		t.Fatal("end fired for a session that had already ended cleanly")
+	})
+	release()
+	release2 := mm.ClaimIngestSession("did:test:a", func(reason string) {})
+	release2()
+}
+
+func TestClaimIngestSessionIndependentStreamers(t *testing.T) {
+	mm := &MediaManager{}
+	releaseA := mm.ClaimIngestSession("did:test:a", func(reason string) {
+		t.Fatal("streamer a's session ended by streamer b's claim")
+	})
+	releaseB := mm.ClaimIngestSession("did:test:b", func(reason string) {})
+	releaseA()
+	releaseB()
+}

--- a/pkg/media/media.go
+++ b/pkg/media/media.go
@@ -85,6 +85,12 @@ type MediaManager struct {
 	// the restarted media timeline into the previous session's continuous encoder.
 	// See withIngestSession / feedStreamTranscoder.
 	ingestSessionSeq atomic.Uint64
+
+	// ingestSessions is the registry enforcing one live ingest session per
+	// streamer: a new push for a DID ends the previous session. Keyed by
+	// repoDID. See ingest_session.go.
+	ingestSessions   map[string]*ingestSession
+	ingestSessionsMu sync.Mutex
 }
 
 // nextIngestSession claims a fresh monotonic ingest-session epoch for a new live

--- a/pkg/media/mist_mkv_ingest_test.go
+++ b/pkg/media/mist_mkv_ingest_test.go
@@ -184,7 +184,6 @@ func TestMKVIngestDualVideoTrack(t *testing.T) {
 	t.Logf("dual-video-track stream: %d segments", segs)
 }
 
-
 // TestMKVIngestMistMetadataTrack: MistServer's MKV push declares a
 // live-metadata track (CodecID M_JSON, TrackType 3) as track 1, ahead of the
 // AAC audio and H264 video tracks. It was the initial suspect for the

--- a/pkg/media/mist_mkv_ingest_test.go
+++ b/pkg/media/mist_mkv_ingest_test.go
@@ -138,6 +138,53 @@ func TestMKVIngestSparseVideoNoWedge(t *testing.T) {
 // the same bytes with the 30-byte M_JSON TrackEntry stripped; tail135 = from
 // 135s (~5s before the keyframe-only transition); full = the whole capture.
 
+// makeDualVideoAACMKV synthesizes an MKV with TWO H264 video tracks plus 48kHz
+// AAC — the shape a multitrack-video (enhanced broadcasting) stream takes once
+// MistServer repackages it for the node's MKV push.
+func makeDualVideoAACMKV(t *testing.T, ctx context.Context, seconds int) []byte {
+	t.Helper()
+	gstinit.InitGST()
+	desc := strings.Join([]string{
+		"matroskamux name=mux streamable=true ! appsink name=sink",
+		fmt.Sprintf("videotestsrc num-buffers=%d pattern=smpte ! video/x-raw,width=640,height=360,framerate=30/1 ! x264enc key-int-max=30 tune=zerolatency speed-preset=ultrafast ! h264parse ! mux.", seconds*30),
+		fmt.Sprintf("videotestsrc num-buffers=%d pattern=ball ! video/x-raw,width=320,height=180,framerate=30/1 ! x264enc key-int-max=30 tune=zerolatency speed-preset=ultrafast ! h264parse ! mux.", seconds*30),
+		fmt.Sprintf("audiotestsrc num-buffers=%d samplesperbuffer=1024 ! audio/x-raw,rate=48000,channels=2 ! audioconvert ! fdkaacenc ! aacparse ! mux.", seconds*47),
+	}, "\n")
+	pipeline, err := gst.NewPipelineFromString(desc)
+	require.NoError(t, err)
+
+	sinkEle, err := pipeline.GetElementByName("sink")
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	app.SinkFromElement(sinkEle).SetCallbacks(&app.SinkCallbacks{
+		NewSampleFunc: WriterNewSample(ctx, &buf),
+	})
+
+	busErr := make(chan error, 1)
+	go func() { busErr <- HandleBusMessages(ctx, pipeline) }()
+	require.NoError(t, pipeline.SetState(gst.StatePlaying))
+	defer func() { _ = pipeline.SetState(gst.StateNull) }()
+	require.NoError(t, <-busErr, "synthesize dual-video MKV")
+	require.NotEmpty(t, buf.Bytes())
+	return buf.Bytes()
+}
+
+// TestMKVIngestDualVideoTrack probes what today's single-video-branch ingest
+// pipeline does with a multitrack-video (enhanced broadcasting) MKV. Until
+// multitrack ingest is actually built, a dual-track push must at least not
+// wedge or kill the session: the second video track should be ignored and the
+// first one segmented like any other stream.
+func TestMKVIngestDualVideoTrack(t *testing.T) {
+	ctx := context.Background()
+	mkv := makeDualVideoAACMKV(t, ctx, 10)
+
+	segs, err := runMKVThroughIngestWorker(t, mkv, true)
+	require.NoError(t, err, "dual-video-track stream ingests without a pipeline error")
+	require.GreaterOrEqual(t, segs, 5, "dual-video-track stream emits its ~1s GoP segments")
+	t.Logf("dual-video-track stream: %d segments", segs)
+}
+
+
 // TestMKVIngestMistMetadataTrack: MistServer's MKV push declares a
 // live-metadata track (CodecID M_JSON, TrackType 3) as track 1, ahead of the
 // AAC audio and H264 video tracks. It was the initial suspect for the

--- a/pkg/media/mkv_ingest.go
+++ b/pkg/media/mkv_ingest.go
@@ -97,9 +97,19 @@ func buildMKVIngestPipeline(ctx context.Context, input io.Reader, signerElem *gs
 	// which downstream makes qtdemux EOS the audio pad early and every segment
 	// fails validation with "no audio in segment". h264timestamper rebuilds
 	// DTS from the H264 picture order count.
+	//
+	// max-reorder-frames=0 (a streamplace vendored property): without it the
+	// element assumes the full DPB size as a reorder delay for any stream
+	// whose SPS lacks VUI parameters — notably VideoToolbox, which writes no
+	// VUI — and mints a spurious constant ctts offset (~0.5s at 60fps, scaled
+	// by a guessed framerate) on streams that never actually reorder. That
+	// offset shifts every GoP's presentation past the flat wrap's edit-list
+	// window, and WebRTC packetize dropped the tail of every segment (frame
+	// loss at every keyframe). B-frames are not supported here, so no stream
+	// should ever get a reorder window.
 	pipelineSlice := []string{
 		"appsrc name=streamsrc ! matroskademux name=demux",
-		"demux. ! " + constants.Queue2Big + " ! h264parse ! h264timestamper name=videoout",
+		"demux. ! " + constants.Queue2Big + " ! h264parse ! h264timestamper max-reorder-frames=0 name=videoout",
 		"demux. ! " + constants.Queue2Big + " ! fdkaacdec ! audioresample ! opusenc name=audioenc",
 	}
 	pipeline, err := gst.NewPipelineFromString(strings.Join(pipelineSlice, "\n"))

--- a/pkg/media/mkv_ingest.go
+++ b/pkg/media/mkv_ingest.go
@@ -36,6 +36,12 @@ func (mm *MediaManager) MKVIngest(ctx context.Context, input io.Reader, ms Media
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	release := mm.ClaimIngestSession(ms.Streamer(), func(reason string) {
+		log.Warn(ctx, "ending ingest session", "reason", reason, "streamer", ms.Streamer())
+		cancel()
+	})
+	defer release()
+
 	signer, err := mm.SegmentAndSignElem(ctx, ms)
 	if err != nil {
 		return err

--- a/pkg/media/timestamper_max_reorder_test.go
+++ b/pkg/media/timestamper_max_reorder_test.go
@@ -1,0 +1,152 @@
+package media
+
+import (
+	"bytes"
+	"context"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/go-gst/go-gst/gst"
+	"github.com/go-gst/go-gst/gst/app"
+	"github.com/stretchr/testify/require"
+	"stream.place/streamplace/pkg/gstinit"
+)
+
+// vtSPS is a real VideoToolbox SPS (High, level 5.1, 2560x1440) — crucially
+// with NO VUI parameters, which is what sends h264timestamper down its
+// full-DPB reorder fallback.
+var vtSPS = []byte{0x27, 0x64, 0x00, 0x33, 0xac, 0x56, 0x80, 0x28, 0x00, 0xb5, 0xa6, 0xa0, 0x20, 0x20, 0x20, 0x40}
+
+// makeNoVUIH264 encodes 60fps H264 and replaces the encoder's SPS with the
+// no-VUI VideoToolbox SPS, so the stream signals nothing about reordering
+// (exactly what VT sends). Slices ride along unmodified; the timestamp path
+// is all this test exercises.
+func makeNoVUIH264(t *testing.T, frames int) []byte {
+	t.Helper()
+	gstinit.InitGST()
+	ctx := context.Background()
+	pipeline, err := gst.NewPipelineFromString(
+		"videotestsrc num-buffers=60 ! video/x-raw,width=2560,height=1440,framerate=60/1 ! x264enc tune=zerolatency key-int-max=60 ! video/x-h264,stream-format=byte-stream ! appsink name=sink sync=false")
+	require.NoError(t, err)
+	sinkEle, err := pipeline.GetElementByName("sink")
+	require.NoError(t, err)
+	var out bytes.Buffer
+	app.SinkFromElement(sinkEle).SetCallbacks(&app.SinkCallbacks{
+		NewSampleFunc: WriterNewSample(ctx, &out),
+	})
+	busErr := make(chan error, 1)
+	go func() { busErr <- HandleBusMessages(ctx, pipeline) }()
+	require.NoError(t, pipeline.SetState(gst.StatePlaying))
+	defer func() { _ = pipeline.SetState(gst.StateNull) }()
+	require.NoError(t, <-busErr)
+	// splice the VT SPS in place of every SPS NAL (annex-b, type 7) — x264
+	// can repeat SPS at mid-stream IDRs
+	buf := out.Bytes()
+	var spliced bytes.Buffer
+	i := 0
+	replaced := 0
+	for i+4 < len(buf) {
+		var hdr int
+		if bytes.Equal(buf[i:i+4], []byte{0, 0, 0, 1}) {
+			hdr = 4
+		} else if bytes.Equal(buf[i:i+3], []byte{0, 0, 1}) {
+			hdr = 3
+		} else {
+			spliced.WriteByte(buf[i])
+			i++
+			continue
+		}
+		// find this NAL's end
+		end := len(buf)
+		for j := i + hdr; j+3 < len(buf); j++ {
+			if bytes.Equal(buf[j:j+3], []byte{0, 0, 1}) {
+				end = j
+				break
+			}
+		}
+		spliced.Write(buf[i : i+hdr])
+		if buf[i+hdr]&0x1f == 7 {
+			spliced.Write(vtSPS)
+			replaced++
+		} else {
+			spliced.Write(buf[i+hdr : end])
+		}
+		i = end
+	}
+	require.Greater(t, replaced, 0, "no SPS NAL found in x264 output")
+	if dump := os.Getenv("SPLICE_DUMP"); dump != "" {
+		_ = os.WriteFile(dump, spliced.Bytes(), 0o644)
+	}
+	return spliced.Bytes()
+}
+
+func timestamperDeltas(t *testing.T, bytestream []byte, extraProps string) []float64 {
+	t.Helper()
+	desc := "appsrc name=src caps=video/x-h264,stream-format=byte-stream,framerate=60/1 ! h264parse ! h264timestamper " + extraProps + " name=ts ! appsink name=vsink sync=false"
+	pipeline, err := gst.NewPipelineFromString(desc)
+	require.NoError(t, err)
+	ctx := context.Background()
+	srcEle, err := pipeline.GetElementByName("src")
+	require.NoError(t, err)
+	src := app.SrcFromElement(srcEle)
+	go func() {
+		buf := gst.NewBufferWithSize(int64(len(bytestream)))
+		buf.Map(gst.MapWrite).WriteData(bytestream)
+		buf.Unmap()
+		buf.SetPresentationTimestamp(0)
+		src.PushBuffer(buf)
+		src.EndStream()
+	}()
+	sinkEle, err := pipeline.GetElementByName("vsink")
+	require.NoError(t, err)
+	var deltas []float64
+	var noneCount, sampleCount int
+	app.SinkFromElement(sinkEle).SetCallbacks(&app.SinkCallbacks{
+		NewSampleFunc: func(sink *app.Sink) gst.FlowReturn {
+			sample := sink.PullSample()
+			if sample == nil {
+				return gst.FlowEOS
+			}
+			buf := sample.GetBuffer()
+			pts, dts := buf.PresentationTimestamp(), buf.DecodingTimestamp()
+			sampleCount++
+			if pts != gst.ClockTimeNone && dts != gst.ClockTimeNone {
+				deltas = append(deltas, float64(int64(pts)-int64(dts))/1e9)
+			} else {
+				noneCount++
+				if noneCount <= 3 {
+					t.Logf("sample %d: pts=%v dts=%v", sampleCount, pts, dts)
+				}
+			}
+			return gst.FlowOK
+		},
+	})
+	busErr := make(chan error, 1)
+	go func() { busErr <- HandleBusMessages(ctx, pipeline) }()
+	require.NoError(t, pipeline.SetState(gst.StatePlaying))
+	defer func() { _ = pipeline.SetState(gst.StateNull) }()
+	require.NoError(t, <-busErr)
+	return deltas
+}
+
+// h264timestamper's SPS fallback invents a full-DPB reorder delay for streams
+// without VUI parameters (VideoToolbox), even when the stream never reorders.
+// max-reorder-frames=0 must pin DTS = PTS for those streams.
+func TestH264TimestamperMaxReorderFramesOverride(t *testing.T) {
+	bytestream := makeNoVUIH264(t, 60)
+
+	auto := timestamperDeltas(t, bytestream, "")
+	require.NotEmpty(t, auto)
+	autoMax := 0.0
+	for _, d := range auto {
+		autoMax = math.Max(autoMax, d)
+	}
+	require.Greater(t, autoMax, 0.1, "auto mode: no-VUI stream gets a spurious reorder delay")
+
+	forced := timestamperDeltas(t, bytestream, "max-reorder-frames=0")
+	require.NotEmpty(t, forced)
+	for i, d := range forced {
+		require.Equal(t, 0.0, d, "frame %d: forced no-reorder must give DTS = PTS", i)
+	}
+}

--- a/pkg/media/webrtc_ingest.go
+++ b/pkg/media/webrtc_ingest.go
@@ -48,9 +48,13 @@ func (mm *MediaManager) webRTCIngestPipeline(ctx context.Context, cancel context
 		return nil, fmt.Errorf("failed to add video transceiver: %w", err)
 	}
 
+	// h264timestamper gets max-reorder-frames=0 (a streamplace vendored
+	// property) for the same reason as in buildMKVIngestPipeline: its SPS
+	// fallback otherwise invents a reorder delay for no-VUI (VideoToolbox)
+	// streams.
 	pipelineSlice := []string{
 		"multiqueue name=queue",
-		"appsrc format=time is-live=true do-timestamp=true name=videosrc ! capsfilter caps=application/x-rtp ! rtph264depay ! capsfilter caps=video/x-h264,stream-format=byte-stream,alignment=nal ! h264parse disable-passthrough=true config-interval=-1 ! h264timestamper ! identity ! queue.sink_0",
+		"appsrc format=time is-live=true do-timestamp=true name=videosrc ! capsfilter caps=application/x-rtp ! rtph264depay ! capsfilter caps=video/x-h264,stream-format=byte-stream,alignment=nal ! h264parse disable-passthrough=true config-interval=-1 ! h264timestamper max-reorder-frames=0 ! identity ! queue.sink_0",
 		"appsrc format=time do-timestamp=true name=audiosrc ! capsfilter caps=application/x-rtp,media=audio,encoding-name=OPUS,payload=111 ! rtpopusdepay ! opusparse ! queue.sink_1",
 	}
 

--- a/pkg/media/webrtc_playback2.go
+++ b/pkg/media/webrtc_playback2.go
@@ -151,7 +151,7 @@ func (mm *MediaManager) WebRTCPlayback2(ctx context.Context, user string, rendit
 				}
 			}()
 
-			var scalar float64 = 1
+			var scalar float64
 
 			for {
 				select {
@@ -161,63 +161,9 @@ func (mm *MediaManager) WebRTCPlayback2(ctx context.Context, user string, rendit
 					latency -= packet.Duration
 					scalar = getPlaybackRate(latency)
 					log.Debug(ctx, "playback latency", "latency", latency, "scalar", scalar)
-					var videoDur time.Duration
-					var audioDur time.Duration
-					if len(packet.Video) > 0 {
-						videoDur = packet.Duration / time.Duration(len(packet.Video))
-					}
-					if len(packet.Audio) > 0 {
-						audioDur = packet.Duration / time.Duration(len(packet.Audio))
-					}
-					g, _ := errgroup.WithContext(ctx)
-
-					if !audioOnly && videoDur > 0 {
-						g.Go(func() error {
-							ticker := time.NewTicker(time.Duration(float64(videoDur) * (1 / scalar)))
-							defer ticker.Stop()
-							for _, video := range packet.Video {
-								err := videoTrack.WriteSample(media.Sample{Data: video, Duration: videoDur})
-								if err != nil {
-									return fmt.Errorf("failed to write video sample: %w", err)
-								}
-
-								select {
-								case <-ctx.Done():
-									return nil
-								case <-ticker.C:
-									continue
-								}
-							}
-							return nil
-						})
-					} else if !audioOnly {
-						log.Warn(ctx, "no video samples to write")
-					}
-					if audioDur > 0 {
-						g.Go(func() error {
-							ticker := time.NewTicker(time.Duration(float64(audioDur) * (1 / scalar)))
-							defer ticker.Stop()
-							for _, audio := range packet.Audio {
-								err := audioTrack.WriteSample(media.Sample{Data: audio, Duration: audioDur})
-								if err != nil {
-									return fmt.Errorf("failed to write audio sample: %w", err)
-								}
-								select {
-								case <-ctx.Done():
-									return nil
-								case <-ticker.C:
-									continue
-								}
-							}
-							return nil
-						})
-
-						if err := g.Wait(); err != nil {
-							log.Error(ctx, "failed to write samples", "error", err)
-							cancel()
-						}
-					} else {
-						log.Warn(ctx, "no audio samples to write")
+					if err := writePacketizedSegment(ctx, packet, videoTrack, audioTrack, audioOnly, scalar); err != nil {
+						log.Error(ctx, "failed to write samples", "error", err)
+						cancel()
 					}
 				}
 			}
@@ -292,4 +238,72 @@ func getPlaybackRate(dur time.Duration) float64 {
 		progress := (float64(dur) - float64(7*time.Second)) / (float64(60*time.Second) - float64(7*time.Second))
 		return 1.0 + (0.5 * progress)
 	}
+}
+
+// sampleTrack is the subset of *webrtc.TrackLocalStaticSample the playback
+// writer needs, abstracted so tests can observe write timing.
+type sampleTrack interface {
+	WriteSample(sample media.Sample) error
+}
+
+// writePacketizedSegment writes one segment's video and audio samples to their
+// tracks, paced by the segment's per-sample durations (sped up by scalar when
+// draining a backlog). It returns only after every sample is written: the
+// caller pulls the next segment the moment it returns, so returning early
+// would interleave two GoPs' frames into one RTP track.
+func writePacketizedSegment(ctx context.Context, packet *bus.PacketizedSegment, videoTrack, audioTrack sampleTrack, audioOnly bool, scalar float64) error {
+	var videoDur time.Duration
+	var audioDur time.Duration
+	if len(packet.Video) > 0 {
+		videoDur = packet.Duration / time.Duration(len(packet.Video))
+	}
+	if len(packet.Audio) > 0 {
+		audioDur = packet.Duration / time.Duration(len(packet.Audio))
+	}
+	g, _ := errgroup.WithContext(ctx)
+
+	if !audioOnly && videoDur > 0 {
+		g.Go(func() error {
+			ticker := time.NewTicker(time.Duration(float64(videoDur) * (1 / scalar)))
+			defer ticker.Stop()
+			for _, video := range packet.Video {
+				err := videoTrack.WriteSample(media.Sample{Data: video, Duration: videoDur})
+				if err != nil {
+					return fmt.Errorf("failed to write video sample: %w", err)
+				}
+
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-ticker.C:
+					continue
+				}
+			}
+			return nil
+		})
+	} else if !audioOnly {
+		log.Warn(ctx, "no video samples to write")
+	}
+	if audioDur > 0 {
+		g.Go(func() error {
+			ticker := time.NewTicker(time.Duration(float64(audioDur) * (1 / scalar)))
+			defer ticker.Stop()
+			for _, audio := range packet.Audio {
+				err := audioTrack.WriteSample(media.Sample{Data: audio, Duration: audioDur})
+				if err != nil {
+					return fmt.Errorf("failed to write audio sample: %w", err)
+				}
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-ticker.C:
+					continue
+				}
+			}
+			return nil
+		})
+	} else {
+		log.Warn(ctx, "no audio samples to write")
+	}
+	return g.Wait()
 }

--- a/pkg/media/webrtc_playback2_test.go
+++ b/pkg/media/webrtc_playback2_test.go
@@ -2,116 +2,95 @@ package media
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
-	"github.com/pion/webrtc/v4"
+	"github.com/pion/webrtc/v4/pkg/media"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
+	"stream.place/streamplace/pkg/bus"
 )
 
-func TestWebRTCPlayback2(t *testing.T) {
-	mm, _ := getStaticTestMediaManager(t)
-	ignore := goleak.IgnoreCurrent()
-	defer goleak.VerifyNone(t, ignore)
-	offer := &webrtc.SessionDescription{
-		Type: webrtc.SDPTypeOffer,
-		SDP:  firefoxNoH264SDP,
-	}
-	answer, err := mm.WebRTCPlayback2(context.Background(), "test-user", "test-rendition", offer, "")
-	require.ErrorContains(t, err, "RTPSender created with no codecs")
-	require.Nil(t, answer)
+type trackWrite struct {
+	data       []byte
+	start, end time.Time
 }
 
-var firefoxNoH264SDP = `v=0
-o=mozilla...THIS_IS_SDPARTA-99.0 2400864153024665403 0 IN IP4 0.0.0.0
-s=-
-t=0 0
-a=sendrecv
-a=fingerprint:sha-256 9A:55:EE:77:40:E7:C9:7F:DB:1A:D4:33:7C:06:9B:07:AE:CE:0F:06:52:1E:DE:5B:8B:A6:65:4C:48:C6:73:15
-a=group:BUNDLE 0 1
-a=ice-options:trickle
-a=msid-semantic:WMS *
-m=video 9 UDP/TLS/RTP/SAVPF 120 124 121 125 99 100 123 122 119
-c=IN IP4 0.0.0.0
-a=candidate:0 1 UDP 2122252543 f2fe908b-a599-4c2b-8e5b-411fb045e57a.local 58949 typ host
-a=candidate:1 1 TCP 2105524479 f2fe908b-a599-4c2b-8e5b-411fb045e57a.local 9 typ host tcptype active
-a=candidate:0 2 UDP 2122252542 f2fe908b-a599-4c2b-8e5b-411fb045e57a.local 52046 typ host
-a=candidate:1 2 TCP 2105524478 f2fe908b-a599-4c2b-8e5b-411fb045e57a.local 9 typ host tcptype active
-a=recvonly
-a=end-of-candidates
-a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
-a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
-a=extmap:5 urn:ietf:params:rtp-hdrext:toffset
-a=extmap:6/recvonly http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
-a=extmap:7 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
-a=extmap-allow-mixed
-a=fmtp:120 max-fs=12288;max-fr=60
-a=fmtp:124 apt=120
-a=fmtp:121 max-fs=12288;max-fr=60
-a=fmtp:125 apt=121
-a=fmtp:100 apt=99
-a=fmtp:119 apt=122
-a=ice-pwd:073b56d923776f7889e9f31dd122eaf5
-a=ice-ufrag:9ba3b1bf
-a=mid:0
-a=rtcp:52046 IN IP4 f2fe908b-a599-4c2b-8e5b-411fb045e57a.local
-a=rtcp-fb:120 nack
-a=rtcp-fb:120 nack pli
-a=rtcp-fb:120 ccm fir
-a=rtcp-fb:120 goog-remb
-a=rtcp-fb:120 transport-cc
-a=rtcp-fb:121 nack
-a=rtcp-fb:121 nack pli
-a=rtcp-fb:121 ccm fir
-a=rtcp-fb:121 goog-remb
-a=rtcp-fb:121 transport-cc
-a=rtcp-fb:99 nack
-a=rtcp-fb:99 nack pli
-a=rtcp-fb:99 ccm fir
-a=rtcp-fb:99 goog-remb
-a=rtcp-fb:99 transport-cc
-a=rtcp-fb:123 nack
-a=rtcp-fb:123 nack pli
-a=rtcp-fb:123 ccm fir
-a=rtcp-fb:123 goog-remb
-a=rtcp-fb:123 transport-cc
-a=rtcp-fb:122 nack
-a=rtcp-fb:122 nack pli
-a=rtcp-fb:122 ccm fir
-a=rtcp-fb:122 goog-remb
-a=rtcp-fb:122 transport-cc
-a=rtcp-mux
-a=rtcp-rsize
-a=rtpmap:120 VP8/90000
-a=rtpmap:124 rtx/90000
-a=rtpmap:121 VP9/90000
-a=rtpmap:125 rtx/90000
-a=rtpmap:99 AV1/90000
-a=rtpmap:100 rtx/90000
-a=rtpmap:123 ulpfec/90000
-a=rtpmap:122 red/90000
-a=rtpmap:119 rtx/90000
-a=setup:actpass
-a=ssrc:3998233880 cname:{d6f4dc1f-0f71-4a23-8ba7-8c95370e5479}
-m=audio 0 UDP/TLS/RTP/SAVPF 109 9 0 8 101
-c=IN IP4 0.0.0.0
-a=bundle-only
-a=recvonly
-a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-a=extmap:2/recvonly urn:ietf:params:rtp-hdrext:csrc-audio-level
-a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
-a=extmap-allow-mixed
-a=fmtp:109 maxplaybackrate=48000;stereo=1;useinbandfec=1
-a=fmtp:101 0-15
-a=ice-pwd:073b56d923776f7889e9f31dd122eaf5
-a=ice-ufrag:9ba3b1bf
-a=mid:1
-a=rtcp-mux
-a=rtpmap:109 opus/48000/2
-a=rtpmap:9 G722/8000/1
-a=rtpmap:0 PCMU/8000
-a=rtpmap:8 PCMA/8000
-a=rtpmap:101 telephone-event/8000
-a=setup:actpass
-a=ssrc:543748180 cname:{d6f4dc1f-0f71-4a23-8ba7-8c95370e5479}
-`
+type recordingTrack struct {
+	mu     sync.Mutex
+	delay  time.Duration
+	writes []trackWrite
+}
+
+func (rt *recordingTrack) WriteSample(sample media.Sample) error {
+	start := time.Now()
+	time.Sleep(rt.delay)
+	rt.mu.Lock()
+	rt.writes = append(rt.writes, trackWrite{data: sample.Data, start: start, end: time.Now()})
+	rt.mu.Unlock()
+	return nil
+}
+
+func (rt *recordingTrack) recorded() []trackWrite {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return append([]trackWrite(nil), rt.writes...)
+}
+
+// writePacketizedSegment must not return until every sample of the segment is
+// written: the playback loop pulls the next segment the moment it returns, so
+// an early return interleaves two GoPs' frames into one RTP track. (The old
+// loop only awaited the audio writer, so a segment with video but no audio
+// samples overlapped the next segment's writes.)
+func TestWritePacketizedSegmentReturnsAfterAllWrites(t *testing.T) {
+	ctx := context.Background()
+	video := &recordingTrack{delay: 10 * time.Millisecond}
+	audio := &recordingTrack{delay: 10 * time.Millisecond}
+	packet := &bus.PacketizedSegment{
+		Video:    [][]byte{[]byte("v0"), []byte("v1"), []byte("v2")},
+		Duration: 3 * time.Millisecond,
+	}
+	err := writePacketizedSegment(ctx, packet, video, audio, false, 1.0)
+	require.NoError(t, err)
+	require.Len(t, video.recorded(), 3, "video writes still in flight at return")
+	require.Len(t, audio.recorded(), 0)
+
+	// a second segment's writes must start after the first segment's ended
+	err = writePacketizedSegment(ctx, packet, video, audio, false, 1.0)
+	require.NoError(t, err)
+	writes := video.recorded()
+	require.Len(t, writes, 6)
+	require.False(t, writes[3].start.Before(writes[2].end), "segments overlapped on the video track")
+	for i, w := range writes {
+		require.Equal(t, []byte{byte('v'), byte('0' + i%3)}, w.data)
+	}
+}
+
+// With both tracks present, video and audio write concurrently but both
+// complete before return.
+func TestWritePacketizedSegmentWaitsForBothTracks(t *testing.T) {
+	ctx := context.Background()
+	video := &recordingTrack{delay: 10 * time.Millisecond}
+	audio := &recordingTrack{delay: 10 * time.Millisecond}
+	packet := &bus.PacketizedSegment{
+		Video:    [][]byte{[]byte("v0"), []byte("v1")},
+		Audio:    [][]byte{[]byte("a0"), []byte("a1"), []byte("a2")},
+		Duration: 2 * time.Millisecond,
+	}
+	err := writePacketizedSegment(ctx, packet, video, audio, false, 1.0)
+	require.NoError(t, err)
+	require.Len(t, video.recorded(), 2)
+	require.Len(t, audio.recorded(), 3)
+}
+
+func TestWritePacketizedSegmentAudioOnly(t *testing.T) {
+	ctx := context.Background()
+	audio := &recordingTrack{}
+	packet := &bus.PacketizedSegment{
+		Audio:    [][]byte{[]byte("a0")},
+		Duration: time.Millisecond,
+	}
+	err := writePacketizedSegment(ctx, packet, nil, audio, true, 1.0)
+	require.NoError(t, err)
+	require.Len(t, audio.recorded(), 1)
+}

--- a/pkg/spmetrics/spmetrics.go
+++ b/pkg/spmetrics/spmetrics.go
@@ -103,6 +103,11 @@ var SegmentPublishDropped = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "segments dropped for a subscriber whose queue was a full buffer behind",
 }, []string{"streamer", "rendition"})
 
+var PlaybackQueueDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "streamplace_playback_queue_dropped_total",
+	Help: "playback segments dropped because the session's packetize queue was full",
+}, []string{"streamer", "rendition"})
+
 var LabelerFirehosesConnected = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "streamplace_labeler_firehoses_connected",
 	Help: "number of currently connected labeler firehoses",

--- a/pkg/spmetrics/spmetrics.go
+++ b/pkg/spmetrics/spmetrics.go
@@ -98,6 +98,11 @@ var SegmentSubscriptionsOpen = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "number of open new segment subscriptions",
 }, []string{"streamer", "rendition"})
 
+var SegmentPublishDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "streamplace_segment_publish_dropped_total",
+	Help: "segments dropped for a subscriber whose queue was a full buffer behind",
+}, []string{"streamer", "rendition"})
+
 var LabelerFirehosesConnected = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "streamplace_labeler_firehoses_connected",
 	Help: "number of currently connected labeler firehoses",

--- a/pkg/spmetrics/spmetrics.go
+++ b/pkg/spmetrics/spmetrics.go
@@ -108,6 +108,11 @@ var PlaybackQueueDropped = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "playback segments dropped because the session's packetize queue was full",
 }, []string{"streamer", "rendition"})
 
+var IngestSessionsReplaced = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "streamplace_ingest_sessions_replaced_total",
+	Help: "ingest sessions ended because a newer push for the same streamer arrived",
+}, []string{"streamer"})
+
 var LabelerFirehosesConnected = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "streamplace_labeler_firehoses_connected",
 	Help: "number of currently connected labeler firehoses",

--- a/subprojects/gstreamer-full.wrap
+++ b/subprojects/gstreamer-full.wrap
@@ -2,3 +2,4 @@
 url = https://gitlab.freedesktop.org/iameli/gstreamer.git
 revision = 627ce52e1735b08ca49ca3a18bce60becd5d1a80
 depth = 1
+patch_directory = gstreamer-full-patches

--- a/subprojects/packagefiles/gstreamer-full-patches/0001-codectimestamper-max-reorder-frames.patch
+++ b/subprojects/packagefiles/gstreamer-full-patches/0001-codectimestamper-max-reorder-frames.patch
@@ -1,0 +1,119 @@
+diff --git a/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c b/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c
+index cc71d33..183ebfa 100644
+--- a/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c
++++ b/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c
+@@ -83,6 +83,8 @@ struct _GstH264Timestamper
+   GstH264NalParser *parser;
+   gboolean packetized;
+   guint nal_length_size;
++  /* protected by GST_OBJECT_LOCK */
++  gint max_reorder_frames;
+ };
+ 
+ static gboolean gst_h264_timestamper_start (GstCodecTimestamper * timestamper);
+@@ -93,6 +95,21 @@ static GstFlowReturn gst_h264_timestamper_handle_buffer (GstCodecTimestamper *
+     timestamper, GstBuffer * buffer);
+ static void gst_h264_timestamper_process_nal (GstH264Timestamper * self,
+     GstH264NalUnit * nalu);
++static void gst_h264_timestamper_set_property (GObject * object,
++    guint prop_id, const GValue * value, GParamSpec * pspec);
++static void gst_h264_timestamper_get_property (GObject * object,
++    guint prop_id, GValue * value, GParamSpec * pspec);
++
++enum
++{
++  PROP_0,
++  PROP_MAX_REORDER_FRAMES
++};
++
++/* -1: derive the reorder window from the SPS (element default).
++ *  0: no reordering — DTS = PTS.
++ * >0: force that reorder window. */
++#define DEFAULT_MAX_REORDER_FRAMES -1
+ 
+ G_DEFINE_TYPE (GstH264Timestamper,
+     gst_h264_timestamper, GST_TYPE_CODEC_TIMESTAMPER);
+@@ -103,10 +120,27 @@ GST_ELEMENT_REGISTER_DEFINE (h264timestamper, "h264timestamper",
+ static void
+ gst_h264_timestamper_class_init (GstH264TimestamperClass * klass)
+ {
++  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+   GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
+   GstCodecTimestamperClass *timestamper_class =
+       GST_CODEC_TIMESTAMPER_CLASS (klass);
+ 
++  gobject_class->set_property =
++      GST_DEBUG_FUNCPTR (gst_h264_timestamper_set_property);
++  gobject_class->get_property =
++      GST_DEBUG_FUNCPTR (gst_h264_timestamper_get_property);
++
++  g_object_class_install_property (gobject_class, PROP_MAX_REORDER_FRAMES,
++      g_param_spec_int ("max-reorder-frames", "Max Reorder Frames",
++          "Frame-reordering window used when reconstructing DTS: -1 derives "
++          "it from the stream's SPS (default), 0 disables reordering "
++          "(DTS = PTS), and a positive value forces that window. The SPS "
++          "fallback applies a full-DPB delay to streams without VUI "
++          "parameters (e.g. VideoToolbox), which is wrong for streams that "
++          "do not actually reorder.",
++          -1, 16, DEFAULT_MAX_REORDER_FRAMES,
++          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
++
+   gst_element_class_add_static_pad_template (element_class, &sinktemplate);
+   gst_element_class_add_static_pad_template (element_class, &srctemplate);
+ 
+@@ -128,6 +162,43 @@ gst_h264_timestamper_class_init (GstH264TimestamperClass * klass)
+ static void
+ gst_h264_timestamper_init (GstH264Timestamper * self)
+ {
++  self->max_reorder_frames = DEFAULT_MAX_REORDER_FRAMES;
++}
++
++static void
++gst_h264_timestamper_set_property (GObject * object, guint prop_id,
++    const GValue * value, GParamSpec * pspec)
++{
++  GstH264Timestamper *self = GST_H264_TIMESTAMPER (object);
++
++  switch (prop_id) {
++    case PROP_MAX_REORDER_FRAMES:
++      GST_OBJECT_LOCK (self);
++      self->max_reorder_frames = g_value_get_int (value);
++      GST_OBJECT_UNLOCK (self);
++      break;
++    default:
++      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
++      break;
++  }
++}
++
++static void
++gst_h264_timestamper_get_property (GObject * object, guint prop_id,
++    GValue * value, GParamSpec * pspec)
++{
++  GstH264Timestamper *self = GST_H264_TIMESTAMPER (object);
++
++  switch (prop_id) {
++    case PROP_MAX_REORDER_FRAMES:
++      GST_OBJECT_LOCK (self);
++      g_value_set_int (value, self->max_reorder_frames);
++      GST_OBJECT_UNLOCK (self);
++      break;
++    default:
++      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
++      break;
++  }
+ }
+ 
+ static gboolean
+@@ -306,6 +377,11 @@ gst_h264_timestamper_process_sps (GstH264Timestamper * self, GstH264SPS * sps)
+     }
+   }
+ 
++  GST_OBJECT_LOCK (self);
++  if (self->max_reorder_frames >= 0)
++    max_reorder_frames = self->max_reorder_frames;
++  GST_OBJECT_UNLOCK (self);
++
+   GST_DEBUG_OBJECT (self, "Max num reorder frames %d", max_reorder_frames);
+ 
+   gst_codec_timestamper_set_window_size (GST_CODEC_TIMESTAMPER_CAST (self),


### PR DESCRIPTION
Noting that I don't seem to hit this path after I reset OBS settings, so would treat this as more or less untested.

Frame loss at every keyframe on certain streams, WebRTC (WHEP) playback only (HLS and multistream-RTMP outputs unaffected). Triggered I think by a stream ending up in a duplicated/multitrack ingest state by OBS.
