### PR TITLE
atproto: survive a repair marked while a repo is being deepened

### DIFF
--- a/pkg/atproto/atproto.go
+++ b/pkg/atproto/atproto.go
@@ -193,11 +193,15 @@ func (atsync *ATProtoSynchronizer) DeepenRepo(ctx context.Context, did string) (
 	}
 
 	// The same lock a full sync takes, so the two cannot walk one repo at once.
-	// Nothing re-enters it: indexing a record calls SyncBlueskyRepoCached, which
-	// short-circuits on the Version this row already has.
+	// Indexing a record re-enters SyncBlueskyRepoCached for this same DID, and
+	// the Version check above is not enough to keep that from walking in here:
+	// a firehose gap detected mid-walk marks the repo for repair, which blanks
+	// Version. The in-flight mark is what holds regardless — without it, the
+	// re-entry takes this very lock and deadlocks the lane forever.
 	handleLock := handleLocks.GetLock(did)
 	handleLock.Lock()
 	defer handleLock.Unlock()
+	defer markSyncInFlight(did)()
 
 	ident, err := atsync.resolveIdent(ctx, did, true)
 	if err != nil {
@@ -230,8 +234,16 @@ func (atsync *ATProtoSynchronizer) DeepenRepo(ctx context.Context, did string) (
 		return false, "", err
 	}
 
-	if err := atsync.Model.AdvanceRepoBackfill(ctx, did, rev, root, window.Lo, window.Genesis); err != nil {
+	applied, err := atsync.Model.AdvanceRepoBackfill(ctx, did, rev, root, window.Lo, window.Genesis)
+	if err != nil {
 		return false, "", fmt.Errorf("failed to record backfill watermark for %s: %w", did, err)
+	}
+	if !applied {
+		// A repair wedged this repo while its window was being walked. The
+		// wedge wins: the window goes unrecorded, the repair re-syncs the repo,
+		// and the sweep ladders it again from the floor it already had.
+		log.Log(ctx, "repo was marked for repair mid-deepen; leaving it wedged")
+		return false, repo.BackfillFloor, nil
 	}
 	// Debug: at one line per repo per window this is thousands of lines per
 	// sweep. The sweep logs one Info summary per repo when its ladder finishes.

--- a/pkg/atproto/atproto.go
+++ b/pkg/atproto/atproto.go
@@ -63,16 +63,19 @@ func (atsync *ATProtoSynchronizer) SyncBlueskyRepo(ctx context.Context, handle s
 	// back, and a row can vanish mid-walk — an operator deleting it to force
 	// a resync is a long-standing habit. With no row, the walk's own record
 	// visitor falls through to here and would lock the mutex its caller
-	// already holds. An in-flight DID never wants a second sync started
-	// anyway; the record this call was serving is re-indexed by whatever
-	// sync runs next.
-	if syncInFlight(ident.DID.String()) {
-		return nil, fmt.Errorf("sync already in flight for %s", ident.DID.String())
+	// already holds. The ctx marker identifies exactly that call tree and
+	// nothing else: an unrelated caller racing this DID's first sync still
+	// waits on the lock like it always has, instead of getting an error for
+	// a microsecond coincidence. The record the refused call was serving is
+	// re-indexed by whatever sync runs next.
+	if walkingDID(ctx) == ident.DID.String() {
+		return nil, fmt.Errorf("refusing re-entrant sync of %s inside its own walk", ident.DID.String())
 	}
 
 	handleLock := handleLocks.GetLock(ident.DID.String())
 	handleLock.Lock()
 	defer handleLock.Unlock()
+	ctx = markWalking(ctx, ident.DID.String())
 
 	// Tell re-entrant callers (handleCreateUpdate syncs the repos it sees
 	// records from) that this DID's placeholder row is being filled in right
@@ -214,6 +217,7 @@ func (atsync *ATProtoSynchronizer) DeepenRepo(ctx context.Context, did string) (
 	handleLock.Lock()
 	defer handleLock.Unlock()
 	defer markSyncInFlight(did)()
+	ctx = markWalking(ctx, did)
 
 	ident, err := atsync.resolveIdent(ctx, did, true)
 	if err != nil {
@@ -261,6 +265,24 @@ func (atsync *ATProtoSynchronizer) DeepenRepo(ctx context.Context, did string) (
 	// sweep. The sweep logs one Info summary per repo when its ladder finishes.
 	log.Debug(ctx, "deepened repo history", "rev", rev, "floor", window.Lo, "done", window.Genesis)
 	return window.Genesis, window.Lo, nil
+}
+
+// walkingDIDKey carries, on a ctx, the DID whose repo walk this call tree is
+// performing. It is how a re-entrant sync attempt for that DID — a record
+// visitor calling back into SyncBlueskyRepo after the row vanished out from
+// under its walk — can be refused instead of deadlocking on the per-DID lock
+// its own caller holds. A ctx value rather than a registry on purpose: it
+// names one call tree, so unrelated concurrent callers are never mistaken for
+// re-entry.
+type walkingDIDKey struct{}
+
+func markWalking(ctx context.Context, did string) context.Context {
+	return context.WithValue(ctx, walkingDIDKey{}, did)
+}
+
+func walkingDID(ctx context.Context) string {
+	s, _ := ctx.Value(walkingDIDKey{}).(string)
+	return s
 }
 
 // syncsInFlight holds the DIDs whose backfill is running in this process right

--- a/pkg/atproto/atproto.go
+++ b/pkg/atproto/atproto.go
@@ -58,6 +58,18 @@ func (atsync *ATProtoSynchronizer) SyncBlueskyRepo(ctx context.Context, handle s
 
 	ctx = log.WithLogValues(ctx, "did", ident.DID.String(), "handle", ident.Handle.String())
 
+	// The nil-row flavour of SyncBlueskyRepoCached's re-entrancy guard. That
+	// guard can only consult the in-flight mark when it has a row to hand
+	// back, and a row can vanish mid-walk — an operator deleting it to force
+	// a resync is a long-standing habit. With no row, the walk's own record
+	// visitor falls through to here and would lock the mutex its caller
+	// already holds. An in-flight DID never wants a second sync started
+	// anyway; the record this call was serving is re-indexed by whatever
+	// sync runs next.
+	if syncInFlight(ident.DID.String()) {
+		return nil, fmt.Errorf("sync already in flight for %s", ident.DID.String())
+	}
+
 	handleLock := handleLocks.GetLock(ident.DID.String())
 	handleLock.Lock()
 	defer handleLock.Unlock()

--- a/pkg/atproto/backfill_walk_test.go
+++ b/pkg/atproto/backfill_walk_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -849,4 +850,93 @@ func createBackfillRecord(t *testing.T, acct *devenv.DevEnvAccount, collection, 
 	out, err := comatproto.RepoCreateRecord(context.Background(), acct.XRPC, in)
 	require.NoError(t, err, "creating %s record", collection)
 	return collection + "/" + out.Uri[strings.LastIndex(out.Uri, "/")+1:]
+}
+
+// wedgeOnGetBlocks marks a repo for repair the first time a sync fetch goes
+// out, which lands in exactly the window a live firehose gap detection can
+// fire in: after DeepenRepo's entry check of Version, while its walk is in
+// flight and the per-DID lock is held.
+type wedgeOnGetBlocks struct {
+	base http.RoundTripper
+	once sync.Once
+	mod  model.Model
+	ctx  context.Context
+	did  string
+	from string
+	err  error
+}
+
+func (w *wedgeOnGetBlocks) RoundTrip(req *http.Request) (*http.Response, error) {
+	if strings.Contains(req.URL.Path, "com.atproto.sync.getBlocks") {
+		w.once.Do(func() {
+			marked, err := w.mod.MarkRepoForRepair(w.ctx, w.did, w.from)
+			if err != nil {
+				w.err = fmt.Errorf("wedging repo: %w", err)
+			} else if !marked {
+				w.err = fmt.Errorf("wedging repo: CAS did not apply")
+			}
+		})
+	}
+	return w.base.RoundTrip(req)
+}
+
+// TestDeepenSurvivesMidWalkRepair reproduces a production deadlock. DeepenRepo
+// holds the per-DID lock for its whole window walk; a firehose gap detection
+// marked the repo for repair mid-walk, blanking Version; the walk's visitor
+// then re-entered SyncBlueskyRepoCached for the same DID, whose Version
+// short-circuit fell through -- and the re-entry locked the mutex its own
+// caller was holding. Forever: the lane and every later action for that user
+// queued up behind a lock nothing would release. The in-flight mark is what
+// makes the re-entry take the wedged row instead.
+//
+// It also pins down what happens to the wedge afterwards: the deepen's
+// watermark write must not resurrect Version over a repair somebody has
+// evidence for.
+func TestDeepenSurvivesMidWalkRepair(t *testing.T) {
+	dev := devenv.WithDevEnv(t)
+	ctx := context.Background()
+	atsync, mod := backfillTestSynchronizer(t, dev)
+
+	user := dev.CreateAccount(t)
+	createBackfillRecord(t, user, "place.stream.chat.profile", "self", &placestream.ChatProfile{})
+	// A chat message three days old: outside the shallow window, so it is the
+	// deepening walk -- not the shallow sync -- that indexes it and re-enters.
+	oldRkey := reposync.TIDForTime(time.Now().Add(-72 * time.Hour))
+	createBackfillRecord(t, user, "place.stream.chat.message", oldRkey,
+		chatMessageRecord(user.DID, "from the deep window"))
+
+	_, err := atsync.SyncBlueskyRepoCached(ctx, user.DID)
+	require.NoError(t, err)
+	synced, err := mod.GetRepo(user.DID)
+	require.NoError(t, err)
+	require.NotEmpty(t, synced.Version)
+	require.False(t, synced.BackfillDone, "the old message leaves history to deepen")
+
+	// From here on the next sync fetch is the deepen's: wedge the repo there.
+	wedge := &wedgeOnGetBlocks{base: SyncHTTPClient.Transport, mod: mod, ctx: ctx, did: user.DID, from: synced.Version}
+	SyncHTTPClient.Transport = wedge
+	t.Cleanup(func() { SyncHTTPClient.Transport = wedge.base })
+
+	type result struct {
+		done bool
+		err  error
+	}
+	got := make(chan result, 1)
+	go func() {
+		done, _, err := atsync.DeepenRepo(ctx, user.DID)
+		got <- result{done, err}
+	}()
+	select {
+	case r := <-got:
+		require.NoError(t, r.err)
+		require.False(t, r.done, "a wedged repo is not done deepening")
+	case <-time.After(30 * time.Second):
+		t.Fatal("DeepenRepo deadlocked on its own per-DID lock")
+	}
+	require.NoError(t, wedge.err)
+
+	wedged, err := mod.GetRepo(user.DID)
+	require.NoError(t, err)
+	require.Empty(t, wedged.Version, "the repair wedge survives the deepen")
+	require.Equal(t, synced.Version, wedged.RepairFrom, "and still knows where the missed span starts")
 }

--- a/pkg/atproto/backfill_walk_test.go
+++ b/pkg/atproto/backfill_walk_test.go
@@ -852,30 +852,20 @@ func createBackfillRecord(t *testing.T, acct *devenv.DevEnvAccount, collection, 
 	return collection + "/" + out.Uri[strings.LastIndex(out.Uri, "/")+1:]
 }
 
-// wedgeOnGetBlocks marks a repo for repair the first time a sync fetch goes
-// out, which lands in exactly the window a live firehose gap detection can
-// fire in: after DeepenRepo's entry check of Version, while its walk is in
-// flight and the per-DID lock is held.
+// wedgeOnGetBlocks runs a hook the first time a sync fetch goes out, which
+// lands in exactly the window a concurrent actor can strike in: after
+// DeepenRepo's entry check of the row, while its walk is in flight and the
+// per-DID lock is held.
 type wedgeOnGetBlocks struct {
 	base http.RoundTripper
 	once sync.Once
-	mod  model.Model
-	ctx  context.Context
-	did  string
-	from string
+	hook func() error
 	err  error
 }
 
 func (w *wedgeOnGetBlocks) RoundTrip(req *http.Request) (*http.Response, error) {
 	if strings.Contains(req.URL.Path, "com.atproto.sync.getBlocks") {
-		w.once.Do(func() {
-			marked, err := w.mod.MarkRepoForRepair(w.ctx, w.did, w.from)
-			if err != nil {
-				w.err = fmt.Errorf("wedging repo: %w", err)
-			} else if !marked {
-				w.err = fmt.Errorf("wedging repo: CAS did not apply")
-			}
-		})
+		w.once.Do(func() { w.err = w.hook() })
 	}
 	return w.base.RoundTrip(req)
 }
@@ -912,8 +902,18 @@ func TestDeepenSurvivesMidWalkRepair(t *testing.T) {
 	require.NotEmpty(t, synced.Version)
 	require.False(t, synced.BackfillDone, "the old message leaves history to deepen")
 
-	// From here on the next sync fetch is the deepen's: wedge the repo there.
-	wedge := &wedgeOnGetBlocks{base: SyncHTTPClient.Transport, mod: mod, ctx: ctx, did: user.DID, from: synced.Version}
+	// From here on the next sync fetch is the deepen's: wedge the repo there,
+	// the way a live firehose gap detection does.
+	wedge := &wedgeOnGetBlocks{base: SyncHTTPClient.Transport, hook: func() error {
+		marked, err := mod.MarkRepoForRepair(ctx, user.DID, synced.Version)
+		if err != nil {
+			return fmt.Errorf("wedging repo: %w", err)
+		}
+		if !marked {
+			return fmt.Errorf("wedging repo: CAS did not apply")
+		}
+		return nil
+	}}
 	SyncHTTPClient.Transport = wedge
 	t.Cleanup(func() { SyncHTTPClient.Transport = wedge.base })
 
@@ -939,4 +939,63 @@ func TestDeepenSurvivesMidWalkRepair(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, wedged.Version, "the repair wedge survives the deepen")
 	require.Equal(t, synced.Version, wedged.RepairFrom, "and still knows where the missed span starts")
+}
+
+// TestDeepenSurvivesMidWalkRowDeletion is the second trigger of the same
+// deadlock, performed in production by an operator: deleting a repo's row was
+// the old system's way to force a full resync, and doing it while a deepen
+// held the row's lock left the walk's visitor with no row at all -- which
+// falls through SyncBlueskyRepoCached's guard (it needs a row to consult) into
+// a full sync that locks the mutex its caller holds. The nil-row in-flight
+// guard in SyncBlueskyRepo is what turns that into a per-record error the walk
+// shrugs off. Afterwards, the delete does what the operator wanted all along:
+// the next touch resyncs the repo from scratch.
+func TestDeepenSurvivesMidWalkRowDeletion(t *testing.T) {
+	dev := devenv.WithDevEnv(t)
+	ctx := context.Background()
+	atsync, mod := backfillTestSynchronizer(t, dev)
+
+	user := dev.CreateAccount(t)
+	createBackfillRecord(t, user, "place.stream.chat.profile", "self", &placestream.ChatProfile{})
+	oldRkey := reposync.TIDForTime(time.Now().Add(-72 * time.Hour))
+	createBackfillRecord(t, user, "place.stream.chat.message", oldRkey,
+		chatMessageRecord(user.DID, "from the deep window"))
+
+	_, err := atsync.SyncBlueskyRepoCached(ctx, user.DID)
+	require.NoError(t, err)
+	synced, err := mod.GetRepo(user.DID)
+	require.NoError(t, err)
+	require.NotEmpty(t, synced.Version)
+	require.False(t, synced.BackfillDone)
+
+	// Mid-walk, the operator deletes the row to "force a resync".
+	wedge := &wedgeOnGetBlocks{base: SyncHTTPClient.Transport, hook: func() error {
+		return mod.(*model.DBModel).DB.Exec("DELETE FROM repos WHERE did = ?", user.DID).Error
+	}}
+	SyncHTTPClient.Transport = wedge
+	t.Cleanup(func() { SyncHTTPClient.Transport = wedge.base })
+
+	type result struct {
+		done bool
+		err  error
+	}
+	got := make(chan result, 1)
+	go func() {
+		done, _, err := atsync.DeepenRepo(ctx, user.DID)
+		got <- result{done, err}
+	}()
+	select {
+	case r := <-got:
+		require.NoError(t, r.err)
+		require.False(t, r.done, "a deleted row records nothing")
+	case <-time.After(30 * time.Second):
+		t.Fatal("DeepenRepo deadlocked on its own per-DID lock")
+	}
+	require.NoError(t, wedge.err)
+
+	// The lock is free again, so the delete now means what it used to: the
+	// next touch resyncs the account from scratch.
+	resynced, err := atsync.SyncBlueskyRepoCached(ctx, user.DID)
+	require.NoError(t, err)
+	require.NotEmpty(t, resynced.Version)
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -39,7 +39,7 @@ type Model interface {
 	SearchReposByHandle(query string, limit int) ([]Repo, error)
 	UpdateRepo(repo *Repo) error
 	UpdateRepoIdentity(did, handle, pds string) error
-	AdvanceRepoBackfill(ctx context.Context, did, version, rootCID, floor string, done bool) error
+	AdvanceRepoBackfill(ctx context.Context, did, version, rootCID, floor string, done bool) (bool, error)
 	AdvanceRepoVersion(ctx context.Context, did, from, to string) (bool, error)
 	MarkRepoForRepair(ctx context.Context, did, from string) (bool, error)
 	SetRepoStatus(ctx context.Context, did string, status string) error

--- a/pkg/model/repo.go
+++ b/pkg/model/repo.go
@@ -131,22 +131,32 @@ func (m *DBModel) SetRepoStatus(ctx context.Context, did string, status string) 
 
 // AdvanceRepoBackfill records the outcome of one deepening window: the repo is
 // now indexed from floor forward (empty floor meaning all the way back), at the
-// revision that window was read at.
+// revision that window was read at. It reports whether the record applied.
 //
 // It writes exactly those four columns rather than the whole row, so a
 // concurrent handle change or status update cannot be rolled back by a sweep
 // that read the row minutes ago. Select names the fields explicitly, which is
 // also what makes the zero values -- an empty floor, a false flag -- get
 // written instead of skipped.
-func (m *DBModel) AdvanceRepoBackfill(ctx context.Context, did, version, rootCID, floor string, done bool) error {
-	return m.DB.WithContext(ctx).Model(&Repo{}).Where("did = ?", did).
+//
+// A repo whose Version has been blanked is left alone, and the write reports
+// false: an empty Version is a repair somebody has evidence for, marked while
+// this window was being walked, and writing a Version here would quietly
+// cancel it. The wedge wins; the window goes unrecorded and is re-walked
+// after the repair.
+func (m *DBModel) AdvanceRepoBackfill(ctx context.Context, did, version, rootCID, floor string, done bool) (bool, error) {
+	res := m.DB.WithContext(ctx).Model(&Repo{}).Where("did = ? AND version <> ''", did).
 		Select("Version", "RootCID", "BackfillFloor", "BackfillDone").
 		Updates(Repo{
 			Version:       version,
 			RootCID:       rootCID,
 			BackfillFloor: floor,
 			BackfillDone:  done,
-		}).Error
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected > 0, nil
 }
 
 // AdvanceRepoVersion moves a repo's revision from one value to another, and


### PR DESCRIPTION
Claude says:

Production deadlock, held for 80+ minutes on two lanes: DeepenRepo holds the per-DID lock for its whole window walk, and its safety story against re-entry -- indexing a record calls SyncBlueskyRepoCached, which short-circuits on the Version the row already has -- silently assumed Version stays put. It does not: a firehose gap detected mid-walk marks the repo for repair, which blanks Version. The next record the walk indexed fell through the short-circuit into a full SyncBlueskyRepo, which locked the mutex its own caller was holding. The lane died, and every later action for that user queued up behind a lock nothing would ever release.

Two fixes, both sides of the same race:

- DeepenRepo now marks syncsInFlight, the same signal SyncBlueskyRepo itself uses, so the mid-walk re-entry takes the wedged row instead of the lock.
- AdvanceRepoBackfill refuses to write over a blanked Version and reports whether it applied. A wedge is a repair somebody has evidence for; the deepen recording its watermark would have quietly cancelled it. Now the wedge wins, the window goes unrecorded, and the repair re-syncs the repo before the sweep ladders it again.

TestDeepenSurvivesMidWalkRepair reproduces the whole thing against the reference PDS, using a test transport that marks the repo for repair the moment the deepen's first fetch goes out: without the in-flight mark it deadlocks (caught by a timeout), with it the walk completes, and the wedge -- RepairFrom included -- survives the deepen.