### PR TITLE
fix: debug recordings never reached S3

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1440,6 +1440,17 @@ func (cli *CLI) S3Config() s3.Config {
 	}
 }
 
+// SetS3Config applies an s3.Config to the CLI's S3 fields — the inverse of
+// S3Config, for processes (ingest workers) that receive the S3 destination over
+// a handshake instead of from flags.
+func (cli *CLI) SetS3Config(c s3.Config) {
+	cli.S3Endpoint = c.Endpoint
+	cli.S3Bucket = c.Bucket
+	cli.S3AccessKeyID = c.AccessKeyID
+	cli.S3SecretAccessKey = c.SecretAccessKey
+	cli.S3Region = c.Region
+}
+
 // DebugRecordingFile is the write target returned by DebugRecordingCreate: an
 // *os.File on local disk, or an S3 upload that commits on Close. Name() reports
 // the destination (path or object key) for logging.
@@ -1458,7 +1469,11 @@ type DebugRecordingFile interface {
 func (cli *CLI) DebugRecordingCreate(ctx context.Context, fpath []string, contentType string, overwrite bool) (DebugRecordingFile, error) {
 	if cli.S3Configured() {
 		key := strings.Join(fpath, "/")
-		return s3.NewUploadWriter(ctx, s3.NewClient(cli.S3Config()), cli.S3Bucket, key, contentType)
+		// The recording outlives the ingest session's ctx: Close commits the upload
+		// during teardown, after that ctx is typically cancelled — a cancelled ctx
+		// here would abort the upload and lose the object. Callers bound the commit
+		// with their own finalize waits instead.
+		return s3.NewUploadWriter(context.WithoutCancel(ctx), s3.NewClient(cli.S3Config()), cli.S3Bucket, key, contentType)
 	}
 	return cli.DataFileCreate(fpath, overwrite)
 }

--- a/pkg/media/ingest_supervisor.go
+++ b/pkg/media/ingest_supervisor.go
@@ -278,6 +278,14 @@ func (mm *MediaManager) buildWorkerConfig(ctx context.Context, ms MediaSigner) (
 	} else if rec {
 		cfg.Record = true
 		cfg.DataDir = mm.cli.DataDir
+		// The worker writes the recording, so it needs main's S3 destination too —
+		// without it, DebugRecordingCreate inside the worker would silently fall
+		// back to local disk under DataDir. Only sent when recording, to keep the
+		// S3 secret out of handshakes that don't need it.
+		if mm.cli.S3Configured() {
+			s3cfg := mm.cli.S3Config()
+			cfg.S3 = &s3cfg
+		}
 	}
 	// Node transcode signer lets the worker complete to dual-codec itself. If it's
 	// unavailable, the worker emits single-codec (the node doesn't re-transcode the

--- a/pkg/media/ingest_worker.go
+++ b/pkg/media/ingest_worker.go
@@ -13,6 +13,7 @@ import (
 	"stream.place/streamplace/pkg/gstinit"
 	"stream.place/streamplace/pkg/log"
 	"stream.place/streamplace/pkg/muxl"
+	"stream.place/streamplace/pkg/s3"
 )
 
 // manifestHolder holds the worker's current C2PA manifest. It starts as the
@@ -90,14 +91,18 @@ type IngestWorkerConfig struct {
 	Chunked bool   `json:"chunked,omitempty"`
 
 	// Record, when true, makes the worker write a debug recording of this session
-	// (the MKV/RTMP push body, or the WHIP session) under
-	// DataDir/debug-recordings/<did>/. main evaluates the per-stream DebugRecording
-	// setting (which needs the DB) and the worker carries it out — so debug
-	// recording keeps working on the isolated paths without main being in the data
-	// path, and a recording even survives a main restart. DataDir is set (only when
-	// Record) to the node data dir the worker writes recordings under.
-	Record  bool   `json:"record,omitempty"`
-	DataDir string `json:"data_dir,omitempty"`
+	// (the MKV/RTMP push body, or the WHIP session). main evaluates the per-stream
+	// DebugRecording setting (which needs the DB) and the worker carries it out —
+	// so debug recording keeps working on the isolated paths without main being in
+	// the data path, and a recording even survives a main restart. The recording
+	// streams to S3 under debug-recordings/<did>/ when S3 is set (production), and
+	// falls back to DataDir/debug-recordings/<did>/ on local disk otherwise (dev).
+	// DataDir and S3 are set (only when Record) from main's config; S3 carries the
+	// secret key, which is fine here — the handshake exists to carry key material
+	// off argv/env.
+	Record  bool       `json:"record,omitempty"`
+	DataDir string     `json:"data_dir,omitempty"`
+	S3      *s3.Config `json:"s3,omitempty"`
 
 	// Transport selects the worker's ingest source: "" / "mkv" reads MKV media
 	// (stdin or InputFD); "whip" makes the worker own the WebRTC PeerConnection,
@@ -111,6 +116,18 @@ type IngestWorkerConfig struct {
 
 // IngestTransportWHIP is the cfg.Transport value selecting the WHIP worker.
 const IngestTransportWHIP = "whip"
+
+// workerCLI assembles the minimal config.CLI a worker runs with: the
+// broadcaster identity plus the debug-recording destination (S3 when main
+// handed its config over the handshake, else local disk under DataDir). Shared
+// by the MKV and WHIP workers so both record to the same place main would.
+func (cfg IngestWorkerConfig) workerCLI() *config.CLI {
+	cli := &config.CLI{BroadcasterHost: cfg.BroadcasterHost, DataDir: cfg.DataDir}
+	if cfg.S3 != nil {
+		cli.SetS3Config(*cfg.S3)
+	}
+	return cli
+}
 
 // WorkerInput reconstructs the raw media stream the gst pipeline reads from the
 // fd-passed push connection: prepend any bytes main already read past the headers
@@ -211,23 +228,22 @@ func RunMKVIngestWorker(ctx context.Context, cfg IngestWorkerConfig, stdin io.Re
 
 	// Minimal manager: the broadcaster identity the transcode completion
 	// (finishTranscodedSegment) stamps into the node-signed AAC track, plus the
-	// data dir for an optional debug recording.
-	mm := &MediaManager{cli: &config.CLI{BroadcasterHost: cfg.BroadcasterHost, DataDir: cfg.DataDir}}
+	// destination for an optional debug recording.
+	mm := &MediaManager{cli: cfg.workerCLI()}
 	onSegment, flush := mm.workerSegmentSink(ctx, cfg, frames)
 
-	// Debug recording: tee the ingest media to a file before it reaches gst. main
-	// decided this (cfg.Record) and handed us DataDir; recording here keeps main
+	// Debug recording: tee the ingest media before it reaches gst. main decided
+	// this (cfg.Record) and handed us the destination; recording here keeps main
 	// out of the data path and lets the recording survive a main restart.
 	media := stdin
 	if cfg.Record {
 		log.Log(ctx, "recording ingest media to file", "streamer", cfg.StreamerDID)
-		pr, pw := io.Pipe()
-		media = io.TeeReader(stdin, pw)
-		go func() {
-			if derr := mm.dumpToFile(ctx, pr, cfg.StreamerDID, ".rtmp.mkv"); derr != nil {
-				log.Error(ctx, "ingest worker: dump recording to file", "error", derr)
-			}
-		}()
+		var finalize func()
+		media, finalize = mm.recordTee(ctx, stdin, cfg.StreamerDID, ".rtmp.mkv")
+		// Registered before the pipeline's SetState(Null) defer, so it runs after
+		// the pipeline stops reading — and before this worker process exits, which
+		// would otherwise strand an uncommitted S3 upload.
+		defer finalize()
 	}
 
 	signerElem, done, err := muxlSignSegmentElem(ctx, mm.cli, workerSignStream(cfg, getManifest), onSegment)

--- a/pkg/media/ingest_worker_test.go
+++ b/pkg/media/ingest_worker_test.go
@@ -6,9 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +22,7 @@ import (
 	"stream.place/streamplace/pkg/gstinit"
 	"stream.place/streamplace/pkg/ingestframe"
 	"stream.place/streamplace/pkg/muxl"
+	"stream.place/streamplace/pkg/s3"
 )
 
 // TestWorkerInputDeframes checks the body-deframing the worker applies to the
@@ -217,6 +221,115 @@ func TestRunMKVIngestWorkerRecords(t *testing.T) {
 		got, rerr := os.ReadFile(matches[0])
 		return rerr == nil && bytes.Equal(got, mkv)
 	}, 10*time.Second, 25*time.Millisecond, "worker records the ingest media verbatim")
+}
+
+// fakeS3Server is a minimal path-style S3 endpoint speaking just enough of the
+// multipart-upload protocol for UploadWriter: initiate → upload parts →
+// complete. Completed objects land in objects keyed by "<bucket>/<key>".
+type fakeS3Server struct {
+	mu      sync.Mutex
+	parts   map[string][]byte // "<path>#<partNumber>" → body
+	objects map[string][]byte // completed "<bucket>/<key>" → body
+}
+
+func newFakeS3Server() *fakeS3Server {
+	return &fakeS3Server{parts: map[string][]byte{}, objects: map[string][]byte{}}
+}
+
+func (f *fakeS3Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	path := strings.TrimPrefix(r.URL.Path, "/")
+	q := r.URL.Query()
+	switch {
+	case r.Method == "POST" && q.Has("uploads"):
+		fmt.Fprintf(w, `<InitiateMultipartUploadResult><UploadId>test-upload</UploadId></InitiateMultipartUploadResult>`)
+	case r.Method == "PUT" && q.Has("partNumber"):
+		body, _ := io.ReadAll(r.Body)
+		f.parts[path+"#"+q.Get("partNumber")] = body
+		w.Header().Set("ETag", `"part-`+q.Get("partNumber")+`"`)
+	case r.Method == "POST" && q.Has("uploadId"):
+		var buf []byte
+		for i := 1; ; i++ {
+			part, ok := f.parts[fmt.Sprintf("%s#%d", path, i)]
+			if !ok {
+				break
+			}
+			buf = append(buf, part...)
+		}
+		f.objects[path] = buf
+		fmt.Fprintf(w, `<CompleteMultipartUploadResult><Key>%s</Key></CompleteMultipartUploadResult>`, path)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+	}
+}
+
+// objectWithPrefix finds a completed object whose key starts with prefix and
+// ends with suffix (the recording's timestamped filename isn't predictable).
+func (f *fakeS3Server) objectWithPrefix(prefix, suffix string) ([]byte, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for path, b := range f.objects {
+		if strings.HasPrefix(path, prefix) && strings.HasSuffix(path, suffix) {
+			return b, true
+		}
+	}
+	return nil, false
+}
+
+// TestRunMKVIngestWorkerRecordsToS3 proves the debug recording streams to S3
+// when main hands its S3 config over the handshake (cfg.S3) — the production
+// shape. Without that plumbing the worker's minimal CLI has no S3 fields and
+// DebugRecordingCreate silently falls back to local disk, which is exactly the
+// regression this guards against: recordings must land in the bucket, not under
+// DataDir.
+func TestRunMKVIngestWorkerRecordsToS3(t *testing.T) {
+	ctx := context.Background()
+	ms := newBareSegmentSigner(t)
+
+	keyPEM, err := signers.MarshalES256KPrivateKeyPEM(ms.Signer)
+	require.NoError(t, err)
+	manifest, err := ms.buildManifest(ctx, time.Now().UnixMilli())
+	require.NoError(t, err)
+
+	fake := newFakeS3Server()
+	srv := httptest.NewServer(fake)
+	defer srv.Close()
+
+	dataDir := t.TempDir()
+	cfg := IngestWorkerConfig{
+		StreamerDID:     ms.Streamer(),
+		KeyPEM:          keyPEM,
+		CertPEM:         ms.Cert,
+		Manifest:        manifest,
+		BroadcasterHost: "test.example.com",
+		Record:          true,
+		DataDir:         dataDir,
+		S3: &s3.Config{
+			Endpoint:        srv.URL,
+			Bucket:          "debug-bucket",
+			AccessKeyID:     "test-access",
+			SecretAccessKey: "test-secret",
+			Region:          "auto",
+		},
+	}
+
+	mkv := makeH264AACMKV(t, ctx, getFixture("5sec.mp4"))
+
+	require.NoError(t, RunMKVIngestWorker(ctx, cfg, bytes.NewReader(mkv), ingestframe.NewWriter(io.Discard), func() []byte { return cfg.Manifest }))
+
+	// The upload commits asynchronously (the dump goroutine's Close); the object
+	// must appear at debug-bucket/debug-recordings/<did>/<ts>.rtmp.mkv holding
+	// exactly the ingested media.
+	wantPrefix := "debug-bucket/debug-recordings/" + ms.Streamer() + "/"
+	require.Eventually(t, func() bool {
+		got, ok := fake.objectWithPrefix(wantPrefix, ".rtmp.mkv")
+		return ok && bytes.Equal(got, mkv)
+	}, 10*time.Second, 25*time.Millisecond, "worker streams the recording to the S3 bucket verbatim")
+
+	// And nothing fell back to local disk.
+	matches, _ := filepath.Glob(filepath.Join(dataDir, "debug-recordings", "*", "*"))
+	require.Empty(t, matches, "recording must go to S3, not DataDir")
 }
 
 // TestRunMKVIngestWorkerSelfWatchdog proves the worker's OWN watchdog contains a

--- a/pkg/media/mkv_ingest.go
+++ b/pkg/media/mkv_ingest.go
@@ -22,14 +22,9 @@ func (mm *MediaManager) MKVIngest(ctx context.Context, input io.Reader, ms Media
 	}
 	if shouldRecord {
 		log.Log(ctx, "recording RTMP stream to file", "streamer", ms.Streamer())
-		pr, pw := io.Pipe()
-		input = io.TeeReader(input, pw)
-		go func() {
-			err := mm.dumpToFile(ctx, pr, ms.Streamer(), ".rtmp.mkv")
-			if err != nil {
-				log.Error(ctx, "error dumping to file", "error", err)
-			}
-		}()
+		var finalize func()
+		input, finalize = mm.recordTee(ctx, input, ms.Streamer(), ".rtmp.mkv")
+		defer finalize()
 	} else {
 		log.Log(ctx, "not recording RTMP stream to file", "streamer", ms.Streamer())
 	}
@@ -125,6 +120,38 @@ func buildMKVIngestPipeline(ctx context.Context, input io.Reader, signerElem *gs
 		return nil, err
 	}
 	return pipeline, nil
+}
+
+// debugRecordingFlushTimeout bounds how long ingest teardown waits for a debug
+// recording to finalize — for S3 the commit only happens at Close, so an
+// unbounded wait could wedge teardown while an unwaited exit loses the object.
+const debugRecordingFlushTimeout = 30 * time.Second
+
+// recordTee wires up a debug recording: everything read through the returned
+// reader is teed into an asynchronous dumpToFile. The returned finalize ends
+// the dump (closing the tee's pipe — the dump's io.Copy never sees EOF
+// otherwise, since a TeeReader doesn't propagate one) and waits, bounded, for
+// it to commit. Callers MUST finalize after ingest ends: on the S3 path the
+// object only exists once Close commits the upload, so skipping it (e.g. a
+// worker process exiting) silently loses the recording.
+func (mm *MediaManager) recordTee(ctx context.Context, r io.Reader, user string, filesuffix string) (io.Reader, func()) {
+	pr, pw := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := mm.dumpToFile(ctx, pr, user, filesuffix); err != nil {
+			log.Error(ctx, "error dumping to file", "error", err, "streamer", user)
+		}
+	}()
+	finalize := func() {
+		pw.Close()
+		select {
+		case <-done:
+		case <-time.After(debugRecordingFlushTimeout):
+			log.Error(ctx, "debug recording did not finalize in time", "streamer", user)
+		}
+	}
+	return io.TeeReader(r, pw), finalize
 }
 
 func (mm *MediaManager) dumpToFile(ctx context.Context, r io.Reader, user string, filesuffix string) error {

--- a/pkg/media/mkv_ingest.go
+++ b/pkg/media/mkv_ingest.go
@@ -125,7 +125,14 @@ func buildMKVIngestPipeline(ctx context.Context, input io.Reader, signerElem *gs
 // debugRecordingFlushTimeout bounds how long ingest teardown waits for a debug
 // recording to finalize — for S3 the commit only happens at Close, so an
 // unbounded wait could wedge teardown while an unwaited exit loses the object.
-const debugRecordingFlushTimeout = 30 * time.Second
+// Generous on purpose: at teardown there can be up to ~128 MB of backpressured
+// parts still uploading (multipartUploadConcurrency × MultipartPartSize), and a
+// slow-but-working uplink deserves the time to land them — a post-stream worker
+// lingering is cheap, a lost recording isn't. A genuinely stalled connection is
+// bounded separately by the s3 package's per-operation timeouts; past this
+// window the recording is abandoned (logged by the dump goroutine when its op
+// timeouts fire; bucket lifecycle rules should reap the dangling multipart).
+const debugRecordingFlushTimeout = 5 * time.Minute
 
 // recordTee wires up a debug recording: everything read through the returned
 // reader is teed into an asynchronous dumpToFile. The returned finalize ends

--- a/pkg/media/whip_worker.go
+++ b/pkg/media/whip_worker.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/pion/webrtc/v4"
-	"stream.place/streamplace/pkg/config"
 	"stream.place/streamplace/pkg/gstinit"
 	"stream.place/streamplace/pkg/log"
 	"stream.place/streamplace/pkg/rtcrec"
@@ -59,11 +58,11 @@ func ServeWHIPIngestWorkerSocket(ctx context.Context, cfg IngestWorkerConfig) er
 		return runErr
 	}
 
-	mm := &MediaManager{cli: &config.CLI{BroadcasterHost: cfg.BroadcasterHost, DataDir: cfg.DataDir}}
+	mm := &MediaManager{cli: cfg.workerCLI()}
 
 	// The worker owns the PeerConnection (its own UDP sockets), built with the
 	// same codec/interceptor setup as the in-process server. Debug recording is
-	// decided by main (cfg.Record) and written by the worker under cfg.DataDir.
+	// decided by main (cfg.Record) and written by the worker (S3 or cfg.DataDir).
 	api, webrtcConfig, err := newWebRTCAPI()
 	if err != nil {
 		return finish(fmt.Errorf("webrtc api: %w", err))
@@ -110,5 +109,10 @@ func ServeWHIPIngestWorkerSocket(ctx context.Context, cfg IngestWorkerConfig) er
 	cancel()
 	<-signerDone
 	flush()
+	// The recording commits asynchronously after pc.Close (drain sleep + S3
+	// commit); wait for it, or this process exits and the object never appears.
+	if rpc, ok := pc.(*rtcrec.RecordingPeerConnection); ok {
+		rpc.FinalizeRecording(ctx)
+	}
 	return finish(streamErr)
 }

--- a/pkg/rtcrec/recording_peerconnection.go
+++ b/pkg/rtcrec/recording_peerconnection.go
@@ -18,8 +18,9 @@ type RecordingPeerConnection struct {
 	pionpc    *webrtc.PeerConnection
 	file      config.DebugRecordingFile
 	stream    *RecorderStream
+	logCtx    context.Context // for finishRecording's logs (it outlives the session)
 	closeOnce sync.Once
-	recDone   chan struct{} // closed once the recording file/upload is committed
+	recDone   chan struct{} // closed once the finalize ATTEMPT is over — check the logs for commit failures
 }
 
 func NewRecordingPeerConnection(ctx context.Context, cli config.CLI, user string, pionpc *webrtc.PeerConnection, enabled bool) (PeerConnection, error) {
@@ -46,6 +47,7 @@ func NewRecordingPeerConnection(ctx context.Context, cli config.CLI, user string
 		file:    f,
 		stream:  stream,
 		enabled: enabled,
+		logCtx:  context.WithoutCancel(ctx),
 		recDone: make(chan struct{}),
 	}, nil
 }
@@ -63,21 +65,27 @@ func (pc *RecordingPeerConnection) Close() error {
 
 // finishRecording drains stragglers, commits the recording (for S3, Close IS
 // the commit), and signals recDone. Idempotent — Close on the disconnect path
-// and FinalizeRecording at worker exit can both trigger it.
+// and FinalizeRecording at worker exit can both trigger it. recDone means the
+// attempt finished, not that it succeeded: a failed commit is logged loudly
+// (there is nothing better to do with it at this point — the session is over).
 func (pc *RecordingPeerConnection) finishRecording() {
 	pc.closeOnce.Do(func() {
 		// This is sloppy but there might be other goroutines still writing so let's chill for a sec
 		time.Sleep(10 * time.Second)
-		pc.file.Close()
+		if err := pc.file.Close(); err != nil {
+			log.Error(pc.logCtx, "debug recording commit FAILED; the recording is lost", "file", pc.file.Name(), "error", err)
+		} else {
+			log.Log(pc.logCtx, "debug recording committed", "file", pc.file.Name())
+		}
 		close(pc.recDone)
 	})
 }
 
-// FinalizeRecording blocks until the debug recording is committed (bounded).
-// Call it before process exit on paths like the WHIP ingest worker: Close only
-// *starts* the drain+commit on a goroutine, and a process that exits first
-// strands an uncommitted S3 upload — the object never appears. No-op when not
-// recording.
+// FinalizeRecording blocks until the debug recording's commit attempt finishes
+// (bounded; failures are logged by finishRecording). Call it before process
+// exit on paths like the WHIP ingest worker: Close only *starts* the
+// drain+commit on a goroutine, and a process that exits first strands an
+// uncommitted S3 upload — the object never appears. No-op when not recording.
 func (pc *RecordingPeerConnection) FinalizeRecording(ctx context.Context) {
 	if !pc.enabled {
 		return

--- a/pkg/rtcrec/recording_peerconnection.go
+++ b/pkg/rtcrec/recording_peerconnection.go
@@ -99,8 +99,13 @@ func (pc *RecordingPeerConnection) FinalizeRecording(ctx context.Context) {
 }
 
 // recordingFinalizeTimeout bounds FinalizeRecording: the 10s straggler drain in
-// finishRecording plus generous headroom for the S3 commit.
-const recordingFinalizeTimeout = 40 * time.Second
+// finishRecording plus generous headroom for the S3 commit — enough for a
+// slow-but-working uplink to land any backpressured parts (a post-stream worker
+// lingering is cheap, a lost recording isn't). A genuinely stalled connection
+// is bounded separately by the s3 package's per-operation timeouts; past this
+// window the recording is abandoned and the commit failure logged when those
+// fire.
+const recordingFinalizeTimeout = 5 * time.Minute
 
 func (pc *RecordingPeerConnection) CreateAnswer(options *webrtc.AnswerOptions) (webrtc.SessionDescription, error) {
 	now := time.Now()

--- a/pkg/rtcrec/recording_peerconnection.go
+++ b/pkg/rtcrec/recording_peerconnection.go
@@ -3,6 +3,7 @@ package rtcrec
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/pion/rtcp"
@@ -13,10 +14,12 @@ import (
 )
 
 type RecordingPeerConnection struct {
-	enabled bool
-	pionpc  *webrtc.PeerConnection
-	file    config.DebugRecordingFile
-	stream  *RecorderStream
+	enabled   bool
+	pionpc    *webrtc.PeerConnection
+	file      config.DebugRecordingFile
+	stream    *RecorderStream
+	closeOnce sync.Once
+	recDone   chan struct{} // closed once the recording file/upload is committed
 }
 
 func NewRecordingPeerConnection(ctx context.Context, cli config.CLI, user string, pionpc *webrtc.PeerConnection, enabled bool) (PeerConnection, error) {
@@ -43,6 +46,7 @@ func NewRecordingPeerConnection(ctx context.Context, cli config.CLI, user string
 		file:    f,
 		stream:  stream,
 		enabled: enabled,
+		recDone: make(chan struct{}),
 	}, nil
 }
 
@@ -53,13 +57,42 @@ func (pc *RecordingPeerConnection) Do(f func()) {
 }
 
 func (pc *RecordingPeerConnection) Close() error {
-	pc.Do(func() {
+	pc.Do(pc.finishRecording)
+	return pc.pionpc.Close()
+}
+
+// finishRecording drains stragglers, commits the recording (for S3, Close IS
+// the commit), and signals recDone. Idempotent — Close on the disconnect path
+// and FinalizeRecording at worker exit can both trigger it.
+func (pc *RecordingPeerConnection) finishRecording() {
+	pc.closeOnce.Do(func() {
 		// This is sloppy but there might be other goroutines still writing so let's chill for a sec
 		time.Sleep(10 * time.Second)
 		pc.file.Close()
+		close(pc.recDone)
 	})
-	return pc.pionpc.Close()
 }
+
+// FinalizeRecording blocks until the debug recording is committed (bounded).
+// Call it before process exit on paths like the WHIP ingest worker: Close only
+// *starts* the drain+commit on a goroutine, and a process that exits first
+// strands an uncommitted S3 upload — the object never appears. No-op when not
+// recording.
+func (pc *RecordingPeerConnection) FinalizeRecording(ctx context.Context) {
+	if !pc.enabled {
+		return
+	}
+	go pc.finishRecording() // in case nothing called Close (e.g. pipeline error)
+	select {
+	case <-pc.recDone:
+	case <-time.After(recordingFinalizeTimeout):
+		log.Error(ctx, "debug recording did not finalize in time", "file", pc.file.Name())
+	}
+}
+
+// recordingFinalizeTimeout bounds FinalizeRecording: the 10s straggler drain in
+// finishRecording plus generous headroom for the S3 commit.
+const recordingFinalizeTimeout = 40 * time.Second
 
 func (pc *RecordingPeerConnection) CreateAnswer(options *webrtc.AnswerOptions) (webrtc.SessionDescription, error) {
 	now := time.Now()

--- a/pkg/s3/multipart_writer.go
+++ b/pkg/s3/multipart_writer.go
@@ -37,6 +37,17 @@ const MultipartPartSize = 16 * 1024 * 1024
 // so a 1.5 GB upload dragged on for tens of minutes.
 const multipartUploadConcurrency = 8
 
+// Per-operation deadlines for MultipartWriter's S3 calls. The SDK's default
+// HTTP client has no request timeout, so without these a stalled connection
+// blocks its caller forever — e.g. a debug-recording commit, whose writer
+// deliberately runs on a non-cancellable ctx (config.DebugRecordingCreate) so
+// session teardown can't abort it. Values are far above healthy operation
+// times; only genuine stalls hit them.
+const (
+	s3PartOpTimeout    = 10 * time.Minute // one ≤MultipartPartSize UploadPart
+	s3ControlOpTimeout = 2 * time.Minute  // create/complete/abort/empty-put
+)
+
 // multipartAPI is the subset of *s3.Client that MultipartWriter calls.
 // Pulled out so tests can inject a fake; *s3.Client satisfies it.
 type multipartAPI interface {
@@ -105,7 +116,9 @@ func newMultipartWriter(ctx context.Context, client multipartAPI, bucket, key, c
 	if contentType != "" {
 		in.ContentType = aws.String(contentType)
 	}
-	resp, err := client.CreateMultipartUpload(ctx, in)
+	cctx, cancel := context.WithTimeout(ctx, s3ControlOpTimeout)
+	defer cancel()
+	resp, err := client.CreateMultipartUpload(cctx, in)
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("create multipart upload s3://%s/%s: %w", bucket, key, err)
@@ -175,6 +188,8 @@ func (w *MultipartWriter) uploadPart(num int32, body []byte) {
 		attribute.Int("part_size_bytes", len(body)),
 	))
 	defer span.End()
+	ctx, cancel := context.WithTimeout(ctx, s3PartOpTimeout)
+	defer cancel()
 	resp, err := w.client.UploadPart(ctx, &s3.UploadPartInput{
 		Bucket:     aws.String(w.bucket),
 		Key:        aws.String(w.key),
@@ -244,6 +259,8 @@ func (w *MultipartWriter) Complete() error {
 		return err
 	}
 	span.SetAttributes(attribute.Int("part_count", len(w.parts)))
+	ctx, cancel := context.WithTimeout(ctx, s3ControlOpTimeout)
+	defer cancel()
 	if len(w.parts) == 0 {
 		// Zero-byte upload: S3 won't accept an empty CompletedMultipartUpload,
 		// so abort and create an empty object via PutObject.
@@ -308,6 +325,8 @@ func (w *MultipartWriter) Abort() error {
 		attribute.Int("parts_pending", len(w.parts)),
 	))
 	defer span.End()
+	ctx, cancel := context.WithTimeout(ctx, s3ControlOpTimeout)
+	defer cancel()
 	_, err := w.client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
 		Bucket:   aws.String(w.bucket),
 		Key:      aws.String(w.key),

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -15,13 +15,15 @@ import (
 	"stream.place/streamplace/pkg/log"
 )
 
-// Config holds the configuration for an S3-compatible upload target.
+// Config holds the configuration for an S3-compatible upload target. The json
+// tags exist because it rides the ingest-worker startup handshake (a dedicated
+// pipe fd, never argv/env — it carries the secret key).
 type Config struct {
-	Endpoint        string
-	Bucket          string
-	AccessKeyID     string
-	SecretAccessKey string
-	Region          string
+	Endpoint        string `json:"endpoint,omitempty"`
+	Bucket          string `json:"bucket,omitempty"`
+	AccessKeyID     string `json:"access_key_id,omitempty"`
+	SecretAccessKey string `json:"secret_access_key,omitempty"`
+	Region          string `json:"region,omitempty"`
 }
 
 // Recorder is an optional persistence hook for S3Uploader. RecordStart is


### PR DESCRIPTION
Two bugs, both from the July 4 S3 debug-recording change (bba1d2ca) meeting the June 6 worker-isolated recording change (f2c72925):

1. Ingest workers never got main's S3 config. buildWorkerConfig handed the worker only Record + DataDir, and both workers built a minimal config.CLI with no S3 fields — so S3Configured() was always false in the worker and DebugRecordingCreate silently fell back to local disk under DataDir. Every isolated-ingest recording (MKV/RTMP and WHIP, i.e. production) has been landing on the node's disk, not the bucket. The S3 config now rides the startup handshake (cfg.S3, sent only when recording), the same pipe that already carries the signing keys, and a shared workerCLI() applies it on both worker paths.

2. Nothing ever committed the S3 upload. The MKV tee's pipe writer was never closed, so the dump goroutine's io.Copy never returned and UploadWriter.Close — which is what completes the multipart upload — never ran. Harmless on local disk (bytes flush as written), fatal for S3 (the object never appears; this also broke the in-process path where main DOES have S3 config). The tee wiring is now a shared recordTee() whose finalize closes the pipe and waits, bounded, for the commit; MKVIngest and RunMKVIngestWorker both finalize at teardown. Same story on WHIP: rtcrec's delayed file.Close raced worker-process exit, so FinalizeRecording() now lets the WHIP worker block until the recording is committed. DebugRecordingCreate detaches the upload from the session ctx (WithoutCancel) so teardown's cancel can't abort the in-flight commit.

TestRunMKVIngestWorkerRecordsToS3 covers the production shape end to end against a fake path-style S3 server: cfg.S3 over the handshake, the object committed to the bucket verbatim, nothing on local disk.