### PR TITLE
vod: sign CDN blob URLs with bunny.net token authentication

### DIFF
--- a/pkg/cdn/bunny/log.go
+++ b/pkg/cdn/bunny/log.go
@@ -1,0 +1,269 @@
+package bunny
+
+import (
+	"bufio"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"stream.place/streamplace/pkg/aqhttp"
+	"stream.place/streamplace/pkg/cdn"
+	"stream.place/streamplace/pkg/log"
+)
+
+// Request is the provider-neutral record type this package emits.
+// Aliased so the parser tests don't have to import pkg/cdn.
+type Request = cdn.Request
+
+// ParseLine decodes one line of bunny's pipe-delimited access-log
+// format:
+//
+//	cache-status|status|timestamp-ms|bytes-sent|pull-zone-id|remote-ip|
+//	referer|url|edge-location|user-agent|request-id|country-code
+//
+// Bunny strips '|' from the user-controllable fields, so a naive split
+// is safe. Lines with fewer than 12 fields, or an unparseable status,
+// timestamp or byte count, are rejected. Extra trailing fields (a
+// future format extension) are ignored.
+func ParseLine(line string) (Request, error) {
+	line = strings.TrimRight(line, "\r\n")
+	f := strings.Split(line, "|")
+	if len(f) < 12 {
+		return Request{}, fmt.Errorf("bunny log: %d fields, want 12", len(f))
+	}
+	status, err := strconv.Atoi(f[1])
+	if err != nil {
+		return Request{}, fmt.Errorf("bunny log: status %q: %w", f[1], err)
+	}
+	ms, err := strconv.ParseInt(f[2], 10, 64)
+	if err != nil {
+		return Request{}, fmt.Errorf("bunny log: timestamp %q: %w", f[2], err)
+	}
+	bytes, err := strconv.ParseInt(f[3], 10, 64)
+	if err != nil {
+		return Request{}, fmt.Errorf("bunny log: bytes %q: %w", f[3], err)
+	}
+	return Request{
+		Time:      time.UnixMilli(ms).UTC(),
+		Status:    status,
+		BytesSent: bytes,
+		RemoteIP:  f[5],
+		URL:       f[7],
+	}, nil
+}
+
+// LogStorage implements cdn.LogSource over a bunny Edge Storage zone
+// that a pull zone's Permanent Log Storage writes into. Bunny files
+// parts as
+//
+//	pullzone-logs/<pull-zone>/<YYYY>/<MM>/<dd>_<worker>-<part>-<rand>.gzip
+//
+// Each part is immutable once it lands (parts close on size, line
+// count, age or the UTC midnight boundary and are never rewritten),
+// which is what lets the ingester treat "seen this path" as "done".
+type LogStorage struct {
+	// Endpoint is the storage region's API base, e.g.
+	// https://storage.bunnycdn.com or https://ny.storage.bunnycdn.com.
+	Endpoint string
+	// Zone is the storage zone name.
+	Zone string
+	// AccessKey is the storage zone's password (read-only is enough).
+	AccessKey string
+	// PullZone is the pull zone name as it appears in the log path.
+	PullZone string
+	// HTTPClient overrides the outbound client (tests). Defaults to
+	// aqhttp.TrustedClient: the endpoint is operator-configured.
+	HTTPClient *http.Client
+	// Now overrides the clock (tests).
+	Now func() time.Time
+}
+
+// storageObject is the subset of bunny's List Files response we read.
+type storageObject struct {
+	ObjectName  string `json:"ObjectName"`
+	IsDirectory bool   `json:"IsDirectory"`
+	Length      int64  `json:"Length"`
+}
+
+func (s *LogStorage) client() *http.Client {
+	if s.HTTPClient != nil {
+		return s.HTTPClient
+	}
+	return &aqhttp.TrustedClient
+}
+
+func (s *LogStorage) now() time.Time {
+	if s.Now != nil {
+		return s.Now()
+	}
+	return time.Now()
+}
+
+// logPrefix is the directory all of this pull zone's parts live under.
+func (s *LogStorage) logPrefix() string {
+	return "pullzone-logs/" + s.PullZone
+}
+
+func (s *LogStorage) objectURL(p string) (string, error) {
+	base, err := url.Parse(strings.TrimRight(s.Endpoint, "/"))
+	if err != nil || base.Host == "" {
+		return "", fmt.Errorf("bunny storage: bad endpoint %q", s.Endpoint)
+	}
+	base.Path = path.Join(base.Path, s.Zone, p)
+	// Directory listings need the trailing slash; path.Join drops it.
+	if strings.HasSuffix(p, "/") {
+		base.Path += "/"
+	}
+	return base.String(), nil
+}
+
+func (s *LogStorage) get(ctx context.Context, p string) (*http.Response, error) {
+	u, err := s.objectURL(p)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("AccessKey", s.AccessKey)
+	req.Header.Set("Accept", "*/*")
+	resp, err := s.client().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("bunny storage: GET %s: %w", p, err)
+	}
+	return resp, nil
+}
+
+// ListParts walks the month directories from since's UTC month through
+// the current month and returns every part whose day-of-month prefix
+// falls on or after since's UTC date.
+func (s *LogStorage) ListParts(ctx context.Context, since time.Time) ([]cdn.Part, error) {
+	since = since.UTC()
+	sinceDay := time.Date(since.Year(), since.Month(), since.Day(), 0, 0, 0, 0, time.UTC)
+	now := s.now().UTC()
+	var parts []cdn.Part
+	for m := time.Date(since.Year(), since.Month(), 1, 0, 0, 0, 0, time.UTC); !m.After(now); m = m.AddDate(0, 1, 0) {
+		dir := fmt.Sprintf("%s/%04d/%02d/", s.logPrefix(), m.Year(), int(m.Month()))
+		objs, err := s.list(ctx, dir)
+		if err != nil {
+			return nil, err
+		}
+		for _, o := range objs {
+			if o.IsDirectory {
+				continue
+			}
+			day, ok := partDay(m, o.ObjectName)
+			if !ok {
+				log.Debug(ctx, "bunny storage: skipping unrecognized object", "dir", dir, "name", o.ObjectName)
+				continue
+			}
+			if day.Before(sinceDay) {
+				continue
+			}
+			parts = append(parts, cdn.Part{
+				ID:   dir + o.ObjectName,
+				Day:  day,
+				Size: o.Length,
+			})
+		}
+	}
+	return parts, nil
+}
+
+// partDay extracts the UTC date from a part filename like
+// `06_abc123-0-1a2b3c4d.gzip` inside the given month directory.
+func partDay(month time.Time, name string) (time.Time, bool) {
+	if !strings.HasSuffix(name, ".gzip") && !strings.HasSuffix(name, ".gz") {
+		return time.Time{}, false
+	}
+	i := strings.IndexByte(name, '_')
+	if i <= 0 {
+		return time.Time{}, false
+	}
+	d, err := strconv.Atoi(name[:i])
+	if err != nil || d < 1 || d > 31 {
+		return time.Time{}, false
+	}
+	return time.Date(month.Year(), month.Month(), d, 0, 0, 0, 0, time.UTC), true
+}
+
+func (s *LogStorage) list(ctx context.Context, dir string) ([]storageObject, error) {
+	resp, err := s.get(ctx, dir)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		// A month with no logs yet (or a pull zone that hasn't
+		// written anything) is not an error.
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bunny storage: list %s: HTTP %d", dir, resp.StatusCode)
+	}
+	var objs []storageObject
+	if err := json.NewDecoder(resp.Body).Decode(&objs); err != nil {
+		return nil, fmt.Errorf("bunny storage: decode listing %s: %w", dir, err)
+	}
+	return objs, nil
+}
+
+// maxLineBytes bounds a single log line. Bunny lines are a few hundred
+// bytes; user-agent + referer are the only unbounded fields.
+const maxLineBytes = 1 << 20
+
+// ReadPart downloads the gzip part and streams parsed records. Lines
+// that fail to parse are skipped and counted; the count is logged at
+// the end so a format change is visible without failing the whole
+// part.
+func (s *LogStorage) ReadPart(ctx context.Context, part cdn.Part, emit func(Request) error) error {
+	resp, err := s.get(ctx, part.ID)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bunny storage: read %s: HTTP %d", part.ID, resp.StatusCode)
+	}
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return fmt.Errorf("bunny storage: gunzip %s: %w", part.ID, err)
+	}
+	defer gz.Close()
+	return readLines(ctx, gz, part.ID, emit)
+}
+
+func readLines(ctx context.Context, r io.Reader, name string, emit func(Request) error) error {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 64*1024), maxLineBytes)
+	var bad int
+	for sc.Scan() {
+		if len(sc.Bytes()) == 0 {
+			continue
+		}
+		req, err := ParseLine(sc.Text())
+		if err != nil {
+			bad++
+			continue
+		}
+		if err := emit(req); err != nil {
+			return err
+		}
+	}
+	if bad > 0 {
+		log.Warn(ctx, "bunny storage: skipped unparseable log lines", "part", name, "lines", bad)
+	}
+	if err := sc.Err(); err != nil {
+		return fmt.Errorf("bunny storage: read %s: %w", name, err)
+	}
+	return nil
+}

--- a/pkg/cdn/bunny/log_test.go
+++ b/pkg/cdn/bunny/log_test.go
@@ -1,0 +1,128 @@
+package bunny
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const sampleLine = `HIT|206|1725580800123|524288|123456|203.0.113.7|https://stream.place/|https://eli-vod-dev.b-cdn.net/blobs/bafyblob.mp4?token=abc&did=did%3Aplc%3Aabc&sid=tid123&expires=1725600000|NY|Mozilla/5.0|req-1|US`
+
+func TestParseLine(t *testing.T) {
+	req, err := ParseLine(sampleLine + "\r\n")
+	require.NoError(t, err)
+	require.Equal(t, time.UnixMilli(1725580800123).UTC(), req.Time)
+	require.Equal(t, 206, req.Status)
+	require.EqualValues(t, 524288, req.BytesSent)
+	require.Equal(t, "203.0.113.7", req.RemoteIP)
+	require.Equal(t, "https://eli-vod-dev.b-cdn.net/blobs/bafyblob.mp4?token=abc&did=did%3Aplc%3Aabc&sid=tid123&expires=1725600000", req.URL)
+}
+
+func TestParseLineRejectsShortAndMalformed(t *testing.T) {
+	_, err := ParseLine("HIT|200|123")
+	require.Error(t, err)
+	_, err = ParseLine(strings.Replace(sampleLine, "|206|", "|xx|", 1))
+	require.Error(t, err)
+	_, err = ParseLine(strings.Replace(sampleLine, "|1725580800123|", "|soon|", 1))
+	require.Error(t, err)
+}
+
+// fakeStorage serves a bunny-shaped listing + gzip parts.
+func fakeStorage(t *testing.T, listings map[string][]storageObject, files map[string]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "zone-key", r.Header.Get("AccessKey"))
+		p := strings.TrimPrefix(r.URL.Path, "/logs-zone/")
+		if objs, ok := listings[p]; ok {
+			_ = json.NewEncoder(w).Encode(objs)
+			return
+		}
+		if body, ok := files[p]; ok {
+			var buf bytes.Buffer
+			gz := gzip.NewWriter(&buf)
+			_, _ = gz.Write([]byte(body))
+			_ = gz.Close()
+			_, _ = w.Write(buf.Bytes())
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+func TestLogStorageListAndRead(t *testing.T) {
+	srv := fakeStorage(t,
+		map[string][]storageObject{
+			"pullzone-logs/eli-vod-dev/2025/08/": {
+				{ObjectName: "30_w1-0-aaaaaaaa.gzip", Length: 10},
+				{ObjectName: "31_w1-0-bbbbbbbb.gzip", Length: 20},
+			},
+			"pullzone-logs/eli-vod-dev/2025/09/": {
+				{ObjectName: "01_w1-0-cccccccc.gzip", Length: 30},
+				{ObjectName: "01_w2-0-dddddddd.gzip", Length: 40},
+				{ObjectName: "notes", IsDirectory: true},
+				{ObjectName: "junk.txt"},
+			},
+		},
+		map[string]string{
+			"pullzone-logs/eli-vod-dev/2025/09/01_w1-0-cccccccc.gzip": sampleLine + "\n" + "garbage line\n" + sampleLine + "\n",
+		},
+	)
+	defer srv.Close()
+
+	s := &LogStorage{
+		Endpoint:  srv.URL,
+		Zone:      "logs-zone",
+		AccessKey: "zone-key",
+		PullZone:  "eli-vod-dev",
+		Now:       func() time.Time { return time.Date(2025, 9, 6, 12, 0, 0, 0, time.UTC) },
+	}
+	ctx := context.Background()
+
+	// since = Aug 31 12:00 → the Aug 30 part is skipped, Aug 31 and
+	// both Sep 1 parts are listed; the Oct directory (404) is never
+	// reached because Now is in September.
+	parts, err := s.ListParts(ctx, time.Date(2025, 8, 31, 12, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	var ids []string
+	for _, p := range parts {
+		ids = append(ids, p.ID)
+	}
+	require.Equal(t, []string{
+		"pullzone-logs/eli-vod-dev/2025/08/31_w1-0-bbbbbbbb.gzip",
+		"pullzone-logs/eli-vod-dev/2025/09/01_w1-0-cccccccc.gzip",
+		"pullzone-logs/eli-vod-dev/2025/09/01_w2-0-dddddddd.gzip",
+	}, ids)
+	require.Equal(t, time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC), parts[1].Day)
+	require.EqualValues(t, 30, parts[1].Size)
+
+	var got []Request
+	err = s.ReadPart(ctx, parts[1], func(r Request) error {
+		got = append(got, r)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2, "the garbage line is skipped, not fatal")
+	require.Equal(t, 206, got[0].Status)
+
+	// A missing part is an error, not silently empty.
+	err = s.ReadPart(ctx, parts[2], func(Request) error { return nil })
+	require.Error(t, err)
+}
+
+func TestLogStorageMissingMonthIsEmpty(t *testing.T) {
+	srv := fakeStorage(t, nil, nil)
+	defer srv.Close()
+	s := &LogStorage{Endpoint: srv.URL, Zone: "logs-zone", AccessKey: "zone-key", PullZone: "pz",
+		Now: func() time.Time { return time.Date(2025, 9, 6, 0, 0, 0, 0, time.UTC) }}
+	parts, err := s.ListParts(context.Background(), time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.Empty(t, parts)
+}

--- a/pkg/cdn/bunny/sign.go
+++ b/pkg/cdn/bunny/sign.go
@@ -1,0 +1,56 @@
+// Package bunny is the bunny.net CDN provider: Token Authentication
+// URL signing for pull zones and an ingester for the pull zone's
+// permanent log storage.
+package bunny
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Signer implements cdn.Signer with bunny.net Token Authentication in
+// its query-string form.
+type Signer struct {
+	// Key is the pull zone's Token Authentication key.
+	Key string
+}
+
+// SignURL mirrors bunny's reference implementation: the token is the
+// unpadded base64url SHA-256 of `key + decodedPath + expires + params`,
+// where params is every non-empty query parameter as `k=v`, sorted by
+// key and joined with `&`. The signed URL carries the same params
+// (URL-encoded) plus `token` and `expires`; bunny recomputes the hash
+// on its side and refuses anything that doesn't match or has expired.
+// Because the path is in the hash, a token for one blob can't be
+// replayed against another.
+func (s Signer) SignURL(u *url.URL, expires time.Time) string {
+	q := u.Query()
+	keys := make([]string, 0, len(q))
+	for k := range q {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var hashParams, urlParams strings.Builder
+	for _, k := range keys {
+		for _, v := range q[k] {
+			if v == "" {
+				continue
+			}
+			if hashParams.Len() > 0 {
+				hashParams.WriteByte('&')
+			}
+			hashParams.WriteString(k + "=" + v)
+			urlParams.WriteString("&" + url.QueryEscape(k) + "=" + url.QueryEscape(v))
+		}
+	}
+	exp := strconv.FormatInt(expires.Unix(), 10)
+	sum := sha256.Sum256([]byte(s.Key + u.Path + exp + hashParams.String()))
+	token := base64.RawURLEncoding.EncodeToString(sum[:])
+	return u.Scheme + "://" + u.Host + u.EscapedPath() +
+		"?token=" + token + urlParams.String() + "&expires=" + exp
+}

--- a/pkg/cdn/bunny/sign_test.go
+++ b/pkg/cdn/bunny/sign_test.go
@@ -1,0 +1,40 @@
+package bunny
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The expected tokens were computed independently with bunny's
+// published reference algorithm (sha256(key + path + expires + sorted
+// "k=v" params), base64url, no padding), so a drift here means bunny
+// would 403 every segment.
+func TestSignerMatchesReference(t *testing.T) {
+	s := Signer{Key: "secret-key"}
+	exp := time.Unix(1700000000, 0)
+
+	u, _ := url.Parse("https://cdn.example.com/blobs/bafyblob.mp4?did=did%3Aplc%3Aabc&sid=tid123")
+	require.Equal(t,
+		"https://cdn.example.com/blobs/bafyblob.mp4?token=KIxqgRCnXmqKj07FcqY4y6jxhYQ47kyCj2QLdC-wlo4&did=did%3Aplc%3Aabc&sid=tid123&expires=1700000000",
+		s.SignURL(u, exp))
+
+	// A path prefix is part of the signed path; an absent sid is left
+	// out of both the hash and the URL.
+	u, _ = url.Parse("https://cdn.example.com/vods/blobs/bafyblob.mp4?did=did%3Aplc%3Aabc")
+	require.Equal(t,
+		"https://cdn.example.com/vods/blobs/bafyblob.mp4?token=hSHnZu2PJHcclObmqnsI66szGuzpeePfHt_rYt327Fk&did=did%3Aplc%3Aabc&expires=1700000000",
+		s.SignURL(u, exp))
+}
+
+func TestSignerTokenBoundToPath(t *testing.T) {
+	s := Signer{Key: "secret-key"}
+	exp := time.Unix(1700000000, 0)
+	a, _ := url.Parse("https://cdn.example.com/blobs/bafyblob.mp4?did=x")
+	b, _ := url.Parse("https://cdn.example.com/blobs/bafyother.mp4?did=x")
+	require.NotEqual(t, s.SignURL(a, exp), s.SignURL(b, exp))
+	// The input URL is not mutated.
+	require.Equal(t, "did=x", a.RawQuery)
+}

--- a/pkg/cdn/cdn.go
+++ b/pkg/cdn/cdn.go
@@ -1,0 +1,89 @@
+// Package cdn defines the seam between streamplace and whatever CDN an
+// operator puts in front of the VOD blob store. Two capabilities are
+// provider-specific and everything else is not:
+//
+//   - Signer: how a blob URL in an HLS playlist gets signed so the CDN
+//     only serves what this node handed out. Every CDN has its own
+//     recipe (bunny is an HMAC in the query string, CloudFront is a
+//     signed policy, Cloudflare is whatever your worker verifies).
+//
+//   - LogSource: where the CDN's archived access logs live and how a
+//     line decodes. Once the CDN serves segments, the node no longer
+//     sees segment requests, so view counting depends on pulling them
+//     back out of the CDN's logs (see pkg/viewlog RunIngest).
+//
+// Providers live in subpackages (pkg/cdn/bunny) and are selected by
+// --vod-cdn-provider via pkg/cdn/providers.FromConfig. The generic
+// --vod-cdn-url flag keeps working on its own as an unsigned, log-less
+// static CDN.
+package cdn
+
+import (
+	"context"
+	"net/url"
+	"time"
+)
+
+// Signer produces the viewer-facing URL for a blob served by the CDN.
+type Signer interface {
+	// SignURL returns the URL a player should fetch for u, valid until
+	// expires. Implementations must not mutate u. Unsigned providers
+	// return u.String().
+	SignURL(u *url.URL, expires time.Time) string
+}
+
+// Static is the no-signature Signer: a plain CDN over a public bucket.
+type Static struct{}
+
+func (Static) SignURL(u *url.URL, _ time.Time) string { return u.String() }
+
+// Part is one immutable archived access-log file at the provider.
+type Part struct {
+	// ID is the provider-unique, stable identity of the part (e.g.
+	// its storage path). Ingest cursors key on it, so it must not
+	// change between listings.
+	ID string
+	// Day is the UTC date the provider filed the part under. Events
+	// inside are at or after this day's start; the ingester uses it
+	// to skip parts older than its lookback.
+	Day time.Time
+	// Size is the compressed byte length, for logging.
+	Size int64
+}
+
+// Request is one CDN access-log record in provider-neutral shape.
+// Only the fields view counting needs are carried.
+type Request struct {
+	// Time is when the edge served the request.
+	Time time.Time
+	// Status is the HTTP status the edge returned.
+	Status int
+	// BytesSent is the response body size the edge reports. Access
+	// logs carry no Range header, so this is the only byte signal.
+	BytesSent int64
+	// RemoteIP is the viewer's address, hashed by the ingester before
+	// it's persisted.
+	RemoteIP string
+	// URL is what the viewer requested: a path plus query string, or
+	// an absolute URL (providers differ; consumers must parse).
+	URL string
+}
+
+// LogSource lists and decodes a provider's archived access logs.
+type LogSource interface {
+	// ListParts returns every part filed on or after `since`'s UTC
+	// date. Parts already ingested are filtered by the caller.
+	ListParts(ctx context.Context, since time.Time) ([]Part, error)
+	// ReadPart streams the part's records to emit in file order. An
+	// error from emit aborts the read and is returned.
+	ReadPart(ctx context.Context, part Part, emit func(Request) error) error
+}
+
+// Provider bundles what the configured CDN can do. Logs is nil when
+// the provider has no log source configured.
+type Provider struct {
+	// Name is the --vod-cdn-provider value ("" for a plain static CDN).
+	Name   string
+	Signer Signer
+	Logs   LogSource
+}

--- a/pkg/cdn/providers/providers.go
+++ b/pkg/cdn/providers/providers.go
@@ -1,0 +1,47 @@
+// Package providers maps --vod-cdn-provider onto a cdn.Provider. It
+// sits above pkg/cdn and every provider subpackage so the interfaces
+// package stays import-free.
+package providers
+
+import (
+	"fmt"
+
+	"stream.place/streamplace/pkg/cdn"
+	"stream.place/streamplace/pkg/cdn/bunny"
+	"stream.place/streamplace/pkg/config"
+)
+
+// Provider names accepted by --vod-cdn-provider.
+const (
+	Static = ""
+	Bunny  = "bunny"
+)
+
+// FromConfig builds the Provider described by the CLI flags. Returns
+// nil when no CDN is configured at all (--vod-cdn-url empty). Flag
+// consistency is enforced in config.Validate; this only assembles.
+func FromConfig(cli *config.CLI) (*cdn.Provider, error) {
+	if cli.VODCDNURL == "" {
+		return nil, nil
+	}
+	switch cli.VODCDNProvider {
+	case Static:
+		return &cdn.Provider{Name: Static, Signer: cdn.Static{}}, nil
+	case Bunny:
+		p := &cdn.Provider{Name: Bunny, Signer: cdn.Static{}}
+		if cli.BunnyTokenAuthKey != "" {
+			p.Signer = bunny.Signer{Key: cli.BunnyTokenAuthKey}
+		}
+		if cli.BunnyLogStorageZone != "" {
+			p.Logs = &bunny.LogStorage{
+				Endpoint:  cli.BunnyLogStorageEndpoint,
+				Zone:      cli.BunnyLogStorageZone,
+				AccessKey: cli.BunnyLogStorageKey,
+				PullZone:  cli.BunnyPullZone,
+			}
+		}
+		return p, nil
+	default:
+		return nil, fmt.Errorf("cdn: unknown --vod-cdn-provider %q", cli.VODCDNProvider)
+	}
+}

--- a/pkg/cdn/providers/providers_test.go
+++ b/pkg/cdn/providers/providers_test.go
@@ -1,0 +1,39 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"stream.place/streamplace/pkg/cdn"
+	"stream.place/streamplace/pkg/cdn/bunny"
+	"stream.place/streamplace/pkg/config"
+)
+
+func TestFromConfig(t *testing.T) {
+	p, err := FromConfig(&config.CLI{})
+	require.NoError(t, err)
+	require.Nil(t, p, "no CDN URL → no provider")
+
+	p, err = FromConfig(&config.CLI{VODCDNURL: "https://cdn.example.com"})
+	require.NoError(t, err)
+	require.Equal(t, Static, p.Name)
+	require.IsType(t, cdn.Static{}, p.Signer)
+	require.Nil(t, p.Logs)
+
+	p, err = FromConfig(&config.CLI{VODCDNURL: "https://x.b-cdn.net", VODCDNProvider: "bunny"})
+	require.NoError(t, err)
+	require.IsType(t, cdn.Static{}, p.Signer, "bunny without a token key is unsigned")
+
+	p, err = FromConfig(&config.CLI{
+		VODCDNURL: "https://x.b-cdn.net", VODCDNProvider: "bunny",
+		BunnyTokenAuthKey: "k", BunnyPullZone: "x", BunnyLogStorageZone: "z", BunnyLogStorageKey: "s",
+		BunnyLogStorageEndpoint: "https://storage.bunnycdn.com",
+	})
+	require.NoError(t, err)
+	require.Equal(t, bunny.Signer{Key: "k"}, p.Signer)
+	require.IsType(t, &bunny.LogStorage{}, p.Logs)
+
+	_, err = FromConfig(&config.CLI{VODCDNURL: "https://cdn.example.com", VODCDNProvider: "akamai"})
+	require.Error(t, err)
+}

--- a/pkg/cmd/streamplace.go
+++ b/pkg/cmd/streamplace.go
@@ -29,6 +29,7 @@ import (
 	"stream.place/streamplace/pkg/atproto"
 	"stream.place/streamplace/pkg/blob"
 	"stream.place/streamplace/pkg/bus"
+	"stream.place/streamplace/pkg/cdn/providers"
 	"stream.place/streamplace/pkg/comatproto"
 	"stream.place/streamplace/pkg/director"
 	"stream.place/streamplace/pkg/gstinit"
@@ -506,6 +507,9 @@ func runMain(ctx context.Context, build *config.BuildFlags, platformJobs []jobFu
 			})
 		})
 	}
+	if err := wireCDNLogIngest(ctx, cli, state, vodStore, viewLog, ldb, group); err != nil {
+		return err
+	}
 	a, err := api.MakeStreamplaceAPI(cli, mod, state, noter, mm, ms, b, atsync, d, op, ldb, um, vodStore, viewLog)
 	if err != nil {
 		return err
@@ -745,6 +749,62 @@ func makeVODStore(ctx context.Context, cli *config.CLI) (blob.Store, error) {
 	root := cli.DataFilePath(nil)
 	log.Log(ctx, "VOD store: file", "root", root)
 	return blob.NewFileStore(root)
+}
+
+// wireCDNLogIngest installs the CDN access-log ingester when the
+// configured --vod-cdn-provider has a log source, and warns loudly
+// when a CDN is configured without one: segment fetches then bypass
+// the node entirely and every VOD's view count silently reads zero.
+func wireCDNLogIngest(ctx context.Context, cli *config.CLI, state *statedb.StatefulDB, vodStore blob.Store, viewLog *viewlog.Writer, ldb localdb.LocalDB, group *TimeoutGroup) error {
+	provider, err := providers.FromConfig(cli)
+	if err != nil {
+		return err
+	}
+	if provider == nil {
+		return nil
+	}
+	if provider.Logs == nil {
+		log.Warn(ctx, "VOD CDN is configured without an access-log source: segment requests served by the CDN are invisible to view counting, so view counts for CDN-served VODs will be zero. Configure the provider's log ingestion (e.g. --bunny-log-storage-zone) or accept the gap.",
+			"vod_cdn_url", cli.VODCDNURL, "provider", cli.VODCDNProvider)
+		return nil
+	}
+	if vodStore == nil || cli.ViewCountAggregateInterval <= 0 {
+		log.Warn(ctx, "VOD CDN log source configured but view-count aggregation is off; not ingesting CDN logs")
+		return nil
+	}
+	if cli.CDNLogIngestInterval <= 0 {
+		log.Log(ctx, "cdn log ingest: disabled (cdn-log-ingest-interval=0)")
+		return nil
+	}
+	var salts *viewlog.SaltManager
+	if viewLog != nil {
+		salts = viewLog.Salts()
+	} else {
+		salts = viewlog.NewSaltManager(ldb)
+	}
+	sourceName := provider.Name
+	state.SetCDNLogIngester(func(ctx context.Context) error {
+		_, err := viewlog.RunIngest(ctx, viewlog.IngestInput{
+			Store:      vodStore,
+			Source:     provider.Logs,
+			SourceName: sourceName,
+			Salts:      salts,
+			Cursor:     state,
+			Window:     cli.ViewCountAggregateInterval,
+			Reaggregate: func(ctx context.Context, partID string, start, end time.Time) error {
+				_, err := state.EnqueueTask(ctx, statedb.TaskViewCountAggregate,
+					statedb.ViewCountAggregateTask{WindowStart: start, WindowEnd: end},
+					statedb.WithTaskKey(viewlog.ReaggregateTaskKey(start, end, partID)))
+				return err
+			},
+		})
+		return err
+	})
+	group.Go(func() error {
+		return viewlog.ScheduleIngest(ctx, state, cli.CDNLogIngestInterval)
+	})
+	log.Log(ctx, "cdn log ingest: enabled", "provider", sourceName, "interval", cli.CDNLogIngestInterval)
+	return nil
 }
 
 // makeViewLog returns the configured view-event log writer, or nil if

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -159,6 +159,13 @@ type CLI struct {
 	S3SecretAccessKey           string
 	S3Region                    string
 	VODCDNURL                   string
+	VODCDNProvider              string
+	BunnyTokenAuthKey           string
+	BunnyPullZone               string
+	BunnyLogStorageZone         string
+	BunnyLogStorageEndpoint     string
+	BunnyLogStorageKey          string
+	CDNLogIngestInterval        time.Duration
 	DisableSyndication          bool
 	MuxlInitialMemoryMB         int
 	MuxlMaxMemoryMB             int
@@ -1085,6 +1092,50 @@ func (cli *CLI) NewCommand(name string) *urfavecli.Command {
 				Sources:     urfavecli.EnvVars("SP_VOD_CDN_URL"),
 			},
 			&urfavecli.StringFlag{
+				Name:        "vod-cdn-provider",
+				Usage:       "Which CDN product sits at --vod-cdn-url, selecting URL signing + access-log ingestion. Empty means a plain static CDN over a public bucket: unsigned URLs, and no way to count segment views. Supported: bunny (configure with the --bunny-* flags).",
+				Destination: &cli.VODCDNProvider,
+				Sources:     urfavecli.EnvVars("SP_VOD_CDN_PROVIDER"),
+			},
+			&urfavecli.StringFlag{
+				Name:        "bunny-token-auth-key",
+				Usage:       "bunny.net: the pull zone's Token Authentication key. When set, every blob URL in an HLS playlist is signed (token + expires query params) so the CDN only serves blobs this node handed out; the token is bound to the blob path and expires well after the VOD's duration. Requires --vod-cdn-provider=bunny.",
+				Destination: &cli.BunnyTokenAuthKey,
+				Sources:     urfavecli.EnvVars("SP_BUNNY_TOKEN_AUTH_KEY"),
+			},
+			&urfavecli.StringFlag{
+				Name:        "bunny-pull-zone",
+				Usage:       "bunny.net: the pull zone's name, as it appears in the Permanent Log Storage path (pullzone-logs/<name>/...). Required with --bunny-log-storage-zone.",
+				Destination: &cli.BunnyPullZone,
+				Sources:     urfavecli.EnvVars("SP_BUNNY_PULL_ZONE"),
+			},
+			&urfavecli.StringFlag{
+				Name:        "bunny-log-storage-zone",
+				Usage:       "bunny.net: the Edge Storage zone the pull zone's Permanent Log Storage writes into. When set, the node periodically ingests archived access logs so segment requests served by the CDN count toward views. Requires --vod-cdn-provider=bunny, --bunny-pull-zone and --bunny-log-storage-key.",
+				Destination: &cli.BunnyLogStorageZone,
+				Sources:     urfavecli.EnvVars("SP_BUNNY_LOG_STORAGE_ZONE"),
+			},
+			&urfavecli.StringFlag{
+				Name:        "bunny-log-storage-endpoint",
+				Usage:       "bunny.net: Edge Storage API endpoint for the log storage zone's region (e.g. https://ny.storage.bunnycdn.com).",
+				Value:       "https://storage.bunnycdn.com",
+				Destination: &cli.BunnyLogStorageEndpoint,
+				Sources:     urfavecli.EnvVars("SP_BUNNY_LOG_STORAGE_ENDPOINT"),
+			},
+			&urfavecli.StringFlag{
+				Name:        "bunny-log-storage-key",
+				Usage:       "bunny.net: access key (password) for the log storage zone. A read-only key is sufficient.",
+				Destination: &cli.BunnyLogStorageKey,
+				Sources:     urfavecli.EnvVars("SP_BUNNY_LOG_STORAGE_KEY"),
+			},
+			&urfavecli.DurationFlag{
+				Name:        "cdn-log-ingest-interval",
+				Usage:       "How often to pull newly archived CDN access logs into the view-log store and re-aggregate the view-count windows they touch. Only meaningful when the --vod-cdn-provider has a log source configured. Set to 0 to disable.",
+				Value:       15 * time.Minute,
+				Destination: &cli.CDNLogIngestInterval,
+				Sources:     urfavecli.EnvVars("SP_CDN_LOG_INGEST_INTERVAL"),
+			},
+			&urfavecli.StringFlag{
 				Name:        "beta-invite-did",
 				Usage:       "DID of the atproto account whose place.stream.beta.invite records this node trusts. When set, uploading VODs requires an invite from that account; when empty, falls back to the --allowed-streams allowlist used by livestreaming.",
 				Destination: &cli.BetaInviteDID,
@@ -1323,6 +1374,35 @@ func (cli *CLI) Validate(cmd *urfavecli.Command) error {
 	// Set default replicator if none specified
 	if len(cli.Replicators) == 0 {
 		cli.Replicators = []string{ReplicatorWebsocket}
+	}
+	if err := cli.validateVODCDN(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateVODCDN refuses half-configured CDN setups: provider flags
+// without their provider, a provider without a CDN URL, or a log
+// source missing one of its parts. Anything that passes here is a
+// combination cdn.FromConfig can assemble without surprises.
+func (cli *CLI) validateVODCDN() error {
+	bunnyFlags := cli.BunnyTokenAuthKey != "" || cli.BunnyPullZone != "" ||
+		cli.BunnyLogStorageZone != "" || cli.BunnyLogStorageKey != ""
+	switch cli.VODCDNProvider {
+	case "":
+		if bunnyFlags {
+			return fmt.Errorf("--bunny-* flags are set but --vod-cdn-provider is not; set --vod-cdn-provider=bunny")
+		}
+	case "bunny":
+		if cli.VODCDNURL == "" {
+			return fmt.Errorf("--vod-cdn-provider=bunny requires --vod-cdn-url (the pull zone hostname)")
+		}
+		logFlags := cli.BunnyPullZone != "" || cli.BunnyLogStorageZone != "" || cli.BunnyLogStorageKey != ""
+		if logFlags && (cli.BunnyPullZone == "" || cli.BunnyLogStorageZone == "" || cli.BunnyLogStorageKey == "") {
+			return fmt.Errorf("bunny log ingestion needs all of --bunny-pull-zone, --bunny-log-storage-zone and --bunny-log-storage-key")
+		}
+	default:
+		return fmt.Errorf("unknown --vod-cdn-provider %q (supported: bunny)", cli.VODCDNProvider)
 	}
 	return nil
 }

--- a/pkg/config/config_vodcdn_test.go
+++ b/pkg/config/config_vodcdn_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateVODCDN(t *testing.T) {
+	ok := func(c CLI) { t.Helper(); require.NoError(t, c.validateVODCDN()) }
+	bad := func(c CLI) { t.Helper(); require.Error(t, c.validateVODCDN()) }
+
+	ok(CLI{})
+	ok(CLI{VODCDNURL: "https://cdn.example.com"})
+	ok(CLI{VODCDNURL: "https://x.b-cdn.net", VODCDNProvider: "bunny"})
+	ok(CLI{VODCDNURL: "https://x.b-cdn.net", VODCDNProvider: "bunny", BunnyTokenAuthKey: "k"})
+	ok(CLI{VODCDNURL: "https://x.b-cdn.net", VODCDNProvider: "bunny",
+		BunnyPullZone: "x", BunnyLogStorageZone: "z", BunnyLogStorageKey: "s"})
+
+	// Provider flags without the provider.
+	bad(CLI{BunnyTokenAuthKey: "k"})
+	bad(CLI{VODCDNURL: "https://cdn.example.com", BunnyLogStorageZone: "z"})
+	// Provider without a CDN URL.
+	bad(CLI{VODCDNProvider: "bunny"})
+	// Partial log source.
+	bad(CLI{VODCDNURL: "https://x.b-cdn.net", VODCDNProvider: "bunny", BunnyLogStorageZone: "z"})
+	bad(CLI{VODCDNURL: "https://x.b-cdn.net", VODCDNProvider: "bunny", BunnyPullZone: "x", BunnyLogStorageKey: "s"})
+	// Unknown provider.
+	bad(CLI{VODCDNURL: "https://cdn.example.com", VODCDNProvider: "akamai"})
+}

--- a/pkg/spxrpc/place_stream_playback_getvideo.go
+++ b/pkg/spxrpc/place_stream_playback_getvideo.go
@@ -11,11 +11,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/labstack/echo/v4"
 
 	"stream.place/streamplace/pkg/blob"
+	"stream.place/streamplace/pkg/cdn"
 	"stream.place/streamplace/pkg/log"
 	"stream.place/streamplace/pkg/placestream"
 	"stream.place/streamplace/pkg/spid"
@@ -335,7 +337,7 @@ func (s *Server) HandleGetVideoPlaylist(c echo.Context) error {
 		// server side, so the propagation stays in clip-local time.
 		body = masterPlaylist(meta, uri, sid, startMS, endMS)
 	} else {
-		body, err = mediaPlaylist(meta, track, aturi.Authority().String(), sid, s.cli.VODCDNURL, effectiveStartMS, effectiveEndMS)
+		body, err = mediaPlaylist(meta, track, aturi.Authority().String(), sid, s.vodCDN(), effectiveStartMS, effectiveEndMS)
 		if err != nil {
 			return err
 		}
@@ -511,10 +513,57 @@ func (s *Server) fetchMetafile(ctx context.Context, cid string) (*vod.Metafile, 
 
 // --- playlist generation -----------------------------------------------
 
+// vodCDN describes the CDN (if any) fronting the VOD blob store, as
+// configured by --vod-cdn-url / --vod-cdn-provider.
+type vodCDN struct {
+	// URL is the CDN base URL. Empty means self-hosted: playlists
+	// link back to our own getVideoBlob endpoint.
+	URL string
+	// Signer turns a blob URL into what the player fetches. nil or
+	// cdn.Static{} emits the URL unsigned.
+	Signer cdn.Signer
+	// now overrides the clock used for token expiry. nil = time.Now.
+	now func() time.Time
+}
+
+// cdnTokenSlack is the minimum lifetime of a signed blob URL beyond
+// the VOD's own duration. A VOD media playlist is fetched once and
+// never refreshed, so the tokens it carries have to outlive any
+// realistic viewing session — including pausing and seeking around —
+// or the player hits 403s mid-watch. 24h is the longest VOD we
+// promise to serve, so it doubles as the floor here. Being generous
+// costs nothing: the token is bound to a single blob path, so the
+// only thing it can ever unlock is the VOD it was minted for.
+const cdnTokenSlack = 24 * time.Hour
+
+// tokenExpiry picks the expiry for blob URLs in a playlist covering a
+// VOD of the given duration.
+func (c vodCDN) tokenExpiry(vodDuration time.Duration) time.Time {
+	now := time.Now
+	if c.now != nil {
+		now = c.now
+	}
+	return now().Add(cdnTokenSlack + 2*vodDuration)
+}
+
+// ticksToDuration converts a tick count at the given timescale
+// without overflowing: multiplying ticks by time.Second first would
+// wrap past ~9.2e9 ticks (a day and change at 90 kHz), so split into
+// whole seconds and a sub-second remainder.
+func ticksToDuration(ticks uint64, timescale uint32) time.Duration {
+	if timescale == 0 {
+		return 0
+	}
+	ts := uint64(timescale)
+	secs := ticks / ts
+	rem := ticks % ts
+	return time.Duration(secs)*time.Second + time.Duration(rem*uint64(time.Second)/ts)
+}
+
 // blobURL is where the .m3u8 references segments + init blobs.
 // Behaviour depends on whether a CDN sits in front of the bucket:
 //
-//   - cdnURL == "": self-hosted mode. The playlist links back to our
+//   - cdn.URL == "": self-hosted mode. The playlist links back to our
 //     own getVideoBlob endpoint, content-addressed by query param.
 //     The trailing `.m4s` is cosmetic but load-bearing: ffmpeg's HLS
 //     demuxer refuses to fetch segment URLs whose extension isn't in
@@ -523,29 +572,42 @@ func (s *Server) fetchMetafile(ctx context.Context, cid string) (*vod.Metafile, 
 //     the last query param — we can't let url.Values sort other keys
 //     after it. The handler strips the suffix back off before lookup.
 //
-//   - cdnURL != "": CDN-fronted mode. The playlist links straight at
+//   - cdn.URL != "": CDN-fronted mode. The playlist links straight at
 //     the configured CDN, which in turn serves blobs/<cid>.mp4 out of
 //     the bucket. The `blobs/` prefix is baked in — operators point
 //     --vod-cdn-url at the bucket root, and we know the layout from
 //     vod.BlobsPrefix. We don't need the `.m4s` trick here because the
 //     path itself carries `.mp4`; query params come after (browser HLS
-//     players don't care).
+//     players don't care). The provider's Signer then gets the last
+//     word, e.g. bunny appends token + expires.
 //
 // `did` is the owning account, carried in either mode so the request
 // is attributable for egress accounting. `sid` is the playback session
 // id used for view-count correlation; the CDN passes both through to
-// access logs.
-func blobURL(cdnURL, did, cid, sid string) string {
+// access logs, which is how CDN-served segments get counted.
+func blobURL(c vodCDN, did, cid, sid string, expires time.Time) string {
 	q := url.Values{"did": {did}}
 	if sid != "" {
 		q.Set("sid", sid)
 	}
-	if cdnURL != "" {
-		return strings.TrimRight(cdnURL, "/") + "/" + vod.BlobsPrefix +
+	if c.URL == "" {
+		return "/xrpc/place.stream.playback.getVideoBlob?" + q.Encode() +
+			"&cid=" + url.QueryEscape(cid) + ".m4s"
+	}
+	u, err := url.Parse(c.URL)
+	if err != nil || u.Host == "" {
+		// Not a parseable absolute URL; fall back to naive string
+		// concatenation (unsigned — there's no path to sign).
+		return strings.TrimRight(c.URL, "/") + "/" + vod.BlobsPrefix +
 			url.PathEscape(cid) + ".mp4?" + q.Encode()
 	}
-	return "/xrpc/place.stream.playback.getVideoBlob?" + q.Encode() +
-		"&cid=" + url.QueryEscape(cid) + ".m4s"
+	u.Path = strings.TrimRight(u.Path, "/") + "/" + vod.BlobsPrefix + cid + ".mp4"
+	u.RawPath = ""
+	u.RawQuery = q.Encode()
+	if c.Signer == nil {
+		return u.String()
+	}
+	return c.Signer.SignURL(u, expires)
 }
 
 // trackPlaylistURL is the URL to a single-track media playlist served
@@ -631,12 +693,21 @@ func masterPlaylist(meta *vod.Metafile, uri, sid string, startMS, endMS *int64) 
 // threaded into every blob URL for egress accounting and `sid` for
 // view-count correlation against the request that built this playlist.
 // `cdnURL` is the configured CDN root, or "" for self-hosted serving.
-func mediaPlaylist(meta *vod.Metafile, trackID, ownerDID, sid, cdnURL string, startMS, endMS *int64) (string, error) {
+func mediaPlaylist(meta *vod.Metafile, trackID, ownerDID, sid string, c vodCDN, startMS, endMS *int64) (string, error) {
 	t, ok := meta.Tracks[trackID]
 	if !ok {
 		return "", echo.NewHTTPError(http.StatusNotFound, "TrackNotFound")
 	}
 	segments, discontinuitySeq := filterSegments(t.Segments, t.Timescale, startMS, endMS)
+
+	// Signed CDN URLs expire relative to the whole track's duration
+	// (not the clipped window) so every playlist over one VOD gets a
+	// comparably long-lived token.
+	var totalTicks uint64
+	for _, s := range t.Segments {
+		totalTicks += s.DurationTicks
+	}
+	expires := c.tokenExpiry(ticksToDuration(totalTicks, t.Timescale))
 
 	var maxDurSec float64
 	for _, s := range segments {
@@ -668,10 +739,10 @@ func mediaPlaylist(meta *vod.Metafile, trackID, ownerDID, sid, cdnURL string, st
 		lines = append(lines, fmt.Sprintf("#EXT-X-DISCONTINUITY-SEQUENCE:%d", discontinuitySeq))
 	}
 	lines = append(lines,
-		fmt.Sprintf(`#EXT-X-MAP:URI=%q`, blobURL(cdnURL, ownerDID, t.InitCID, sid)),
+		fmt.Sprintf(`#EXT-X-MAP:URI=%q`, blobURL(c, ownerDID, t.InitCID, sid, expires)),
 		"",
 	)
-	bURL := blobURL(cdnURL, ownerDID, t.BlobCID, sid)
+	bURL := blobURL(c, ownerDID, t.BlobCID, sid, expires)
 	for i, seg := range segments {
 		// A segment whose decode time reset (a concatenated reconnect/restart)
 		// begins a new timeline; signal it so players re-anchor instead of

--- a/pkg/spxrpc/place_stream_playback_getvideo_test.go
+++ b/pkg/spxrpc/place_stream_playback_getvideo_test.go
@@ -2,11 +2,13 @@ package spxrpc
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/labstack/echo/v4"
@@ -14,6 +16,7 @@ import (
 	"stream.place/streamplace/pkg/comatproto"
 
 	"stream.place/streamplace/pkg/blob"
+	"stream.place/streamplace/pkg/cdn/bunny"
 	"stream.place/streamplace/pkg/model"
 	"stream.place/streamplace/pkg/placestream"
 	"stream.place/streamplace/pkg/spid"
@@ -103,7 +106,7 @@ func TestMasterPlaylist_PropagatesTimeRange(t *testing.T) {
 }
 
 func TestMediaPlaylist_Video(t *testing.T) {
-	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, fixtureSID, "", nil, nil)
+	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, fixtureSID, vodCDN{}, nil, nil)
 	require.NoError(t, err)
 	require.Contains(t, pl, "#EXT-X-PLAYLIST-TYPE:VOD")
 	require.Contains(t, pl, "#EXT-X-INDEPENDENT-SEGMENTS")
@@ -157,7 +160,7 @@ func reconnectVideoMetafile() *vod.Metafile {
 }
 
 func TestMediaPlaylist_Discontinuity(t *testing.T) {
-	pl, err := mediaPlaylist(reconnectVideoMetafile(), "1", fixtureDID, fixtureSID, "", nil, nil)
+	pl, err := mediaPlaylist(reconnectVideoMetafile(), "1", fixtureDID, fixtureSID, vodCDN{}, nil, nil)
 	require.NoError(t, err)
 	// Exactly one inline EXT-X-DISCONTINUITY (its own line — distinct from the
 	// EXT-X-DISCONTINUITY-SEQUENCE header), and no sequence header for full play.
@@ -173,7 +176,7 @@ func TestMediaPlaylist_Discontinuity(t *testing.T) {
 
 func TestMediaPlaylist_DiscontinuityTrimmedToBoundary(t *testing.T) {
 	start := int64(1000) // ms — segment index 1 (the boundary) starts at 1s
-	pl, err := mediaPlaylist(reconnectVideoMetafile(), "1", fixtureDID, fixtureSID, "", &start, nil)
+	pl, err := mediaPlaylist(reconnectVideoMetafile(), "1", fixtureDID, fixtureSID, vodCDN{}, &start, nil)
 	require.NoError(t, err)
 	// The boundary is now the first served segment: reflected as a sequence
 	// bump, NOT an inline tag.
@@ -184,7 +187,7 @@ func TestMediaPlaylist_DiscontinuityTrimmedToBoundary(t *testing.T) {
 }
 
 func TestMediaPlaylist_UnknownTrack(t *testing.T) {
-	_, err := mediaPlaylist(fixtureMetafile(), "99", fixtureDID, fixtureSID, "", nil, nil)
+	_, err := mediaPlaylist(fixtureMetafile(), "99", fixtureDID, fixtureSID, vodCDN{}, nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "TrackNotFound")
 }
@@ -194,7 +197,7 @@ func TestMediaPlaylist_TimeRangeFilters(t *testing.T) {
 	// ticks each). Ask for [1000ms, 2000ms): should keep only segment 1.
 	start := int64(1_000)
 	end := int64(2_000)
-	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, fixtureSID, "", &start, &end)
+	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, fixtureSID, vodCDN{}, &start, &end)
 	require.NoError(t, err)
 	require.NotContains(t, pl, `#EXT-X-BYTERANGE:2000@100`)
 	require.Contains(t, pl, `#EXT-X-BYTERANGE:1800@2100`)
@@ -204,7 +207,7 @@ func TestMediaPlaylist_EmptySIDOmitsParam(t *testing.T) {
 	// Belt-and-suspenders for direct callers: passing an empty sid
 	// shouldn't put a stray `sid=` in the URLs (URL-builder uses
 	// url.Values.Set only when non-empty).
-	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, "", "", nil, nil)
+	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, "", vodCDN{}, nil, nil)
 	require.NoError(t, err)
 	require.NotContains(t, pl, "sid=")
 }
@@ -215,7 +218,7 @@ func TestMediaPlaylist_EmptySIDOmitsParam(t *testing.T) {
 // The XRPC path must NOT appear.
 func TestMediaPlaylist_CDN(t *testing.T) {
 	const cdn = "https://cdn.example.com"
-	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, fixtureSID, cdn, nil, nil)
+	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, fixtureSID, vodCDN{URL: cdn}, nil, nil)
 	require.NoError(t, err)
 	// Both the init segment and the content blob are served from the
 	// CDN — no /xrpc/place.stream.playback.getVideoBlob anywhere.
@@ -234,7 +237,7 @@ func TestMediaPlaylist_CDN(t *testing.T) {
 func TestMediaPlaylist_CDNTrailingSlashNormalized(t *testing.T) {
 	// `--vod-cdn-url=https://cdn.example.com/` shouldn't double-slash
 	// between the base and the baked-in blobs/ prefix.
-	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, fixtureSID, "https://cdn.example.com/", nil, nil)
+	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, fixtureSID, vodCDN{URL: "https://cdn.example.com/"}, nil, nil)
 	require.NoError(t, err)
 	require.NotContains(t, pl, "//blobs/")
 	require.Contains(t, pl, "https://cdn.example.com/blobs/bafyblob.mp4?")
@@ -244,17 +247,73 @@ func TestBlobURL_CDNWithPathPrefix(t *testing.T) {
 	// A CDN URL with its own path is preserved verbatim; we still
 	// append the baked-in blobs/<cid>.mp4 layout under it. Lets ops
 	// front one CDN over multiple bucket sub-trees.
-	got := blobURL("https://cdn.example.com/vods", "did:plc:abc", "bafyblob", "tid123")
+	got := blobURL(vodCDN{URL: "https://cdn.example.com/vods"}, "did:plc:abc", "bafyblob", "tid123", time.Time{})
 	require.Equal(t, "https://cdn.example.com/vods/blobs/bafyblob.mp4?did=did%3Aplc%3Aabc&sid=tid123", got)
 }
 
 func TestBlobURL_SelfHosted(t *testing.T) {
 	// Empty cdnURL keeps the existing XRPC URL shape. The .m4s suffix
 	// stays at the end of the URL string for ffmpeg.
-	got := blobURL("", "did:plc:abc", "bafyblob", "tid123")
+	got := blobURL(vodCDN{}, "did:plc:abc", "bafyblob", "tid123", time.Time{})
 	require.Equal(t,
 		"/xrpc/place.stream.playback.getVideoBlob?did=did%3Aplc%3Aabc&sid=tid123&cid=bafyblob.m4s",
 		got)
+}
+
+// TestBlobURL_Signed: with a provider signer configured the CDN URL
+// is handed to it with the did/sid params already in place. The bunny
+// hash itself is pinned in pkg/cdn/bunny; this checks the plumbing.
+func TestBlobURL_Signed(t *testing.T) {
+	c := vodCDN{URL: "https://cdn.example.com", Signer: bunny.Signer{Key: "secret-key"}}
+	got := blobURL(c, "did:plc:abc", "bafyblob", "tid123", time.Unix(1700000000, 0))
+	require.Equal(t,
+		"https://cdn.example.com/blobs/bafyblob.mp4?token=KIxqgRCnXmqKj07FcqY4y6jxhYQ47kyCj2QLdC-wlo4&did=did%3Aplc%3Aabc&sid=tid123&expires=1700000000",
+		got)
+
+	// A CDN path prefix survives, and an absent sid is omitted.
+	c.URL = "https://cdn.example.com/vods/"
+	got = blobURL(c, "did:plc:abc", "bafyblob", "", time.Unix(1700000000, 0))
+	require.Equal(t,
+		"https://cdn.example.com/vods/blobs/bafyblob.mp4?token=hSHnZu2PJHcclObmqnsI66szGuzpeePfHt_rYt327Fk&did=did%3Aplc%3Aabc&expires=1700000000",
+		got)
+}
+
+func TestBlobURL_SignerWithoutCDNIsIgnored(t *testing.T) {
+	// A signer with no CDN URL can't happen via config (Validate
+	// refuses it) but the self-hosted URL must never be "signed".
+	got := blobURL(vodCDN{Signer: bunny.Signer{Key: "secret-key"}}, "did:plc:abc", "bafyblob", "tid123", time.Unix(1700000000, 0))
+	require.Equal(t,
+		"/xrpc/place.stream.playback.getVideoBlob?did=did%3Aplc%3Aabc&sid=tid123&cid=bafyblob.m4s",
+		got)
+}
+
+// TestMediaPlaylist_SignedCDN: with a signer configured, the init and
+// content blob URLs both carry a token + expiry, and the expiry
+// outlives the VOD by the slack plus twice its duration (fixture track
+// 1 is two 1s segments at timescale 6000).
+func TestMediaPlaylist_SignedCDN(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	c := vodCDN{URL: "https://cdn.example.com", Signer: bunny.Signer{Key: "secret-key"}, now: func() time.Time { return now }}
+	pl, err := mediaPlaylist(fixtureMetafile(), "1", fixtureDID, fixtureSID, c, nil, nil)
+	require.NoError(t, err)
+	wantExpires := fmt.Sprintf("&expires=%d", now.Add(cdnTokenSlack+2*2*time.Second).Unix())
+	for _, line := range strings.Split(pl, "\n") {
+		if strings.Contains(line, "cdn.example.com") {
+			require.Contains(t, line, "?token=")
+			require.Contains(t, line, wantExpires)
+		}
+	}
+	require.Contains(t, pl, `#EXT-X-MAP:URI="https://cdn.example.com/blobs/bafyvideoinit.mp4?token=`)
+	require.Contains(t, pl, "https://cdn.example.com/blobs/bafyblob.mp4?token=")
+	require.NotContains(t, pl, "/xrpc/place.stream.playback.getVideoBlob")
+}
+
+func TestTicksToDuration(t *testing.T) {
+	require.Equal(t, 2*time.Second, ticksToDuration(12000, 6000))
+	require.Equal(t, 1500*time.Millisecond, ticksToDuration(72000, 48000))
+	require.Equal(t, time.Duration(0), ticksToDuration(12000, 0))
+	// 29 hours at 90 kHz overflows a naive ticks*time.Second.
+	require.Equal(t, 29*time.Hour, ticksToDuration(29*3600*90000, 90000))
 }
 
 func TestSessionIDOrNew(t *testing.T) {

--- a/pkg/spxrpc/spxrpc.go
+++ b/pkg/spxrpc/spxrpc.go
@@ -19,6 +19,7 @@ import (
 	"stream.place/streamplace/pkg/atproto"
 	"stream.place/streamplace/pkg/blob"
 	"stream.place/streamplace/pkg/bus"
+	"stream.place/streamplace/pkg/cdn/providers"
 	"stream.place/streamplace/pkg/config"
 	"stream.place/streamplace/pkg/localdb"
 	"stream.place/streamplace/pkg/log"
@@ -52,14 +53,29 @@ type Server struct {
 	// fetches) for later view-count aggregation. Optional; nil when
 	// --view-log-flush-interval is 0 or no playback store is wired.
 	viewLog *viewlog.Writer
+	// cdn is the VOD CDN configuration playlists are generated
+	// against (URL + URL signer). Zero-valued for self-hosted.
+	cdn     vodCDN
 	aliases map[string]string
 }
 
+// vodCDN returns the playlist-generation CDN settings.
+func (s *Server) vodCDN() vodCDN { return s.cdn }
+
 func NewServer(ctx context.Context, cli *config.CLI, model model.Model, statefulDB *statedb.StatefulDB, op *oatproxy.OATProxy, mdlw middleware.Middleware, atsync *atproto.ATProtoSynchronizer, bus *bus.Bus, ldb localdb.LocalDB, mm *media.MediaManager, um *upload.Manager, playbackStore blob.Store, viewLog *viewlog.Writer, aliases map[string]string) (*Server, error) {
 	e := echo.New()
+	provider, err := providers.FromConfig(cli)
+	if err != nil {
+		return nil, err
+	}
+	var vcdn vodCDN
+	if provider != nil {
+		vcdn = vodCDN{URL: cli.VODCDNURL, Signer: provider.Signer}
+	}
 	s := &Server{
 		e:               e,
 		cli:             cli,
+		cdn:             vcdn,
 		model:           model,
 		OGImageCache:    cache.New(5*time.Minute, 10*time.Minute),
 		LiveUsersCache:  cache.New(30*time.Second, 60*time.Second),
@@ -81,7 +97,7 @@ func NewServer(ctx context.Context, cli *config.CLI, model model.Model, stateful
 	e.Use(echomiddleware.Handler("", mdlw))
 	e.Use(s.ServiceAuthMiddleware())
 	e.Use(op.OAuthMiddleware)
-	err := s.RegisterHandlersPlacestream(e)
+	err = s.RegisterHandlersPlacestream(e)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/statedb/cdn_log_part.go
+++ b/pkg/statedb/cdn_log_part.go
@@ -1,0 +1,65 @@
+package statedb
+
+import (
+	"context"
+	"time"
+
+	"gorm.io/gorm/clause"
+)
+
+// CDNLogPart is the ingest cursor for archived CDN access logs: one
+// row per (provider, part) that some node has claimed or finished.
+// Parts are immutable at the provider, so "completed" is permanent.
+// Implements viewlog.IngestCursor.
+type CDNLogPart struct {
+	Source      string     `gorm:"column:source;primaryKey"`
+	PartID      string     `gorm:"column:part_id;primaryKey"`
+	ClaimedAt   time.Time  `gorm:"column:claimed_at;not null"`
+	CompletedAt *time.Time `gorm:"column:completed_at"`
+	Events      int        `gorm:"column:events"`
+}
+
+func (CDNLogPart) TableName() string { return "cdn_log_parts" }
+
+// ClaimPart atomically takes (source, partID) for this caller. A
+// fresh row is inserted with ON CONFLICT DO NOTHING; if the insert
+// didn't land, the row exists and we may only retake it when it's
+// incomplete and its claim is older than staleAfter. Both steps are
+// single statements, so two nodes racing get exactly one winner on
+// either SQLite or Postgres.
+func (state *StatefulDB) ClaimPart(ctx context.Context, source, partID string, staleAfter time.Duration) (bool, error) {
+	now := time.Now().UTC()
+	db := state.DB.WithContext(ctx)
+	ins := db.Clauses(clause.OnConflict{DoNothing: true}).Create(&CDNLogPart{
+		Source: source, PartID: partID, ClaimedAt: now,
+	})
+	if ins.Error != nil {
+		return false, ins.Error
+	}
+	if ins.RowsAffected == 1 {
+		return true, nil
+	}
+	upd := db.Model(&CDNLogPart{}).
+		Where("source = ? AND part_id = ? AND completed_at IS NULL AND claimed_at < ?", source, partID, now.Add(-staleAfter)).
+		Update("claimed_at", now)
+	if upd.Error != nil {
+		return false, upd.Error
+	}
+	return upd.RowsAffected == 1, nil
+}
+
+// CompletePart marks the part done.
+func (state *StatefulDB) CompletePart(ctx context.Context, source, partID string, events int) error {
+	now := time.Now().UTC()
+	return state.DB.WithContext(ctx).Model(&CDNLogPart{}).
+		Where("source = ? AND part_id = ?", source, partID).
+		Updates(map[string]any{"completed_at": now, "events": events}).Error
+}
+
+// ReleasePart drops an in-progress claim so the next run retries.
+// Completed parts are never released.
+func (state *StatefulDB) ReleasePart(ctx context.Context, source, partID string) error {
+	return state.DB.WithContext(ctx).
+		Where("source = ? AND part_id = ? AND completed_at IS NULL", source, partID).
+		Delete(&CDNLogPart{}).Error
+}

--- a/pkg/statedb/cdn_log_part_test.go
+++ b/pkg/statedb/cdn_log_part_test.go
@@ -1,0 +1,63 @@
+package statedb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"stream.place/streamplace/pkg/config"
+	"stream.place/streamplace/pkg/model"
+)
+
+func TestCDNLogPartClaimLifecycle(t *testing.T) {
+	cli := &config.CLI{DBURL: ":memory:"}
+	mod, err := model.MakeDB(":memory:")
+	require.NoError(t, err)
+	state, err := MakeDB(t.Context(), cli, nil, mod)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	// First claim wins; a concurrent second claim loses.
+	ok, err := state.ClaimPart(ctx, "bunny", "p/1.gzip", time.Hour)
+	require.NoError(t, err)
+	require.True(t, ok)
+	ok, err = state.ClaimPart(ctx, "bunny", "p/1.gzip", time.Hour)
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	// A stale claim (staleAfter elapsed) can be retaken.
+	ok, err = state.ClaimPart(ctx, "bunny", "p/1.gzip", 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Completed parts are never reclaimed, even with staleAfter=0.
+	require.NoError(t, state.CompletePart(ctx, "bunny", "p/1.gzip", 42))
+	ok, err = state.ClaimPart(ctx, "bunny", "p/1.gzip", 0)
+	require.NoError(t, err)
+	require.False(t, ok)
+	var row CDNLogPart
+	require.NoError(t, state.DB.Where("source = ? AND part_id = ?", "bunny", "p/1.gzip").First(&row).Error)
+	require.NotNil(t, row.CompletedAt)
+	require.Equal(t, 42, row.Events)
+
+	// Release drops an in-progress claim so it can be retaken at once;
+	// release on a completed part is a no-op.
+	ok, err = state.ClaimPart(ctx, "bunny", "p/2.gzip", time.Hour)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, state.ReleasePart(ctx, "bunny", "p/2.gzip"))
+	ok, err = state.ClaimPart(ctx, "bunny", "p/2.gzip", time.Hour)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, state.ReleasePart(ctx, "bunny", "p/1.gzip"))
+	ok, err = state.ClaimPart(ctx, "bunny", "p/1.gzip", 0)
+	require.NoError(t, err)
+	require.False(t, ok, "completed part survives a release")
+
+	// Sources are independent namespaces.
+	ok, err = state.ClaimPart(ctx, "other", "p/1.gzip", time.Hour)
+	require.NoError(t, err)
+	require.True(t, ok)
+}

--- a/pkg/statedb/queue_processor.go
+++ b/pkg/statedb/queue_processor.go
@@ -29,6 +29,7 @@ var TaskFinalizeLivestream = "finalize_livestream"
 var TaskFinalizeLivestreamVOD = "finalize_livestream_vod"
 var TaskVODProcess = "vod_process"
 var TaskViewCountAggregate = "view_count_aggregate"
+var TaskCDNLogIngest = "cdn_log_ingest"
 
 // nonVODTaskTypes is every task type handled by the general queue worker.
 // VOD processing runs on its own dedicated pool (see ProcessQueue) so a
@@ -42,6 +43,7 @@ var nonVODTaskTypes = []string{
 	TaskStreamReceived,
 	TaskFinalizeLivestream,
 	TaskViewCountAggregate,
+	TaskCDNLogIngest,
 }
 
 type NotificationTask struct {
@@ -94,6 +96,14 @@ type FinalizeLivestreamVODTask struct {
 type ViewCountAggregateTask struct {
 	WindowStart time.Time `json:"windowStart"`
 	WindowEnd   time.Time `json:"windowEnd"`
+}
+
+// CDNLogIngestTask is the payload for one scheduled pass over the
+// CDN's archived access logs. Tick is the UTC-aligned schedule slot;
+// it's in the dedup key, not used by the ingester itself (which
+// always looks for whatever is new).
+type CDNLogIngestTask struct {
+	Tick time.Time `json:"tick"`
 }
 
 // ProcessQueue runs the task queue until ctx is cancelled. VOD tasks are
@@ -178,6 +188,8 @@ func (state *StatefulDB) processTask(ctx context.Context, task *AppTask) error {
 		return state.processFinalizeLivestreamVODTask(ctx, task)
 	case TaskViewCountAggregate:
 		return state.processViewCountAggregateTask(ctx, task)
+	case TaskCDNLogIngest:
+		return state.processCDNLogIngestTask(ctx, task)
 	default:
 		return fmt.Errorf("unknown task type: %s", task.Type)
 	}
@@ -324,6 +336,26 @@ func (state *StatefulDB) processViewCountAggregateTask(ctx context.Context, task
 	}
 	if err := state.viewCountAggregator(ctx, t); err != nil {
 		return fmt.Errorf("view-count aggregation: %w", err)
+	}
+	return state.CompleteTask(ctx, task.ID)
+}
+
+// CDNLogIngester pulls newly archived CDN access logs into the view-log
+// store. Same indirection as ViewCountAggregator.
+type CDNLogIngester func(ctx context.Context) error
+
+func (state *StatefulDB) SetCDNLogIngester(f CDNLogIngester) {
+	state.cdnLogIngester = f
+}
+
+func (state *StatefulDB) processCDNLogIngestTask(ctx context.Context, task *AppTask) error {
+	ctx = log.WithLogValues(ctx, "func", "processCDNLogIngestTask")
+	if state.cdnLogIngester == nil {
+		log.Warn(ctx, "no cdn log ingester configured; dropping task")
+		return state.CompleteTask(ctx, task.ID)
+	}
+	if err := state.cdnLogIngester(ctx); err != nil {
+		return fmt.Errorf("cdn log ingest: %w", err)
 	}
 	return state.CompleteTask(ctx, task.ID)
 }

--- a/pkg/statedb/statedb.go
+++ b/pkg/statedb/statedb.go
@@ -47,6 +47,9 @@ type StatefulDB struct {
 	// SetViewCountAggregator at bootstrap so pkg/statedb doesn't have
 	// to depend on the blob.Store-heavy pkg/viewlog.
 	viewCountAggregator ViewCountAggregator
+	// cdnLogIngester pulls archived CDN access logs into the view-log
+	// store; nil when no CDN log source is configured.
+	cdnLogIngester CDNLogIngester
 	// livestreamVODFinalizer concatenates a finished livestream's recorded
 	// MUXL objects into a VOD. Installed via SetLivestreamVODFinalizer at
 	// bootstrap, same indirection as vodProcessor.
@@ -71,6 +74,7 @@ var StatefulDBModels = []any{
 	S3Segment{},
 	Upload{},
 	DraftVideo{},
+	CDNLogPart{},
 }
 
 var NoPostgresDatabaseCode = "3D000"

--- a/pkg/viewlog/aggregate.go
+++ b/pkg/viewlog/aggregate.go
@@ -259,8 +259,20 @@ func AggregateWindow(ctx context.Context, store blob.Store, in AggregateInput) (
 					}
 					trackRefCache[ev.CID] = refs
 				}
+				// CDN-ingested events carry bytes-sent but no Range;
+				// prorate across tracks by byte share. Node-logged
+				// events carry a Range over the blob, which includes
+				// the flat-MP4 header the metafile's fragment-relative
+				// offsets sit behind, so shift it before intersecting.
+				prorated := ev.BytesSent > 0 && ev.RangeStart == 0 && ev.RangeEnd == 0
+				totalBody := metafileBodyBytes(meta)
 				for tid, track := range meta.Tracks {
-					bytes, durMS := rangeOverlapInTrack(ev.RangeStart, ev.RangeEnd, track)
+					var bytes, durMS int64
+					if prorated {
+						bytes, durMS = prorateInTrack(ev.BytesSent, totalBody, track)
+					} else {
+						bytes, durMS = rangeOverlapInTrack(ev.RangeStart-meta.FlatHeaderSize, ev.RangeEnd-meta.FlatHeaderSize, track)
+					}
 					if bytes == 0 {
 						continue
 					}
@@ -383,6 +395,47 @@ func rangeOverlapInTrack(rangeStart, rangeEnd int64, track vod.MetafileTrack) (b
 		segDurMS := int64(seg.DurationTicks) * 1000 / int64(track.Timescale)
 		durationMS += segDurMS * overlap / seg.Size
 	}
+	return bytes, durationMS
+}
+
+// metafileBodyBytes is the byte length of every track's segments
+// summed: the denominator for prorating a bytes-sent figure.
+func metafileBodyBytes(meta *vod.Metafile) int64 {
+	var total int64
+	for _, t := range meta.Tracks {
+		for _, seg := range t.Segments {
+			total += seg.Size
+		}
+	}
+	return total
+}
+
+// prorateInTrack credits one track with its byte-share of a request
+// whose size we know but whose Range we don't (CDN access logs). The
+// track gets bytesSent * (trackBytes / totalBody) bytes and the same
+// fraction of its playback duration. bytesSent is capped at the blob
+// body so a whole-blob download that also carried the flat header
+// doesn't over-credit.
+func prorateInTrack(bytesSent, totalBody int64, track vod.MetafileTrack) (bytes, durationMS int64) {
+	if bytesSent <= 0 || totalBody <= 0 || track.Timescale == 0 {
+		return 0, 0
+	}
+	if bytesSent > totalBody {
+		bytesSent = totalBody
+	}
+	var trackBytes int64
+	var trackTicks uint64
+	for _, seg := range track.Segments {
+		trackBytes += seg.Size
+		trackTicks += seg.DurationTicks
+	}
+	if trackBytes == 0 {
+		return 0, 0
+	}
+	// Integer math throughout so re-runs are byte-identical.
+	bytes = bytesSent * trackBytes / totalBody
+	trackDurMS := int64(trackTicks) * 1000 / int64(track.Timescale)
+	durationMS = trackDurMS * bytesSent / totalBody
 	return bytes, durationMS
 }
 

--- a/pkg/viewlog/aggregate_test.go
+++ b/pkg/viewlog/aggregate_test.go
@@ -569,3 +569,101 @@ func TestAggregateWindowMissingMetafileDoesNotPoison(t *testing.T) {
 	require.Equal(t, int64(1), res.VideoCounts[0].Count)
 	require.Empty(t, res.VideoCounts[0].Tracks, "no metafile ⇒ no per-track credit")
 }
+
+// TestAggregateWindowFlatHeaderOffset: node-logged Ranges are absolute
+// within the blob, which stores the fragments behind a synthesized
+// flat-MP4 header; the metafile's offsets are fragment-relative. A
+// request for the first video segment therefore arrives shifted by
+// FlatHeaderSize and must still credit exactly that segment.
+func TestAggregateWindowFlatHeaderOffset(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	w := newAggTestWriter(t, root, "did:web:node1", now)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Run(ctx)
+
+	const header = 1000
+	w.Log(ctx, Event{Ts: now, Type: EventTypeManifestRequest, VideoURI: "at://did:plc:alice/place.stream.video/v1", SID: "s"})
+	w.Log(ctx, Event{Ts: now.Add(time.Second), Type: EventTypeSegmentRequest, CID: "bafyfixture", SID: "s", RangeStart: header + 0, RangeEnd: header + 399})
+	require.NoError(t, w.Close())
+
+	store, err := blob.NewFileStore(root)
+	require.NoError(t, err)
+	refs := fixtureTrackRefs()
+	res, err := AggregateWindow(context.Background(), store, AggregateInput{
+		WindowStart: now.Add(-time.Minute),
+		WindowEnd:   now.Add(time.Minute),
+		FetchMetafile: func(ctx context.Context, cid string) (*vod.Metafile, error) {
+			m := fixtureMetafile()
+			m.FlatHeaderSize = header
+			return m, nil
+		},
+		FetchTrackRefs: func(ctx context.Context, cid string) (map[string]comatproto.RepoStrongRef, error) { return refs, nil },
+	})
+	require.NoError(t, err)
+	require.Len(t, res.VideoCounts, 1)
+	require.Len(t, res.VideoCounts[0].Tracks, 1, "only the video track was touched")
+	require.Equal(t, TrackUsage{Track: refs["1"], Bytes: 400, DurationMS: 2000}, res.VideoCounts[0].Tracks[0])
+}
+
+func TestProrateInTrack(t *testing.T) {
+	meta := fixtureMetafile()
+	total := metafileBodyBytes(meta)
+	require.Equal(t, int64(1500), total)
+
+	// A CDN-logged request for 300 bytes with no Range: video holds
+	// 1200/1500 of the body, audio 300/1500. Each track gets that
+	// share of the bytes and the matching share of its own duration.
+	b, d := prorateInTrack(300, total, meta.Tracks["1"])
+	require.Equal(t, int64(240), b)
+	require.Equal(t, int64(1200), d, "6000ms of video * 300/1500")
+	b, d = prorateInTrack(300, total, meta.Tracks["2"])
+	require.Equal(t, int64(60), b)
+	require.Equal(t, int64(1200), d)
+
+	// Bytes beyond the body (a whole-blob fetch that included the flat
+	// header) are capped at the body.
+	b, d = prorateInTrack(99999, total, meta.Tracks["1"])
+	require.Equal(t, int64(1200), b)
+	require.Equal(t, int64(6000), d)
+
+	b, d = prorateInTrack(0, total, meta.Tracks["1"])
+	require.Zero(t, b)
+	require.Zero(t, d)
+}
+
+// TestAggregateWindowBytesSentEvents: CDN-ingested events (BytesSent,
+// no Range) count toward the sid view and are prorated, alongside a
+// node-logged Range event for the same session.
+func TestAggregateWindowBytesSentEvents(t *testing.T) {
+	root := t.TempDir()
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	w := newAggTestWriter(t, root, "did:web:node1", now)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Run(ctx)
+
+	w.Log(ctx, Event{Ts: now, Type: EventTypeManifestRequest, VideoURI: "at://did:plc:alice/place.stream.video/v1", SID: "s"})
+	w.Log(ctx, Event{Ts: now.Add(time.Second), Type: EventTypeSegmentRequest, CID: "bafyfixture", SID: "s", BytesSent: 1500})
+	require.NoError(t, w.Close())
+
+	store, err := blob.NewFileStore(root)
+	require.NoError(t, err)
+	refs := fixtureTrackRefs()
+	res, err := AggregateWindow(context.Background(), store, AggregateInput{
+		WindowStart:    now.Add(-time.Minute),
+		WindowEnd:      now.Add(time.Minute),
+		FetchMetafile:  func(ctx context.Context, cid string) (*vod.Metafile, error) { return fixtureMetafile(), nil },
+		FetchTrackRefs: func(ctx context.Context, cid string) (map[string]comatproto.RepoStrongRef, error) { return refs, nil },
+	})
+	require.NoError(t, err)
+	require.Len(t, res.VideoCounts, 1)
+	require.Equal(t, int64(1), res.VideoCounts[0].Count)
+	byURI := map[string]TrackUsage{}
+	for _, tu := range res.VideoCounts[0].Tracks {
+		byURI[tu.Track.Uri] = tu
+	}
+	require.Equal(t, TrackUsage{Track: refs["1"], Bytes: 1200, DurationMS: 6000}, byURI[refs["1"].Uri])
+	require.Equal(t, TrackUsage{Track: refs["2"], Bytes: 300, DurationMS: 6000}, byURI[refs["2"].Uri])
+}

--- a/pkg/viewlog/event.go
+++ b/pkg/viewlog/event.go
@@ -69,4 +69,10 @@ type Event struct {
 	// Zero values indicate "whole blob" / "open-ended" range.
 	RangeStart int64 `json:"range_start,omitempty"`
 	RangeEnd   int64 `json:"range_end,omitempty"`
+	// BytesSent is the response body size as reported by whoever
+	// served the request. Set on events ingested from CDN access
+	// logs, which carry no Range header: when it's present and the
+	// Range fields are zero, the aggregator prorates it across the
+	// blob's tracks by byte share instead of intersecting a range.
+	BytesSent int64 `json:"bytes_sent,omitempty"`
 }

--- a/pkg/viewlog/ingest.go
+++ b/pkg/viewlog/ingest.go
@@ -138,9 +138,26 @@ func RunIngest(ctx context.Context, in IngestInput) (*IngestResult, error) {
 			}
 			continue
 		}
+		// Request re-aggregation BEFORE marking the part complete. A
+		// completed part is never revisited, so an enqueue that fails
+		// after completion would leave that window's published count
+		// permanently missing the CDN's segments. Failing here instead
+		// releases the claim; the next pass re-ingests the part, which
+		// is idempotent (output keys derive from part ID + window, so
+		// the rewrite lands on the same files with the same content).
+		if err := requestReaggregation(ctx, in, part.ID, pr.windows); err != nil {
+			log.Error(ctx, "viewlog: request re-aggregation failed", "source", in.SourceName, "part", part.ID, "error", err)
+			if rerr := in.Cursor.ReleasePart(ctx, in.SourceName, part.ID); rerr != nil {
+				log.Error(ctx, "viewlog: release part claim", "part", part.ID, "error", rerr)
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
 		if err := in.Cursor.CompletePart(ctx, in.SourceName, part.ID, pr.events); err != nil {
-			// The files are visible; a re-run would duplicate them.
-			// Surface loudly rather than release.
+			// Files + re-aggregation requests are in place; the next
+			// pass will redo both harmlessly. Surface it anyway.
 			return res, fmt.Errorf("viewlog: complete part %s: %w", part.ID, err)
 		}
 		res.PartsIngested++
@@ -150,18 +167,24 @@ func RunIngest(ctx context.Context, in IngestInput) (*IngestResult, error) {
 		log.Log(ctx, "viewlog: ingested cdn log part",
 			"source", in.SourceName, "part", part.ID, "size", part.Size,
 			"events", pr.events, "skipped", pr.skipped, "windows", len(pr.windows))
-		if in.Reaggregate != nil {
-			for _, w := range pr.windows {
-				if err := in.Reaggregate(ctx, part.ID, w, w.Add(in.Window)); err != nil {
-					log.Error(ctx, "viewlog: request re-aggregation", "part", part.ID, "window", w, "error", err)
-					if firstErr == nil {
-						firstErr = err
-					}
-				}
-			}
-		}
 	}
 	return res, firstErr
+}
+
+// requestReaggregation asks for every touched window to be recomputed.
+// Stops at the first failure: the caller releases the part and the
+// whole thing is retried next pass (duplicate requests dedup on their
+// task key).
+func requestReaggregation(ctx context.Context, in IngestInput, partID string, windows []time.Time) error {
+	if in.Reaggregate == nil {
+		return nil
+	}
+	for _, w := range windows {
+		if err := in.Reaggregate(ctx, partID, w, w.Add(in.Window)); err != nil {
+			return fmt.Errorf("window %s: %w", w.Format(time.RFC3339), err)
+		}
+	}
+	return nil
 }
 
 type partResult struct {

--- a/pkg/viewlog/ingest.go
+++ b/pkg/viewlog/ingest.go
@@ -1,0 +1,324 @@
+package viewlog
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"stream.place/streamplace/pkg/blob"
+	"stream.place/streamplace/pkg/cdn"
+	"stream.place/streamplace/pkg/log"
+	"stream.place/streamplace/pkg/statedb"
+	"stream.place/streamplace/pkg/vod"
+)
+
+// IngestCursor remembers which CDN log parts have already been turned
+// into view-log files, so every node in a cluster can run the ingester
+// and each part is still processed exactly once. statedb implements
+// it; tests use an in-memory fake.
+type IngestCursor interface {
+	// ClaimPart marks (source, partID) in-progress for this caller.
+	// Returns false when the part is already complete, or claimed by
+	// someone else less than staleAfter ago (a crashed ingester's
+	// claim goes stale and is retaken).
+	ClaimPart(ctx context.Context, source, partID string, staleAfter time.Duration) (bool, error)
+	// CompletePart records a successful ingest.
+	CompletePart(ctx context.Context, source, partID string, events int) error
+	// ReleasePart drops an in-progress claim after a failure so the
+	// next run retries immediately instead of waiting out staleAfter.
+	ReleasePart(ctx context.Context, source, partID string) error
+}
+
+// IngestInput bundles one ingest pass over a CDN's archived logs.
+type IngestInput struct {
+	// Store is the VOD blob store the view-log files are written into
+	// (the same one the node's own Writer targets).
+	Store blob.Store
+	// Source lists + decodes the provider's archived logs.
+	Source cdn.LogSource
+	// SourceName identifies the provider in the output key layout,
+	// `view-logs/cdn-<SourceName>/...`, and in the cursor.
+	SourceName string
+	Salts      *SaltManager
+	Cursor     IngestCursor
+	// Window is the aggregation bucket size. Each part is re-bucketed
+	// into one output file per window so the aggregator's filename-
+	// timestamp file selection finds it without a huge read margin.
+	Window time.Duration
+	// Lookback bounds how far back parts are listed. Parts older than
+	// this are never considered, even if unseen. Defaults to 48h,
+	// comfortably past bunny's "the next day" delivery.
+	Lookback time.Duration
+	// StaleAfter is how long a claim on a part stands before another
+	// ingester may retake it. Defaults to 1h.
+	StaleAfter time.Duration
+	// Reaggregate is called once per (part, window) after the part's
+	// files are all visible, so the already-published view counts for
+	// that window get recomputed with the CDN's segments included.
+	// Optional.
+	Reaggregate func(ctx context.Context, partID string, start, end time.Time) error
+	// Now overrides the clock (tests).
+	Now func() time.Time
+}
+
+// IngestResult summarises one pass for logs + tests.
+type IngestResult struct {
+	PartsListed   int
+	PartsIngested int
+	// Events is the count of segment_request events written; Skipped
+	// is lines that were not blob fetches (non-2xx, other paths, no
+	// sid) and were dropped.
+	Events  int
+	Skipped int
+	Windows int
+}
+
+// RunIngest lists the source's parts within Lookback, claims each
+// unseen one, streams it into per-window view-log files, marks it
+// complete, and asks for the touched windows to be re-aggregated. A
+// failure on one part releases its claim and moves on; the first
+// error is returned after every part has been attempted.
+func RunIngest(ctx context.Context, in IngestInput) (*IngestResult, error) {
+	if in.Store == nil || in.Source == nil || in.Cursor == nil || in.Salts == nil {
+		return nil, errors.New("viewlog: RunIngest needs Store, Source, Cursor and Salts")
+	}
+	if in.SourceName == "" {
+		return nil, errors.New("viewlog: RunIngest needs a SourceName")
+	}
+	if in.Window <= 0 {
+		return nil, errors.New("viewlog: RunIngest needs a positive Window")
+	}
+	now := time.Now
+	if in.Now != nil {
+		now = in.Now
+	}
+	lookback := in.Lookback
+	if lookback <= 0 {
+		lookback = 48 * time.Hour
+	}
+	staleAfter := in.StaleAfter
+	if staleAfter <= 0 {
+		staleAfter = time.Hour
+	}
+
+	parts, err := in.Source.ListParts(ctx, now().Add(-lookback))
+	if err != nil {
+		return nil, fmt.Errorf("viewlog: list cdn log parts: %w", err)
+	}
+	sort.Slice(parts, func(i, j int) bool { return parts[i].ID < parts[j].ID })
+	res := &IngestResult{PartsListed: len(parts)}
+	var firstErr error
+	for _, part := range parts {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+		claimed, err := in.Cursor.ClaimPart(ctx, in.SourceName, part.ID, staleAfter)
+		if err != nil {
+			return res, fmt.Errorf("viewlog: claim part %s: %w", part.ID, err)
+		}
+		if !claimed {
+			continue
+		}
+		pr, err := ingestPart(ctx, in, part)
+		if err != nil {
+			log.Error(ctx, "viewlog: ingest cdn log part failed", "source", in.SourceName, "part", part.ID, "error", err)
+			if rerr := in.Cursor.ReleasePart(ctx, in.SourceName, part.ID); rerr != nil {
+				log.Error(ctx, "viewlog: release part claim", "part", part.ID, "error", rerr)
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if err := in.Cursor.CompletePart(ctx, in.SourceName, part.ID, pr.events); err != nil {
+			// The files are visible; a re-run would duplicate them.
+			// Surface loudly rather than release.
+			return res, fmt.Errorf("viewlog: complete part %s: %w", part.ID, err)
+		}
+		res.PartsIngested++
+		res.Events += pr.events
+		res.Skipped += pr.skipped
+		res.Windows += len(pr.windows)
+		log.Log(ctx, "viewlog: ingested cdn log part",
+			"source", in.SourceName, "part", part.ID, "size", part.Size,
+			"events", pr.events, "skipped", pr.skipped, "windows", len(pr.windows))
+		if in.Reaggregate != nil {
+			for _, w := range pr.windows {
+				if err := in.Reaggregate(ctx, part.ID, w, w.Add(in.Window)); err != nil {
+					log.Error(ctx, "viewlog: request re-aggregation", "part", part.ID, "window", w, "error", err)
+					if firstErr == nil {
+						firstErr = err
+					}
+				}
+			}
+		}
+	}
+	return res, firstErr
+}
+
+type partResult struct {
+	events, skipped int
+	windows         []time.Time
+}
+
+// bucketWriter is one open per-window output file.
+type bucketWriter struct {
+	w  blob.Writer
+	gz *gzip.Writer
+	n  int
+}
+
+// ingestPart streams one part into per-window files. Nothing becomes
+// visible until every window's file is complete, so a mid-part
+// failure leaves no partial data behind for the aggregator to count.
+func ingestPart(ctx context.Context, in IngestInput, part cdn.Part) (*partResult, error) {
+	prefix := viewLogsPrefix + "cdn-" + in.SourceName + "/" + sanitizePartID(part.ID) + "/"
+	buckets := make(map[time.Time]*bucketWriter)
+	abortAll := func() {
+		for _, b := range buckets {
+			_ = b.w.Close()
+		}
+	}
+	pr := &partResult{}
+	err := in.Source.ReadPart(ctx, part, func(r cdn.Request) error {
+		ev, ok := segmentEventFromRequest(r, in.Salts)
+		if !ok {
+			pr.skipped++
+			return nil
+		}
+		start := ev.Ts.Truncate(in.Window)
+		b := buckets[start]
+		if b == nil {
+			w, err := in.Store.NewWriter(ctx, prefix+start.UTC().Format(keyTimeFormat)+".jsonl.gz", "application/gzip")
+			if err != nil {
+				return fmt.Errorf("open window file: %w", err)
+			}
+			b = &bucketWriter{w: w, gz: gzip.NewWriter(w)}
+			buckets[start] = b
+		}
+		line, err := json.Marshal(&ev)
+		if err != nil {
+			return err
+		}
+		if _, err := b.gz.Write(append(line, '\n')); err != nil {
+			return fmt.Errorf("write window file: %w", err)
+		}
+		b.n++
+		pr.events++
+		return nil
+	})
+	if err != nil {
+		abortAll()
+		return nil, err
+	}
+	for start, b := range buckets {
+		if err := b.gz.Close(); err != nil {
+			abortAll()
+			return nil, fmt.Errorf("gzip close: %w", err)
+		}
+		if err := b.w.Complete(); err != nil {
+			abortAll()
+			return nil, fmt.Errorf("complete window file: %w", err)
+		}
+		pr.windows = append(pr.windows, start)
+	}
+	sort.Slice(pr.windows, func(i, j int) bool { return pr.windows[i].Before(pr.windows[j]) })
+	return pr, nil
+}
+
+// sanitizePartID flattens a provider part ID (usually a storage path)
+// into one key segment.
+func sanitizePartID(id string) string {
+	return strings.NewReplacer("/", "_", "\\", "_", " ", "_").Replace(id)
+}
+
+// segmentEventFromRequest maps a CDN access-log record onto the same
+// segment_request event the node's own blob handler logs. Only
+// successful fetches of blobs/<cid>.mp4 that carry a playback sid
+// qualify; everything else (playlists don't go through the CDN,
+// probes, 403s from expired tokens, sid-less transfers) is dropped.
+func segmentEventFromRequest(r cdn.Request, salts *SaltManager) (Event, bool) {
+	if r.Status != http.StatusOK && r.Status != http.StatusPartialContent {
+		return Event{}, false
+	}
+	u, err := url.Parse(r.URL)
+	if err != nil {
+		return Event{}, false
+	}
+	base := path.Base(u.Path)
+	if !strings.HasSuffix(base, ".mp4") || path.Base(path.Dir(u.Path)) != strings.TrimSuffix(vod.BlobsPrefix, "/") {
+		return Event{}, false
+	}
+	cid := strings.TrimSuffix(base, ".mp4")
+	q := u.Query()
+	sid := q.Get("sid")
+	if cid == "" || sid == "" {
+		return Event{}, false
+	}
+	ts := r.Time.UTC()
+	ipHash, err := salts.HashIP(r.RemoteIP, ts)
+	if err != nil {
+		// Same policy as the live handlers: a missing hash is better
+		// than a missing view.
+		ipHash = ""
+	}
+	return Event{
+		Ts:        ts,
+		Type:      EventTypeSegmentRequest,
+		SID:       sid,
+		IPHash:    ipHash,
+		CID:       cid,
+		OwnerDID:  q.Get("did"),
+		BytesSent: r.BytesSent,
+	}, true
+}
+
+// ReaggregateTaskKey is the dedup key for re-running one aggregation
+// window because CDN part `partID` added segments to it. Distinct
+// from AggregateTaskKey so the scheduled first pass (already done by
+// the time CDN logs arrive) doesn't swallow the re-run.
+func ReaggregateTaskKey(start, end time.Time, partID string) string {
+	return AggregateTaskKey(start, end) + "::reagg::" + sanitizePartID(partID)
+}
+
+// IngestTaskKey is the dedup key for one scheduled ingest tick, so a
+// cluster runs one ingest per interval rather than one per node.
+func IngestTaskKey(tick time.Time) string {
+	return "cdn-log-ingest::" + tick.UTC().Format(time.RFC3339)
+}
+
+// ScheduleIngest runs until ctx is cancelled, enqueueing one
+// TaskCDNLogIngest per Interval, keyed on the UTC-aligned tick so
+// every node's attempt dedups to a single task.
+func ScheduleIngest(ctx context.Context, q TaskEnqueuer, interval time.Duration) error {
+	if interval <= 0 {
+		return fmt.Errorf("viewlog: ScheduleIngest needs a positive interval")
+	}
+	tryEnqueueIngest(ctx, q, interval, time.Now().UTC())
+	tick := time.NewTicker(interval)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case now := <-tick.C:
+			tryEnqueueIngest(ctx, q, interval, now.UTC())
+		}
+	}
+}
+
+func tryEnqueueIngest(ctx context.Context, q TaskEnqueuer, interval time.Duration, now time.Time) {
+	tick := now.Truncate(interval)
+	payload := statedb.CDNLogIngestTask{Tick: tick}
+	if _, err := q.EnqueueTask(ctx, statedb.TaskCDNLogIngest, payload, statedb.WithTaskKey(IngestTaskKey(tick))); err != nil {
+		log.Error(ctx, "viewlog: enqueue cdn log ingest task", "tick", tick, "error", err)
+	}
+}

--- a/pkg/viewlog/ingest_test.go
+++ b/pkg/viewlog/ingest_test.go
@@ -254,6 +254,50 @@ func TestRunIngestFailedPartIsReleasedAndRetried(t *testing.T) {
 	require.Len(t, keys, 2)
 }
 
+// TestRunIngestReaggregateFailureRetriesPart: if requesting
+// re-aggregation fails, the part must not be marked complete, or the
+// window's published count would never pick up the CDN's segments.
+// The next pass redoes the part; the rewrite lands on the same keys.
+func TestRunIngestReaggregateFailureRetriesPart(t *testing.T) {
+	root := t.TempDir()
+	store, err := blob.NewFileStore(root)
+	require.NoError(t, err)
+	day := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+	src := &fakeSource{
+		parts:    []cdn.Part{{ID: "p/a.gzip", Day: day}},
+		requests: map[string][]cdn.Request{"p/a.gzip": {segReq(day.Add(time.Hour), 200, 10, "bafyblob", "tid1")}},
+	}
+	cursor := newMemCursor()
+	failing := true
+	var reaggs int
+	in := IngestInput{
+		Store: store, Source: src, SourceName: "bunny", Salts: NewSaltManager(newMemSaltStorage()),
+		Cursor: cursor, Window: 5 * time.Minute,
+		Reaggregate: func(ctx context.Context, part string, start, end time.Time) error {
+			reaggs++
+			if failing {
+				return errors.New("queue down")
+			}
+			return nil
+		},
+		Now: func() time.Time { return day.Add(26 * time.Hour) },
+	}
+	res, err := RunIngest(context.Background(), in)
+	require.Error(t, err)
+	require.Equal(t, 0, res.PartsIngested)
+	require.Empty(t, cursor.completed, "part is not complete after a failed re-aggregation request")
+
+	failing = false
+	res, err = RunIngest(context.Background(), in)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.PartsIngested)
+	require.Equal(t, 2, reaggs)
+	require.Equal(t, 2, src.reads, "the part was re-read on retry")
+	keys, err := store.List(context.Background(), viewLogsPrefix)
+	require.NoError(t, err)
+	require.Len(t, keys, 1, "the retry overwrote the same window file rather than adding a duplicate")
+}
+
 func TestIngestTaskKeys(t *testing.T) {
 	start := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
 	end := start.Add(5 * time.Minute)

--- a/pkg/viewlog/ingest_test.go
+++ b/pkg/viewlog/ingest_test.go
@@ -1,0 +1,263 @@
+package viewlog
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"stream.place/streamplace/pkg/blob"
+	"stream.place/streamplace/pkg/cdn"
+)
+
+// fakeSource is an in-memory cdn.LogSource.
+type fakeSource struct {
+	parts    []cdn.Part
+	requests map[string][]cdn.Request
+	readErr  map[string]error
+	reads    int
+}
+
+func (f *fakeSource) ListParts(ctx context.Context, since time.Time) ([]cdn.Part, error) {
+	var out []cdn.Part
+	for _, p := range f.parts {
+		if !p.Day.Before(since.Truncate(24 * time.Hour)) {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeSource) ReadPart(ctx context.Context, p cdn.Part, emit func(cdn.Request) error) error {
+	f.reads++
+	if err := f.readErr[p.ID]; err != nil {
+		return err
+	}
+	for _, r := range f.requests[p.ID] {
+		if err := emit(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// memCursor is an in-memory IngestCursor with the same claim semantics
+// as the statedb implementation.
+type memCursor struct {
+	mu        sync.Mutex
+	claimed   map[string]time.Time
+	completed map[string]int
+}
+
+func newMemCursor() *memCursor {
+	return &memCursor{claimed: map[string]time.Time{}, completed: map[string]int{}}
+}
+
+func (c *memCursor) ClaimPart(ctx context.Context, source, id string, stale time.Duration) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	k := source + "/" + id
+	if _, done := c.completed[k]; done {
+		return false, nil
+	}
+	if at, ok := c.claimed[k]; ok && time.Since(at) < stale {
+		return false, nil
+	}
+	c.claimed[k] = time.Now()
+	return true, nil
+}
+
+func (c *memCursor) CompletePart(ctx context.Context, source, id string, events int) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.completed[source+"/"+id] = events
+	return nil
+}
+
+func (c *memCursor) ReleasePart(ctx context.Context, source, id string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.claimed, source+"/"+id)
+	return nil
+}
+
+const blobURLBase = "https://cdn.example.com/blobs/"
+
+func segReq(ts time.Time, status int, bytes int64, cid, sid string) cdn.Request {
+	u := blobURLBase + cid + ".mp4?token=t&did=did%3Aplc%3Aalice&sid=" + sid + "&expires=1"
+	return cdn.Request{Time: ts, Status: status, BytesSent: bytes, RemoteIP: "203.0.113.9", URL: u}
+}
+
+func TestSegmentEventFromRequest(t *testing.T) {
+	salts := NewSaltManager(newMemSaltStorage())
+	ts := time.Date(2026, 9, 6, 10, 0, 0, 0, time.UTC)
+
+	ev, ok := segmentEventFromRequest(segReq(ts, 206, 1234, "bafyblob", "tid1"), salts)
+	require.True(t, ok)
+	require.Equal(t, Event{
+		Ts: ts, Type: EventTypeSegmentRequest, SID: "tid1", IPHash: ev.IPHash,
+		CID: "bafyblob", OwnerDID: "did:plc:alice", BytesSent: 1234,
+	}, ev)
+	require.NotEmpty(t, ev.IPHash)
+
+	// Path-only URLs (some providers log no host) work too.
+	ev, ok = segmentEventFromRequest(cdn.Request{Time: ts, Status: 200, BytesSent: 1, URL: "/blobs/bafyx.mp4?sid=tid2"}, salts)
+	require.True(t, ok)
+	require.Equal(t, "bafyx", ev.CID)
+
+	// Rejected: expired-token 403s, non-blob paths, sid-less fetches.
+	_, ok = segmentEventFromRequest(segReq(ts, 403, 0, "bafyblob", "tid1"), salts)
+	require.False(t, ok)
+	_, ok = segmentEventFromRequest(cdn.Request{Time: ts, Status: 200, URL: "https://cdn.example.com/other/bafyblob.mp4?sid=x"}, salts)
+	require.False(t, ok)
+	_, ok = segmentEventFromRequest(cdn.Request{Time: ts, Status: 200, URL: "https://cdn.example.com/blobs/bafyblob.mp4?did=d"}, salts)
+	require.False(t, ok)
+	_, ok = segmentEventFromRequest(cdn.Request{Time: ts, Status: 200, URL: "https://cdn.example.com/blobs/?sid=x"}, salts)
+	require.False(t, ok)
+}
+
+func TestRunIngestBucketsAndReaggregates(t *testing.T) {
+	root := t.TempDir()
+	store, err := blob.NewFileStore(root)
+	require.NoError(t, err)
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	day := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+	t0 := day.Add(10*time.Hour + 2*time.Minute)
+
+	src := &fakeSource{
+		parts: []cdn.Part{
+			{ID: "pullzone-logs/pz/2026/09/05_w1-0-aaaa.gzip", Day: day},
+			{ID: "pullzone-logs/pz/2026/09/05_w2-0-bbbb.gzip", Day: day},
+			{ID: "pullzone-logs/pz/2026/08/01_w1-0-old.gzip", Day: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)},
+		},
+		requests: map[string][]cdn.Request{
+			"pullzone-logs/pz/2026/09/05_w1-0-aaaa.gzip": {
+				segReq(t0, 206, 100, "bafyblob", "tid1"),
+				segReq(t0.Add(time.Minute), 206, 100, "bafyblob", "tid1"),
+				segReq(t0.Add(4*time.Minute), 206, 100, "bafyblob", "tid1"), // next 5m window
+				segReq(t0, 403, 0, "bafyblob", "tid9"),                      // skipped
+			},
+			"pullzone-logs/pz/2026/09/05_w2-0-bbbb.gzip": {
+				segReq(t0.Add(time.Second), 200, 50, "bafyother", "tid2"),
+			},
+		},
+	}
+	cursor := newMemCursor()
+	type reagg struct {
+		part       string
+		start, end time.Time
+	}
+	var reaggs []reagg
+	in := IngestInput{
+		Store: store, Source: src, SourceName: "bunny", Salts: NewSaltManager(newMemSaltStorage()),
+		Cursor: cursor, Window: 5 * time.Minute, Lookback: 48 * time.Hour,
+		Reaggregate: func(ctx context.Context, part string, start, end time.Time) error {
+			reaggs = append(reaggs, reagg{part, start, end})
+			return nil
+		},
+		Now: func() time.Time { return now },
+	}
+	res, err := RunIngest(context.Background(), in)
+	require.NoError(t, err)
+	require.Equal(t, 2, res.PartsListed, "the August part is outside the 48h lookback")
+	require.Equal(t, 2, res.PartsIngested)
+	require.Equal(t, 4, res.Events)
+	require.Equal(t, 1, res.Skipped)
+	require.Equal(t, 3, res.Windows, "part 1 spans two windows, part 2 one")
+
+	// Output files: one per (part, window), named by window start so
+	// the aggregator's filename-timestamp selection finds them.
+	keys, err := store.List(context.Background(), viewLogsPrefix)
+	require.NoError(t, err)
+	sort.Strings(keys)
+	w0 := t0.Truncate(5 * time.Minute)
+	w1 := w0.Add(5 * time.Minute)
+	require.Equal(t, []string{
+		"view-logs/cdn-bunny/pullzone-logs_pz_2026_09_05_w1-0-aaaa.gzip/" + w0.Format(keyTimeFormat) + ".jsonl.gz",
+		"view-logs/cdn-bunny/pullzone-logs_pz_2026_09_05_w1-0-aaaa.gzip/" + w1.Format(keyTimeFormat) + ".jsonl.gz",
+		"view-logs/cdn-bunny/pullzone-logs_pz_2026_09_05_w2-0-bbbb.gzip/" + w0.Format(keyTimeFormat) + ".jsonl.gz",
+	}, keys)
+	for _, k := range keys {
+		ts, ok := parseViewLogKeyTime(k)
+		require.True(t, ok, k)
+		require.False(t, ts.Before(w0))
+	}
+
+	// Each touched window is handed back for re-aggregation, with the
+	// part in the request so the task key is unique per part.
+	require.Equal(t, []reagg{
+		{"pullzone-logs/pz/2026/09/05_w1-0-aaaa.gzip", w0, w1},
+		{"pullzone-logs/pz/2026/09/05_w1-0-aaaa.gzip", w1, w1.Add(5 * time.Minute)},
+		{"pullzone-logs/pz/2026/09/05_w2-0-bbbb.gzip", w0, w1},
+	}, reaggs)
+
+	// The events round-trip through the aggregator: tid1 fetched three
+	// segments across two windows, tid2 one.
+	var n int
+	for _, k := range keys {
+		require.NoError(t, readJSONLGz(context.Background(), store, k, func(ev *Event) {
+			n++
+			require.Equal(t, EventTypeSegmentRequest, ev.Type)
+			require.NotZero(t, ev.BytesSent)
+			require.Zero(t, ev.RangeEnd)
+		}))
+	}
+	require.Equal(t, 4, n)
+
+	// A second run finds nothing new: every part is complete.
+	res, err = RunIngest(context.Background(), in)
+	require.NoError(t, err)
+	require.Equal(t, 0, res.PartsIngested)
+	require.Equal(t, 2, src.reads, "completed parts are not re-read")
+}
+
+func TestRunIngestFailedPartIsReleasedAndRetried(t *testing.T) {
+	root := t.TempDir()
+	store, err := blob.NewFileStore(root)
+	require.NoError(t, err)
+	day := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+	src := &fakeSource{
+		parts:   []cdn.Part{{ID: "p/bad.gzip", Day: day}, {ID: "p/good.gzip", Day: day}},
+		readErr: map[string]error{"p/bad.gzip": errors.New("boom")},
+		requests: map[string][]cdn.Request{
+			"p/good.gzip": {segReq(day.Add(time.Hour), 200, 10, "bafyblob", "tid1")},
+			"p/bad.gzip":  {segReq(day.Add(time.Hour), 200, 10, "bafyblob", "tid1")},
+		},
+	}
+	cursor := newMemCursor()
+	in := IngestInput{
+		Store: store, Source: src, SourceName: "bunny", Salts: NewSaltManager(newMemSaltStorage()),
+		Cursor: cursor, Window: 5 * time.Minute,
+		Now: func() time.Time { return day.Add(26 * time.Hour) },
+	}
+	res, err := RunIngest(context.Background(), in)
+	require.Error(t, err, "the bad part's error surfaces after every part is attempted")
+	require.Equal(t, 1, res.PartsIngested, "the good part still landed")
+
+	keys, err := store.List(context.Background(), viewLogsPrefix)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Contains(t, keys[0], "p_good.gzip")
+
+	// The failure released the claim; once the source recovers, the
+	// next run ingests it.
+	delete(src.readErr, "p/bad.gzip")
+	res, err = RunIngest(context.Background(), in)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.PartsIngested)
+	keys, err = store.List(context.Background(), viewLogsPrefix)
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+}
+
+func TestIngestTaskKeys(t *testing.T) {
+	start := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	end := start.Add(5 * time.Minute)
+	require.NotEqual(t, AggregateTaskKey(start, end), ReaggregateTaskKey(start, end, "p/a.gzip"))
+	require.NotEqual(t, ReaggregateTaskKey(start, end, "p/a.gzip"), ReaggregateTaskKey(start, end, "p/b.gzip"))
+	require.Equal(t, "cdn-log-ingest::2026-09-05T10:00:00Z", IngestTaskKey(start))
+}


### PR DESCRIPTION
First VOD CDN integration: the node keeps serving HLS playlists, but segment and init-segment URLs now point at a bunny.net pull zone fronting the R2 bucket. A new --vod-cdn-token-key flag (SP_VOD_CDN_TOKEN_KEY), alongside the existing --vod-cdn-url, turns on bunny Token Authentication for every blob URL a playlist emits.

The signature follows bunny's published reference algorithm: base64url(sha256(key + path + expires + sorted "k=v" query params)), unpadded. It covers the blob path plus the did/sid params, so a token minted for one blob can't be replayed against another. Tokens expire six hours plus twice the track's duration after minting, since a VOD media playlist is fetched once and never refreshed. The test fixtures were computed independently from the reference algorithm so a drift in the hashing fails the test instead of 403ing in production.

Unsigned CDN mode and self-hosted mode are unchanged. The self-hosted getVideoBlob endpoint is deliberately left open in CDN mode: node-to- node VOD transfer pulls the content blob through it.