### PR TITLE
Fix live dashboard link

### DIFF
--- a/js/docs/src/content/docs/guides/start-streaming/quick-start.md
+++ b/js/docs/src/content/docs/guides/start-streaming/quick-start.md
@@ -25,7 +25,7 @@ Streamplace is a video streaming service built on top of the AT Protocol (Authen
 
 ## Step 2: Get your stream key
 
-1. Click **Live Dashboard** (or go to [stream.place/dashboard](https://stream.place/dashboard))
+1. Click **Live Dashboard** (or go to [stream.place/live](https://stream.place/live))
 2. Click **Stream from OBS**
 3. Click **Generate Stream Key**
 4. Your key is copied to clipboard automatically


### PR DESCRIPTION
Hi there, I just went through your quick start guide and noticed it's linking to `/dashboard`, which leads to a non-existent user. The correct link appears to be `/live`

Resolves #1216 