### PR TITLE
spxrpc: serve declared lexicon content types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/starttoaster/prometheus-exporter-scraper v0.0.1
 	github.com/streamplace/atmoq/go v0.0.4-0.20260701223355-13757de4ae08
 	github.com/streamplace/atproto-oauth-golang v0.0.0-20260413212710-98956064d06c
-	github.com/streamplace/glex v0.0.0-20260716203108-f73ed7cc31c9
+	github.com/streamplace/glex v0.0.0-20260820164827-814f46540f22
 	github.com/streamplace/muxl/go v0.3.5
 	github.com/streamplace/oatproxy v0.0.0-20260710202406-60d97b9d780b
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1377,6 +1377,8 @@ github.com/streamplace/atproto-oauth-golang v0.0.0-20260413212710-98956064d06c h
 github.com/streamplace/atproto-oauth-golang v0.0.0-20260413212710-98956064d06c/go.mod h1:9LlKkqciiO5lRfbX0n4Wn5KNY9nvFb4R3by8FdW2TWc=
 github.com/streamplace/glex v0.0.0-20260716203108-f73ed7cc31c9 h1:HbIhx8i7wytiNg9mWg2EuHG59r8FXTVlDqlkZObjqbQ=
 github.com/streamplace/glex v0.0.0-20260716203108-f73ed7cc31c9/go.mod h1:LRaoeSMvSgOrhFX8s7ygjRlyka7wXdDa1s7JJ9o1IzY=
+github.com/streamplace/glex v0.0.0-20260820164827-814f46540f22 h1:yy0iaLxWsgdacyeukLFAWMJ6KXRCCZ4IZiv5iODBKGg=
+github.com/streamplace/glex v0.0.0-20260820164827-814f46540f22/go.mod h1:LRaoeSMvSgOrhFX8s7ygjRlyka7wXdDa1s7JJ9o1IzY=
 github.com/streamplace/go-dpop v0.0.0-20250510031900-c897158a8ad4 h1:L1fS4HJSaAyNnkwfuZubgfeZy8rkWmA0cMtH5Z0HqNc=
 github.com/streamplace/go-dpop v0.0.0-20250510031900-c897158a8ad4/go.mod h1:bGUXY9Wd4mnd+XUrOYZr358J2f6z9QO/dLhL1SsiD+0=
 github.com/streamplace/indigo v0.0.0-20260218231908-939cdaf0c507 h1:e8M3qPLr37NxEjlr18TaAwGP+OVyherVjgUG5VVmgWI=

--- a/pkg/spxrpc/stubs.go
+++ b/pkg/spxrpc/stubs.go
@@ -296,7 +296,7 @@ func (s *Server) HandleComAtprotoSyncGetBlocks(c echo.Context) error {
 	if handleErr != nil {
 		return handleErr
 	}
-	return c.Stream(200, "application/octet-stream", out)
+	return c.Stream(200, "application/vnd.ipld.car", out)
 }
 
 func (s *Server) HandleComAtprotoSyncGetLatestCommit(c echo.Context) error {
@@ -326,7 +326,7 @@ func (s *Server) HandleComAtprotoSyncGetRecord(c echo.Context) error {
 	if handleErr != nil {
 		return handleErr
 	}
-	return c.Stream(200, "application/octet-stream", out)
+	return c.Stream(200, "application/vnd.ipld.car", out)
 }
 
 func (s *Server) HandleComAtprotoSyncGetRepo(c echo.Context) error {
@@ -341,7 +341,7 @@ func (s *Server) HandleComAtprotoSyncGetRepo(c echo.Context) error {
 	if handleErr != nil {
 		return handleErr
 	}
-	return c.Stream(200, "application/octet-stream", out)
+	return c.Stream(200, "application/vnd.ipld.car", out)
 }
 
 func (s *Server) HandleComAtprotoSyncListRepos(c echo.Context) error {
@@ -1209,7 +1209,7 @@ func (s *Server) HandlePlaceStreamPlaybackGetLiveSegment(c echo.Context) error {
 	if handleErr != nil {
 		return handleErr
 	}
-	return c.Stream(200, "application/octet-stream", out)
+	return c.Stream(200, "video/mp4", out)
 }
 
 func (s *Server) HandlePlaceStreamPlaybackGetPlaybackServer(c echo.Context) error {
@@ -1239,7 +1239,7 @@ func (s *Server) HandlePlaceStreamPlaybackGetVideoBlob(c echo.Context) error {
 	if handleErr != nil {
 		return handleErr
 	}
-	return c.Stream(200, "application/octet-stream", out)
+	return c.Stream(200, "video/mp4", out)
 }
 
 func (s *Server) HandlePlaceStreamPlaybackGetVideoPlaylist(c echo.Context) error {


### PR DESCRIPTION
The glex server generator hardcoded application/octet-stream for every non-JSON XRPC output, ignoring the encoding declared in the lexicon. Newer reference PDSes (@atproto/lex-client, Dec 2025) strictly validate response content types during lexicon resolution, so resolving place.stream.authFull via com.atproto.sync.getRecord failed with 'Expected "application/vnd.ipld.car" response' and broke OAuth login.

Bump glex to 814f465 (generator: respect non-standard encodings) and regenerate: sync.getBlocks/getRecord/getRepo now serve application/vnd.ipld.car, playback.getLiveSegment/getVideoBlob video/mp4.