### PR TITLE
media: pin h264timestamper to no reordering via a vendored property

### DIFF
--- a/pkg/media/mkv_ingest.go
+++ b/pkg/media/mkv_ingest.go
@@ -91,9 +91,19 @@ func buildMKVIngestPipeline(ctx context.Context, input io.Reader, signerElem *gs
 	// which downstream makes qtdemux EOS the audio pad early and every segment
 	// fails validation with "no audio in segment". h264timestamper rebuilds
 	// DTS from the H264 picture order count.
+	//
+	// max-reorder-frames=0 (a streamplace vendored property): without it the
+	// element assumes the full DPB size as a reorder delay for any stream
+	// whose SPS lacks VUI parameters — notably VideoToolbox, which writes no
+	// VUI — and mints a spurious constant ctts offset (~0.5s at 60fps, scaled
+	// by a guessed framerate) on streams that never actually reorder. That
+	// offset shifts every GoP's presentation past the flat wrap's edit-list
+	// window, and WebRTC packetize dropped the tail of every segment (frame
+	// loss at every keyframe). B-frames are not supported here, so no stream
+	// should ever get a reorder window.
 	pipelineSlice := []string{
 		"appsrc name=streamsrc ! matroskademux name=demux",
-		"demux. ! " + constants.Queue2Big + " ! h264parse ! h264timestamper name=videoout",
+		"demux. ! " + constants.Queue2Big + " ! h264parse ! h264timestamper max-reorder-frames=0 name=videoout",
 		"demux. ! " + constants.Queue2Big + " ! fdkaacdec ! audioresample ! opusenc name=audioenc",
 	}
 	pipeline, err := gst.NewPipelineFromString(strings.Join(pipelineSlice, "\n"))

--- a/pkg/media/mkv_ingest.go
+++ b/pkg/media/mkv_ingest.go
@@ -99,8 +99,11 @@ func buildMKVIngestPipeline(ctx context.Context, input io.Reader, signerElem *gs
 	// by a guessed framerate) on streams that never actually reorder. That
 	// offset shifts every GoP's presentation past the flat wrap's edit-list
 	// window, and WebRTC packetize dropped the tail of every segment (frame
-	// loss at every keyframe). B-frames are not supported here, so no stream
-	// should ever get a reorder window.
+	// loss at every keyframe). The vendored property only overrides the
+	// reorder window for SPS that lack a bitstream_restriction_flag (the VUI
+	// field carrying num_reorder_frames); B-frame streams with valid VUI are
+	// left untouched and keep their SPS-derived reorder window (see
+	// TestMKVIngestBFramesValidate).
 	pipelineSlice := []string{
 		"appsrc name=streamsrc ! matroskademux name=demux",
 		"demux. ! " + constants.Queue2Big + " ! h264parse ! h264timestamper max-reorder-frames=0 name=videoout",

--- a/pkg/media/timestamper_max_reorder_test.go
+++ b/pkg/media/timestamper_max_reorder_test.go
@@ -1,0 +1,152 @@
+package media
+
+import (
+	"bytes"
+	"context"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/go-gst/go-gst/gst"
+	"github.com/go-gst/go-gst/gst/app"
+	"github.com/stretchr/testify/require"
+	"stream.place/streamplace/pkg/gstinit"
+)
+
+// vtSPS is a real VideoToolbox SPS (High, level 5.1, 2560x1440) — crucially
+// with NO VUI parameters, which is what sends h264timestamper down its
+// full-DPB reorder fallback.
+var vtSPS = []byte{0x27, 0x64, 0x00, 0x33, 0xac, 0x56, 0x80, 0x28, 0x00, 0xb5, 0xa6, 0xa0, 0x20, 0x20, 0x20, 0x40}
+
+// makeNoVUIH264 encodes 60fps H264 and replaces the encoder's SPS with the
+// no-VUI VideoToolbox SPS, so the stream signals nothing about reordering
+// (exactly what VT sends). Slices ride along unmodified; the timestamp path
+// is all this test exercises.
+func makeNoVUIH264(t *testing.T, frames int) []byte {
+	t.Helper()
+	gstinit.InitGST()
+	ctx := context.Background()
+	pipeline, err := gst.NewPipelineFromString(
+		"videotestsrc num-buffers=60 ! video/x-raw,width=2560,height=1440,framerate=60/1 ! x264enc tune=zerolatency key-int-max=60 ! video/x-h264,stream-format=byte-stream ! appsink name=sink sync=false")
+	require.NoError(t, err)
+	sinkEle, err := pipeline.GetElementByName("sink")
+	require.NoError(t, err)
+	var out bytes.Buffer
+	app.SinkFromElement(sinkEle).SetCallbacks(&app.SinkCallbacks{
+		NewSampleFunc: WriterNewSample(ctx, &out),
+	})
+	busErr := make(chan error, 1)
+	go func() { busErr <- HandleBusMessages(ctx, pipeline) }()
+	require.NoError(t, pipeline.SetState(gst.StatePlaying))
+	defer func() { _ = pipeline.SetState(gst.StateNull) }()
+	require.NoError(t, <-busErr)
+	// splice the VT SPS in place of every SPS NAL (annex-b, type 7) — x264
+	// can repeat SPS at mid-stream IDRs
+	buf := out.Bytes()
+	var spliced bytes.Buffer
+	i := 0
+	replaced := 0
+	for i+4 < len(buf) {
+		var hdr int
+		if bytes.Equal(buf[i:i+4], []byte{0, 0, 0, 1}) {
+			hdr = 4
+		} else if bytes.Equal(buf[i:i+3], []byte{0, 0, 1}) {
+			hdr = 3
+		} else {
+			spliced.WriteByte(buf[i])
+			i++
+			continue
+		}
+		// find this NAL's end
+		end := len(buf)
+		for j := i + hdr; j+3 < len(buf); j++ {
+			if bytes.Equal(buf[j:j+3], []byte{0, 0, 1}) {
+				end = j
+				break
+			}
+		}
+		spliced.Write(buf[i : i+hdr])
+		if buf[i+hdr]&0x1f == 7 {
+			spliced.Write(vtSPS)
+			replaced++
+		} else {
+			spliced.Write(buf[i+hdr : end])
+		}
+		i = end
+	}
+	require.Greater(t, replaced, 0, "no SPS NAL found in x264 output")
+	if dump := os.Getenv("SPLICE_DUMP"); dump != "" {
+		_ = os.WriteFile(dump, spliced.Bytes(), 0o644)
+	}
+	return spliced.Bytes()
+}
+
+func timestamperDeltas(t *testing.T, bytestream []byte, extraProps string) []float64 {
+	t.Helper()
+	desc := "appsrc name=src caps=video/x-h264,stream-format=byte-stream,framerate=60/1 ! h264parse ! h264timestamper " + extraProps + " name=ts ! appsink name=vsink sync=false"
+	pipeline, err := gst.NewPipelineFromString(desc)
+	require.NoError(t, err)
+	ctx := context.Background()
+	srcEle, err := pipeline.GetElementByName("src")
+	require.NoError(t, err)
+	src := app.SrcFromElement(srcEle)
+	go func() {
+		buf := gst.NewBufferWithSize(int64(len(bytestream)))
+		buf.Map(gst.MapWrite).WriteData(bytestream)
+		buf.Unmap()
+		buf.SetPresentationTimestamp(0)
+		src.PushBuffer(buf)
+		src.EndStream()
+	}()
+	sinkEle, err := pipeline.GetElementByName("vsink")
+	require.NoError(t, err)
+	var deltas []float64
+	var noneCount, sampleCount int
+	app.SinkFromElement(sinkEle).SetCallbacks(&app.SinkCallbacks{
+		NewSampleFunc: func(sink *app.Sink) gst.FlowReturn {
+			sample := sink.PullSample()
+			if sample == nil {
+				return gst.FlowEOS
+			}
+			buf := sample.GetBuffer()
+			pts, dts := buf.PresentationTimestamp(), buf.DecodingTimestamp()
+			sampleCount++
+			if pts != gst.ClockTimeNone && dts != gst.ClockTimeNone {
+				deltas = append(deltas, float64(int64(pts)-int64(dts))/1e9)
+			} else {
+				noneCount++
+				if noneCount <= 3 {
+					t.Logf("sample %d: pts=%v dts=%v", sampleCount, pts, dts)
+				}
+			}
+			return gst.FlowOK
+		},
+	})
+	busErr := make(chan error, 1)
+	go func() { busErr <- HandleBusMessages(ctx, pipeline) }()
+	require.NoError(t, pipeline.SetState(gst.StatePlaying))
+	defer func() { _ = pipeline.SetState(gst.StateNull) }()
+	require.NoError(t, <-busErr)
+	return deltas
+}
+
+// h264timestamper's SPS fallback invents a full-DPB reorder delay for streams
+// without VUI parameters (VideoToolbox), even when the stream never reorders.
+// max-reorder-frames=0 must pin DTS = PTS for those streams.
+func TestH264TimestamperMaxReorderFramesOverride(t *testing.T) {
+	bytestream := makeNoVUIH264(t, 60)
+
+	auto := timestamperDeltas(t, bytestream, "")
+	require.NotEmpty(t, auto)
+	autoMax := 0.0
+	for _, d := range auto {
+		autoMax = math.Max(autoMax, d)
+	}
+	require.Greater(t, autoMax, 0.1, "auto mode: no-VUI stream gets a spurious reorder delay")
+
+	forced := timestamperDeltas(t, bytestream, "max-reorder-frames=0")
+	require.NotEmpty(t, forced)
+	for i, d := range forced {
+		require.Equal(t, 0.0, d, "frame %d: forced no-reorder must give DTS = PTS", i)
+	}
+}

--- a/pkg/media/timestamper_max_reorder_test.go
+++ b/pkg/media/timestamper_max_reorder_test.go
@@ -3,6 +3,7 @@ package media
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math"
 	"os"
 	"testing"
@@ -27,7 +28,7 @@ func makeNoVUIH264(t *testing.T, frames int) []byte {
 	gstinit.InitGST()
 	ctx := context.Background()
 	pipeline, err := gst.NewPipelineFromString(
-		"videotestsrc num-buffers=60 ! video/x-raw,width=2560,height=1440,framerate=60/1 ! x264enc tune=zerolatency key-int-max=60 ! video/x-h264,stream-format=byte-stream ! appsink name=sink sync=false")
+		fmt.Sprintf("videotestsrc num-buffers=%d ! video/x-raw,width=2560,height=1440,framerate=60/1 ! x264enc tune=zerolatency key-int-max=60 ! video/x-h264,stream-format=byte-stream ! appsink name=sink sync=false", frames))
 	require.NoError(t, err)
 	sinkEle, err := pipeline.GetElementByName("sink")
 	require.NoError(t, err)
@@ -149,4 +150,56 @@ func TestH264TimestamperMaxReorderFramesOverride(t *testing.T) {
 	for i, d := range forced {
 		require.Equal(t, 0.0, d, "frame %d: forced no-reorder must give DTS = PTS", i)
 	}
+}
+
+// makeBFrameH264 encodes a real B-frame stream (bframes=2) whose SPS carries
+// a bitstream_restriction_flag with num_reorder_frames. The override must NOT
+// fire for these streams — they need their SPS-derived reorder window.
+func makeBFrameH264(t *testing.T, frames int) []byte {
+	t.Helper()
+	gstinit.InitGST()
+	ctx := context.Background()
+	pipeline, err := gst.NewPipelineFromString(
+		fmt.Sprintf("videotestsrc num-buffers=%d ! video/x-raw,width=320,height=240,framerate=30/1 ! x264enc bframes=2 b-adapt=false key-int-max=30 speed-preset=veryfast ! video/x-h264,stream-format=byte-stream ! appsink name=sink sync=false", frames))
+	require.NoError(t, err)
+	sinkEle, err := pipeline.GetElementByName("sink")
+	require.NoError(t, err)
+	var out bytes.Buffer
+	app.SinkFromElement(sinkEle).SetCallbacks(&app.SinkCallbacks{
+		NewSampleFunc: WriterNewSample(ctx, &out),
+	})
+	busErr := make(chan error, 1)
+	go func() { busErr <- HandleBusMessages(ctx, pipeline) }()
+	require.NoError(t, pipeline.SetState(gst.StatePlaying))
+	defer func() { _ = pipeline.SetState(gst.StateNull) }()
+	require.NoError(t, <-busErr)
+	require.NotEmpty(t, out.Bytes())
+	return out.Bytes()
+}
+
+// max-reorder-frames=0 must only affect streams whose SPS lacks a
+// bitstream_restriction_flag. B-frame streams with valid VUI (x264 bframes=2)
+// keep their SPS-derived reorder window even with the property set to 0.
+func TestH264TimestamperMaxReorderFramesPreservesBFrames(t *testing.T) {
+	bytestream := makeBFrameH264(t, 90)
+
+	// Without the override: the SPS declares num_reorder_frames, so the
+	// timestamper should reconstruct a nonzero DTS offset (DTS < PTS).
+	auto := timestamperDeltas(t, bytestream, "")
+	require.NotEmpty(t, auto)
+	autoMax := 0.0
+	for _, d := range auto {
+		autoMax = math.Max(autoMax, d)
+	}
+	require.Greater(t, autoMax, 0.0, "B-frame stream has nonzero reorder offset without override")
+
+	// With the override set to 0: B-frame streams with valid VUI must be
+	// untouched — the reorder window stays SPS-derived, not forced to 0.
+	forced := timestamperDeltas(t, bytestream, "max-reorder-frames=0")
+	require.NotEmpty(t, forced)
+	forcedMax := 0.0
+	for _, d := range forced {
+		forcedMax = math.Max(forcedMax, d)
+	}
+	require.Greater(t, forcedMax, 0.0, "B-frame stream with valid VUI must not be overridden by max-reorder-frames=0")
 }

--- a/pkg/media/webrtc_ingest.go
+++ b/pkg/media/webrtc_ingest.go
@@ -48,9 +48,13 @@ func (mm *MediaManager) webRTCIngestPipeline(ctx context.Context, cancel context
 		return nil, fmt.Errorf("failed to add video transceiver: %w", err)
 	}
 
+	// h264timestamper gets max-reorder-frames=0 (a streamplace vendored
+	// property) for the same reason as in buildMKVIngestPipeline: its SPS
+	// fallback otherwise invents a reorder delay for no-VUI (VideoToolbox)
+	// streams.
 	pipelineSlice := []string{
 		"multiqueue name=queue",
-		"appsrc format=time is-live=true do-timestamp=true name=videosrc ! capsfilter caps=application/x-rtp ! rtph264depay ! capsfilter caps=video/x-h264,stream-format=byte-stream,alignment=nal ! h264parse disable-passthrough=true config-interval=-1 ! h264timestamper ! identity ! queue.sink_0",
+		"appsrc format=time is-live=true do-timestamp=true name=videosrc ! capsfilter caps=application/x-rtp ! rtph264depay ! capsfilter caps=video/x-h264,stream-format=byte-stream,alignment=nal ! h264parse disable-passthrough=true config-interval=-1 ! h264timestamper max-reorder-frames=0 ! identity ! queue.sink_0",
 		"appsrc format=time do-timestamp=true name=audiosrc ! capsfilter caps=application/x-rtp,media=audio,encoding-name=OPUS,payload=111 ! rtpopusdepay ! opusparse ! queue.sink_1",
 	}
 

--- a/pkg/media/webrtc_ingest.go
+++ b/pkg/media/webrtc_ingest.go
@@ -51,7 +51,9 @@ func (mm *MediaManager) webRTCIngestPipeline(ctx context.Context, cancel context
 	// h264timestamper gets max-reorder-frames=0 (a streamplace vendored
 	// property) for the same reason as in buildMKVIngestPipeline: its SPS
 	// fallback otherwise invents a reorder delay for no-VUI (VideoToolbox)
-	// streams.
+	// streams. The property only overrides the reorder window when the SPS
+	// lacks a bitstream_restriction_flag; B-frame streams with valid VUI
+	// (num_reorder_frames) are untouched.
 	pipelineSlice := []string{
 		"multiqueue name=queue",
 		"appsrc format=time is-live=true do-timestamp=true name=videosrc ! capsfilter caps=application/x-rtp ! rtph264depay ! capsfilter caps=video/x-h264,stream-format=byte-stream,alignment=nal ! h264parse disable-passthrough=true config-interval=-1 ! h264timestamper max-reorder-frames=0 ! identity ! queue.sink_0",

--- a/subprojects/gstreamer-full.wrap
+++ b/subprojects/gstreamer-full.wrap
@@ -2,3 +2,4 @@
 url = https://gitlab.freedesktop.org/iameli/gstreamer.git
 revision = 627ce52e1735b08ca49ca3a18bce60becd5d1a80
 depth = 1
+patch_directory = gstreamer-full-patches

--- a/subprojects/packagefiles/gstreamer-full-patches/0001-codectimestamper-max-reorder-frames.patch
+++ b/subprojects/packagefiles/gstreamer-full-patches/0001-codectimestamper-max-reorder-frames.patch
@@ -1,5 +1,5 @@
 diff --git a/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c b/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c
-index cc71d33..183ebfa 100644
+index cc71d33..afe7ab4 100644
 --- a/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c
 +++ b/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c
 @@ -83,6 +83,8 @@ struct _GstH264Timestamper
@@ -33,7 +33,7 @@ index cc71d33..183ebfa 100644
  
  G_DEFINE_TYPE (GstH264Timestamper,
      gst_h264_timestamper, GST_TYPE_CODEC_TIMESTAMPER);
-@@ -103,10 +120,27 @@ GST_ELEMENT_REGISTER_DEFINE (h264timestamper, "h264timestamper",
+@@ -103,10 +120,32 @@ GST_ELEMENT_REGISTER_DEFINE (h264timestamper, "h264timestamper",
  static void
  gst_h264_timestamper_class_init (GstH264TimestamperClass * klass)
  {
@@ -51,17 +51,22 @@ index cc71d33..183ebfa 100644
 +      g_param_spec_int ("max-reorder-frames", "Max Reorder Frames",
 +          "Frame-reordering window used when reconstructing DTS: -1 derives "
 +          "it from the stream's SPS (default), 0 disables reordering "
-+          "(DTS = PTS), and a positive value forces that window. The SPS "
-+          "fallback applies a full-DPB delay to streams without VUI "
-+          "parameters (e.g. VideoToolbox), which is wrong for streams that "
-+          "do not actually reorder.",
++          "(DTS = PTS), and a positive value forces that window. The "
++          "override applies ONLY to streams whose SPS lacks a "
++          "bitstream_restriction_flag (VUI with num_reorder_frames) — e.g. "
++          "VideoToolbox, which writes no VUI, and x264 through h264parse, "
++          "which adds VUI without the restriction flag — where the fallback "
++          "would otherwise apply a full-DPB delay, wrong for streams that "
++          "do not actually reorder. Streams with a bitstream_restriction "
++          "flag (including B-frame streams that declare num_reorder_frames) "
++          "are left untouched.",
 +          -1, 16, DEFAULT_MAX_REORDER_FRAMES,
 +          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 +
    gst_element_class_add_static_pad_template (element_class, &sinktemplate);
    gst_element_class_add_static_pad_template (element_class, &srctemplate);
  
-@@ -128,6 +162,43 @@ gst_h264_timestamper_class_init (GstH264TimestamperClass * klass)
+@@ -128,6 +167,43 @@ gst_h264_timestamper_class_init (GstH264TimestamperClass * klass)
  static void
  gst_h264_timestamper_init (GstH264Timestamper * self)
  {
@@ -105,12 +110,14 @@ index cc71d33..183ebfa 100644
  }
  
  static gboolean
-@@ -306,6 +377,11 @@ gst_h264_timestamper_process_sps (GstH264Timestamper * self, GstH264SPS * sps)
+@@ -306,6 +382,13 @@ gst_h264_timestamper_process_sps (GstH264Timestamper * self, GstH264SPS * sps)
      }
    }
  
 +  GST_OBJECT_LOCK (self);
-+  if (self->max_reorder_frames >= 0)
++  if (self->max_reorder_frames >= 0
++      && !(sps->vui_parameters_present_flag
++          && sps->vui_parameters.bitstream_restriction_flag))
 +    max_reorder_frames = self->max_reorder_frames;
 +  GST_OBJECT_UNLOCK (self);
 +

--- a/subprojects/packagefiles/gstreamer-full-patches/0001-codectimestamper-max-reorder-frames.patch
+++ b/subprojects/packagefiles/gstreamer-full-patches/0001-codectimestamper-max-reorder-frames.patch
@@ -1,0 +1,119 @@
+diff --git a/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c b/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c
+index cc71d33..183ebfa 100644
+--- a/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c
++++ b/subprojects/gst-plugins-bad/gst/codectimestamper/gsth264timestamper.c
+@@ -83,6 +83,8 @@ struct _GstH264Timestamper
+   GstH264NalParser *parser;
+   gboolean packetized;
+   guint nal_length_size;
++  /* protected by GST_OBJECT_LOCK */
++  gint max_reorder_frames;
+ };
+ 
+ static gboolean gst_h264_timestamper_start (GstCodecTimestamper * timestamper);
+@@ -93,6 +95,21 @@ static GstFlowReturn gst_h264_timestamper_handle_buffer (GstCodecTimestamper *
+     timestamper, GstBuffer * buffer);
+ static void gst_h264_timestamper_process_nal (GstH264Timestamper * self,
+     GstH264NalUnit * nalu);
++static void gst_h264_timestamper_set_property (GObject * object,
++    guint prop_id, const GValue * value, GParamSpec * pspec);
++static void gst_h264_timestamper_get_property (GObject * object,
++    guint prop_id, GValue * value, GParamSpec * pspec);
++
++enum
++{
++  PROP_0,
++  PROP_MAX_REORDER_FRAMES
++};
++
++/* -1: derive the reorder window from the SPS (element default).
++ *  0: no reordering — DTS = PTS.
++ * >0: force that reorder window. */
++#define DEFAULT_MAX_REORDER_FRAMES -1
+ 
+ G_DEFINE_TYPE (GstH264Timestamper,
+     gst_h264_timestamper, GST_TYPE_CODEC_TIMESTAMPER);
+@@ -103,10 +120,27 @@ GST_ELEMENT_REGISTER_DEFINE (h264timestamper, "h264timestamper",
+ static void
+ gst_h264_timestamper_class_init (GstH264TimestamperClass * klass)
+ {
++  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+   GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
+   GstCodecTimestamperClass *timestamper_class =
+       GST_CODEC_TIMESTAMPER_CLASS (klass);
+ 
++  gobject_class->set_property =
++      GST_DEBUG_FUNCPTR (gst_h264_timestamper_set_property);
++  gobject_class->get_property =
++      GST_DEBUG_FUNCPTR (gst_h264_timestamper_get_property);
++
++  g_object_class_install_property (gobject_class, PROP_MAX_REORDER_FRAMES,
++      g_param_spec_int ("max-reorder-frames", "Max Reorder Frames",
++          "Frame-reordering window used when reconstructing DTS: -1 derives "
++          "it from the stream's SPS (default), 0 disables reordering "
++          "(DTS = PTS), and a positive value forces that window. The SPS "
++          "fallback applies a full-DPB delay to streams without VUI "
++          "parameters (e.g. VideoToolbox), which is wrong for streams that "
++          "do not actually reorder.",
++          -1, 16, DEFAULT_MAX_REORDER_FRAMES,
++          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
++
+   gst_element_class_add_static_pad_template (element_class, &sinktemplate);
+   gst_element_class_add_static_pad_template (element_class, &srctemplate);
+ 
+@@ -128,6 +162,43 @@ gst_h264_timestamper_class_init (GstH264TimestamperClass * klass)
+ static void
+ gst_h264_timestamper_init (GstH264Timestamper * self)
+ {
++  self->max_reorder_frames = DEFAULT_MAX_REORDER_FRAMES;
++}
++
++static void
++gst_h264_timestamper_set_property (GObject * object, guint prop_id,
++    const GValue * value, GParamSpec * pspec)
++{
++  GstH264Timestamper *self = GST_H264_TIMESTAMPER (object);
++
++  switch (prop_id) {
++    case PROP_MAX_REORDER_FRAMES:
++      GST_OBJECT_LOCK (self);
++      self->max_reorder_frames = g_value_get_int (value);
++      GST_OBJECT_UNLOCK (self);
++      break;
++    default:
++      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
++      break;
++  }
++}
++
++static void
++gst_h264_timestamper_get_property (GObject * object, guint prop_id,
++    GValue * value, GParamSpec * pspec)
++{
++  GstH264Timestamper *self = GST_H264_TIMESTAMPER (object);
++
++  switch (prop_id) {
++    case PROP_MAX_REORDER_FRAMES:
++      GST_OBJECT_LOCK (self);
++      g_value_set_int (value, self->max_reorder_frames);
++      GST_OBJECT_UNLOCK (self);
++      break;
++    default:
++      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
++      break;
++  }
+ }
+ 
+ static gboolean
+@@ -306,6 +377,11 @@ gst_h264_timestamper_process_sps (GstH264Timestamper * self, GstH264SPS * sps)
+     }
+   }
+ 
++  GST_OBJECT_LOCK (self);
++  if (self->max_reorder_frames >= 0)
++    max_reorder_frames = self->max_reorder_frames;
++  GST_OBJECT_UNLOCK (self);
++
+   GST_DEBUG_OBJECT (self, "Max num reorder frames %d", max_reorder_frames);
+ 
+   gst_codec_timestamper_set_window_size (GST_CODEC_TIMESTAMPER_CAST (self),


### PR DESCRIPTION
add a max-reorder-frames parameter so we don't do extremely bad things (delay by a guessed, yet almost always incorrect framerate) if the SPS lacks VUI params