### PR TITLE
Lift up stream settings so the metadata doesn't revert on rerender

### DIFF
--- a/js/app/components/live-dashboard/livestream-panel.tsx
+++ b/js/app/components/live-dashboard/livestream-panel.tsx
@@ -25,6 +25,7 @@ import {
   useUrl,
   zero,
 } from "@streamplace/components";
+import { useStreamSettings } from "contexts/StreamSettingsContext";
 import { Image } from "expo-image";
 import { ChevronsUpDown, ImagePlus, Lock, X } from "lucide-react-native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -317,9 +318,7 @@ function LivestreamPanel({ scrollable = true }: { scrollable?: boolean }) {
   const [selectedImage, setSelectedImage] = useState<
     string | File | Blob | undefined
   >();
-  const [mode, setMode] = useState<"create" | "metadata" | "moderation">(
-    "create",
-  );
+  const { mode, setMode, metadata, setMetadata } = useStreamSettings();
 
   const [activity, setActivity] = useState<
     place.stream.livestream.Main["activity"] | undefined
@@ -384,7 +383,19 @@ function LivestreamPanel({ scrollable = true }: { scrollable?: boolean }) {
     (newMode: "create" | "metadata" | "moderation") => {
       setMode(newMode);
     },
-    [],
+    [setMode],
+  );
+
+  const handleMetadataChange = useCallback(
+    (next: place.stream.metadata.configuration.Main) => {
+      const hasContent =
+        (next.contentWarnings?.warnings?.length ?? 0) > 0 ||
+        (next.distributionPolicy &&
+          Object.keys(next.distributionPolicy).length > 0) ||
+        (next.contentRights && Object.keys(next.contentRights).length > 0);
+      setMetadata(hasContent ? next : null);
+    },
+    [setMetadata],
   );
 
   const handleSubmit = useCallback(async () => {
@@ -600,6 +611,8 @@ function LivestreamPanel({ scrollable = true }: { scrollable?: boolean }) {
               <ContentMetadataForm
                 showUpdateButton={!userIsLive}
                 style={{ flex: 1, height: "100%" }}
+                initialMetadata={metadata ?? undefined}
+                onMetadataChange={handleMetadataChange}
               />
             </View>
           ) : mode === "moderation" ? (

--- a/js/app/contexts/StreamSettingsContext.tsx
+++ b/js/app/contexts/StreamSettingsContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, ReactNode, useContext, useState } from "react";
+import type { place } from "streamplace";
+
+export type StreamSettingsMode = "create" | "metadata" | "moderation";
+
+export interface StreamSettingsContextValue {
+  mode: StreamSettingsMode;
+  setMode: (mode: StreamSettingsMode) => void;
+  metadata: place.stream.metadata.configuration.Main | null;
+  setMetadata: (
+    metadata: place.stream.metadata.configuration.Main | null,
+  ) => void;
+}
+
+const StreamSettingsContext = createContext<
+  StreamSettingsContextValue | undefined
+>(undefined);
+
+export function StreamSettingsProvider({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState<StreamSettingsMode>("create");
+  const [metadata, setMetadata] =
+    useState<place.stream.metadata.configuration.Main | null>(null);
+
+  return (
+    <StreamSettingsContext.Provider
+      value={{ mode, setMode, metadata, setMetadata }}
+    >
+      {children}
+    </StreamSettingsContext.Provider>
+  );
+}
+
+export function useStreamSettings() {
+  const ctx = useContext(StreamSettingsContext);
+  if (ctx === undefined) {
+    throw new Error(
+      "useStreamSettings must be used within a StreamSettingsProvider",
+    );
+  }
+  return ctx;
+}

--- a/js/app/src/screens/live-dashboard.tsx
+++ b/js/app/src/screens/live-dashboard.tsx
@@ -2,6 +2,7 @@ import { useRoute } from "@react-navigation/native";
 import { LivestreamProvider, PlayerProvider } from "@streamplace/components";
 import BentoGrid from "components/live-dashboard/bento-grid";
 import Loading from "components/loading/loading";
+import { StreamSettingsProvider } from "contexts/StreamSettingsContext";
 import { VideoElementProvider } from "contexts/VideoElementContext";
 import { useLiveUser } from "hooks/useLiveUser";
 import { useCallback, useEffect, useState } from "react";
@@ -42,7 +43,9 @@ export default function LiveDashboard() {
     <LivestreamProvider src={userProfile.did}>
       <VideoElementProvider videoElement={videoElement}>
         <PlayerProvider>
-          <BentoGrid isLive={isLive} videoRef={videoRef} />
+          <StreamSettingsProvider>
+            <BentoGrid isLive={isLive} videoRef={videoRef} />
+          </StreamSettingsProvider>
         </PlayerProvider>
       </VideoElementProvider>
     </LivestreamProvider>

--- a/js/app/src/screens/popout-livestream.tsx
+++ b/js/app/src/screens/popout-livestream.tsx
@@ -5,6 +5,7 @@ import {
 } from "@streamplace/components";
 import LivestreamPanel from "components/live-dashboard/livestream-panel";
 import Loading from "components/loading/loading";
+import { StreamSettingsProvider } from "contexts/StreamSettingsContext";
 import { useEffect } from "react";
 import { View } from "react-native";
 import { useStore } from "store";
@@ -35,9 +36,11 @@ export default function PopoutLivestream() {
   return (
     <LivestreamProvider src={userProfile.did}>
       <PlayerProvider>
-        <View style={[flex.values[1], p[1]]}>
-          <LivestreamPanel />
-        </View>
+        <StreamSettingsProvider>
+          <View style={[flex.values[1], p[1]]}>
+            <LivestreamPanel />
+          </View>
+        </StreamSettingsProvider>
       </PlayerProvider>
     </LivestreamProvider>
   );

--- a/js/components/src/components/content-metadata/content-metadata-form.tsx
+++ b/js/components/src/components/content-metadata/content-metadata-form.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useState } from "react";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
 import { Linking, Pressable, ScrollView, View } from "react-native";
 import {
   CONTENT_WARNINGS,
@@ -115,20 +115,33 @@ export const ContentMetadataForm = forwardRef<any, ContentMetadataFormProps>(
 
     const broadcasterDID = useStreamplaceStore((state) => state.broadcasterDID);
 
-    // Load existing metadata on mount or from initialMetadata prop
+    // Load existing metadata on mount, or restore the working copy passed in
+    // via initialMetadata
+    const initializedRef = useRef(false);
     useEffect(() => {
+      if (initializedRef.current) return;
+      initializedRef.current = true;
+
+      const applyMetadata = (
+        record: place.stream.metadata.configuration.Main,
+      ) => {
+        if (record.contentWarnings?.warnings) {
+          setContentWarnings(
+            record.contentWarnings.warnings as unknown as string[],
+          );
+        }
+        if (record.distributionPolicy) {
+          setDistributionPolicy(record.distributionPolicy);
+        }
+        if (record.contentRights) {
+          setContentRights(record.contentRights);
+          setSelectedLicense(record.contentRights.license || "");
+        }
+      };
+
       if (initialMetadata) {
-        // Use provided initial metadata
-        if (initialMetadata.contentWarnings?.warnings) {
-          setContentWarnings(initialMetadata.contentWarnings.warnings);
-        }
-        if (initialMetadata.distributionPolicy) {
-          setDistributionPolicy(initialMetadata.distributionPolicy);
-        }
-        if (initialMetadata.contentRights) {
-          setContentRights(initialMetadata.contentRights);
-          setSelectedLicense(initialMetadata.contentRights.license || "");
-        }
+        setHasMetadata(true);
+        applyMetadata(initialMetadata);
         return;
       }
 
@@ -139,18 +152,7 @@ export const ContentMetadataForm = forwardRef<any, ContentMetadataFormProps>(
           const metadata = await getContentMetadata();
           if (metadata?.record) {
             setHasMetadata(true);
-            if (metadata.record.contentWarnings?.warnings) {
-              setContentWarnings(
-                metadata.record.contentWarnings.warnings as string[],
-              );
-            }
-            if (metadata.record.distributionPolicy) {
-              setDistributionPolicy(metadata.record.distributionPolicy);
-            }
-            if (metadata.record.contentRights) {
-              setContentRights(metadata.record.contentRights);
-              setSelectedLicense(metadata.record.contentRights.license || "");
-            }
+            applyMetadata(metadata.record);
           }
         } catch (error) {
           // No existing metadata is fine


### PR DESCRIPTION
When crossing the 1200px boundary, we totally reset the live dashboard. So, to rerender the components with the same data, we lift up the stream settings outside of the component and put it in a context.

Ideally we would reflow, but this technique can give us slightly more control if we use the components library in other apps.