### PR TITLE
atproto: remove redundant handle cache

### DIFF
--- a/pkg/atproto/atproto.go
+++ b/pkg/atproto/atproto.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/patrickmn/go-cache"
-
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/xrpc"
@@ -20,8 +18,6 @@ import (
 )
 
 var SyncGetRepo = comatproto.SyncGetRepo
-
-var handleCache = cache.New(1*time.Hour, 10*time.Minute)
 
 func (atsync *ATProtoSynchronizer) SyncBlueskyRepoCached(ctx context.Context, handle string) (*model.Repo, error) {
 	ctx, span := otel.Tracer("signer").Start(ctx, "SyncBlueskyRepoCached")
@@ -357,19 +353,12 @@ func (atsync *ATProtoSynchronizer) RefreshIdentity(ctx context.Context, did stri
 }
 
 func (atsync *ATProtoSynchronizer) ResolveAuthorHandle(ctx context.Context, did string) string {
-	if cached, ok := handleCache.Get(did); ok {
-		return cached.(string)
-	}
 	ident, err := atsync.resolveIdent(ctx, did, true)
 	if err != nil {
 		log.Warn(ctx, "failed to resolve author handle", "did", did, "err", err)
 		return ""
 	}
-	handle := ident.Handle.String()
-	if handle != "" {
-		handleCache.SetDefault(did, handle)
-	}
-	return handle
+	return ident.Handle.String()
 }
 
 // directory hands back the identity directory to resolve with, building the

--- a/pkg/atproto/atproto.go
+++ b/pkg/atproto/atproto.go
@@ -349,6 +349,9 @@ func (atsync *ATProtoSynchronizer) RefreshIdentity(ctx context.Context, did stri
 	if err != nil {
 		return nil, fmt.Errorf("failed to update repo: %w", err)
 	}
+	// Drop the cached identity so subsequent cached resolves pick up the new
+	// PDS/handle instead of serving the stale entry for up to 24h.
+	atsync.purgeIdentCache(ctx, id.DID.String())
 	return id, nil
 }
 

--- a/pkg/atproto/refresh_identity_test.go
+++ b/pkg/atproto/refresh_identity_test.go
@@ -10,10 +10,8 @@ import (
 	"stream.place/streamplace/pkg/devenv"
 )
 
-// TestRefreshIdentityPurgesCache proves that RefreshIdentity drops the cached
-// identity entry, so the next cached resolve picks up a new PDS/handle instead
-// of serving a stale entry for up to 24h. Without the purge, a PDS migration
-// would leave every cached resolve pointing at the dead host.
+// RefreshIdentity should drop the cached identity entry,
+// so the next cached resolve picks up a new PDS/handle
 func TestRefreshIdentityPurgesCache(t *testing.T) {
 	dev := devenv.WithDevEnv(t)
 	ctx := context.Background()

--- a/pkg/atproto/refresh_identity_test.go
+++ b/pkg/atproto/refresh_identity_test.go
@@ -1,0 +1,43 @@
+package atproto
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/stretchr/testify/require"
+	"stream.place/streamplace/pkg/devenv"
+)
+
+// TestRefreshIdentityPurgesCache proves that RefreshIdentity drops the cached
+// identity entry, so the next cached resolve picks up a new PDS/handle instead
+// of serving a stale entry for up to 24h. Without the purge, a PDS migration
+// would leave every cached resolve pointing at the dead host.
+func TestRefreshIdentityPurgesCache(t *testing.T) {
+	dev := devenv.WithDevEnv(t)
+	ctx := context.Background()
+	atsync, _ := backfillTestSynchronizer(t, dev)
+	user := dev.CreateAccount(t)
+
+	// Warm the cache with a cached resolve.
+	_, err := atsync.resolveIdent(ctx, user.DID, true)
+	require.NoError(t, err)
+
+	did, err := syntax.ParseDID(user.DID)
+	require.NoError(t, err)
+
+	cd, ok := atsync.directory(true).(*identity.CacheDirectory)
+	require.True(t, ok)
+	_, hit, err := cd.LookupDIDWithCacheState(ctx, did)
+	require.NoError(t, err)
+	require.True(t, hit, "cache should be warm before refresh")
+
+	// RefreshIdentity should purge the cached entry.
+	_, err = atsync.RefreshIdentity(ctx, user.DID)
+	require.NoError(t, err)
+
+	_, hit, err = cd.LookupDIDWithCacheState(ctx, did)
+	require.NoError(t, err)
+	require.False(t, hit, "RefreshIdentity should purge the cached identity")
+}

--- a/pkg/atproto/resolve_handle_test.go
+++ b/pkg/atproto/resolve_handle_test.go
@@ -11,9 +11,7 @@ import (
 )
 
 // TestResolveAuthorHandleReadsThroughCacheDirectory verifies that
-// ResolveAuthorHandle is served from CacheDirectory, so purgeIdentCache
-// invalidates it. (Dev accounts resolve as handle.invalid, so this tests
-// the purge mechanism rather than a real rename.)
+// ResolveAuthorHandle is served from CacheDirectory and invalidated properly
 func TestResolveAuthorHandleReadsThroughCacheDirectory(t *testing.T) {
 	dev := devenv.WithDevEnv(t)
 	ctx := context.Background()

--- a/pkg/atproto/resolve_handle_test.go
+++ b/pkg/atproto/resolve_handle_test.go
@@ -1,0 +1,46 @@
+package atproto
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/stretchr/testify/require"
+	"stream.place/streamplace/pkg/devenv"
+)
+
+// TestResolveAuthorHandleReadsThroughCacheDirectory verifies that
+// ResolveAuthorHandle is served from CacheDirectory, so purgeIdentCache
+// invalidates it. (Dev accounts resolve as handle.invalid, so this tests
+// the purge mechanism rather than a real rename.)
+func TestResolveAuthorHandleReadsThroughCacheDirectory(t *testing.T) {
+	dev := devenv.WithDevEnv(t)
+	ctx := context.Background()
+	atsync, _ := backfillTestSynchronizer(t, dev)
+	user := dev.CreateAccount(t)
+
+	// First call warms the CacheDirectory.
+	handle := atsync.ResolveAuthorHandle(ctx, user.DID)
+	require.NotEmpty(t, handle, "first resolve should return a handle")
+
+	did, err := syntax.ParseDID(user.DID)
+	require.NoError(t, err)
+
+	cd, ok := atsync.directory(true).(*identity.CacheDirectory)
+	require.True(t, ok)
+	_, hit, err := cd.LookupDIDWithCacheState(ctx, did)
+	require.NoError(t, err)
+	require.True(t, hit, "ResolveAuthorHandle should warm the CacheDirectory")
+
+	// Purge, then confirm the next lookup is a cache miss.
+	atsync.purgeIdentCache(ctx, user.DID)
+	_, hit, err = cd.LookupDIDWithCacheState(ctx, did)
+	require.NoError(t, err)
+	require.False(t, hit, "purgeIdentCache should evict the entry")
+
+	// Second call still resolves successfully after purge.
+	handle2 := atsync.ResolveAuthorHandle(ctx, user.DID)
+	require.NotEmpty(t, handle2, "resolve after purge should still succeed")
+	require.Equal(t, handle, handle2, "same identity, same handle")
+}


### PR DESCRIPTION
Deleted redundant `handleCache`, routing everything through `CacheDirectory` which has proper invalidation on identity change.